### PR TITLE
:sparkles: add key-aware decoding to the query string parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
   tests:
     permissions:
       contents: read
-      actions: write
     name: Swift tests + coverage (${{ matrix.os }}, Swift ${{ matrix.swift }})
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -74,7 +73,6 @@ jobs:
   objc-tests:
     permissions:
       contents: read
-      actions: write
     name: Objective-C E2E tests (Xcode)
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode ${{ matrix.xcode }}
         uses: maxim-lobanov/setup-xcode@v1
@@ -48,6 +50,7 @@ jobs:
           path: |
             ~/.swiftpm
             .build
+            ~/Library/Caches/org.swift.swiftpm
           key: spm-${{ runner.os }}-swift-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-swift-${{ matrix.swift }}-
@@ -97,6 +100,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode ${{ matrix.xcode }}
         uses: maxim-lobanov/setup-xcode@v1
@@ -111,9 +116,12 @@ jobs:
       - name: Work around stale local SwiftPM path (symlink)
         run: |
           set -euxo pipefail
+          # Some SPM/Xcode setups expect the package folder name "QsSwift" (package name)
+          # while the repo slug is "qs-swift"; create/refresh a sibling symlink to avoid stale paths.
           ACTUAL="${GITHUB_WORKSPACE}"
           PARENT="$(dirname "$ACTUAL")"
           EXPECTED="${PARENT}/QsSwift"
+          test -w "$PARENT"
           mkdir -p "$PARENT"
           # Idempotent: force-create/refresh the symlink
           if [ -e "$EXPECTED" ] && [ ! -L "$EXPECTED" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,8 +155,22 @@ jobs:
             -derivedDataPath .derivedData-objc \
             -destination "platform=macOS" \
             CODE_SIGNING_ALLOWED=NO \
+            -enableCodeCoverage YES \
             -resultBundlePath ObjC-Tests.xcresult \
             test
+
+      - name: Upload Objective-C coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ObjC-Tests.xcresult
+          flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
+          name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: ObjC coverage summary (debug)
+        run: |
+          xcrun xccov view --report ObjC-Tests.xcresult || true
 
       - name: Upload ObjC test result bundle
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,9 +162,10 @@ jobs:
       - name: Upload Objective-C coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ObjC-Tests.xcresult
+          files: ${{ github.workspace }}/ObjC-Tests.xcresult
           flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
           name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
+          disable_search: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,12 +117,8 @@ jobs:
           mkdir -p "$PARENT"
           # Idempotent: force-create/refresh the symlink
           if [ -e "$EXPECTED" ] && [ ! -L "$EXPECTED" ]; then
-            echo "Warning: $EXPECTED exists and is not a symlink; validating path and removing for CI."
-            case "$EXPECTED" in
-              "$PARENT"/*) : ;;
-              *) echo "Refusing to remove non-symlink outside $PARENT: $EXPECTED" >&2; exit 1 ;;
-            esac
-            [ "$EXPECTED" != "/" ] && rm -rf "$EXPECTED"
+            echo "Error: $EXPECTED exists and is not a symlink. Refusing to remove it." >&2
+            exit 1
           fi
           if [ -L "$EXPECTED" ]; then
             TARGET="$(readlink "$EXPECTED")"
@@ -166,6 +162,7 @@ jobs:
             -derivedDataPath .derivedData-objc \
             -destination "platform=macOS" -sdk macosx \
             CODE_SIGNING_ALLOWED=NO \
+            -disableAutomaticPackageResolution \
             -enableCodeCoverage YES \
             -resultBundlePath ObjC-Tests.xcresult \
             test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: test-${{ github.ref }}
@@ -149,10 +148,11 @@ jobs:
           NSUnbufferedIO: "YES"
         run: |
           set -euxo pipefail
-          xcodebuild \
+          xcodebuild -quiet \
             -project ObjCE2ETests/ObjCE2ETests.xcodeproj \
             -scheme ObjCE2ETests \
             -configuration Debug \
+            -derivedDataPath .derivedData-objc \
             -destination "platform=macOS" \
             CODE_SIGNING_ALLOWED=NO \
             -resultBundlePath ObjC-Tests.xcresult \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,35 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  style:
-    name: Code style (SwiftPM) + cache warmup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-15
-            swift: '6.1'
-            xcode: '16.3'
-          - os: macos-14
-            swift: '5.10'
-            xcode: '15.4'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Select Xcode ${{ matrix.xcode }}
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.xcode }}
-      - name: Show Swift version (runner default)
-        run: swift --version
-      - name: Build (debug)
-        run: swift build --disable-sandbox
-
   tests:
     name: Swift tests + coverage (${{ matrix.os }}, Swift ${{ matrix.swift }})
     runs-on: ${{ matrix.os }}
-    needs: style
     strategy:
       fail-fast: false
       matrix:
@@ -149,6 +123,18 @@ jobs:
         run: |
           xcodebuild -version
           swift --version
+
+      - name: Work around stale local SwiftPM path (symlink)
+        run: |
+          set -euxo pipefail
+          EXPECTED="/Users/runner/work/qs-swift/QsSwift"
+          ACTUAL="${GITHUB_WORKSPACE}"
+          mkdir -p /Users/runner/work/qs-swift
+          if [ ! -e "$EXPECTED" ]; then
+            ln -s "$ACTUAL" "$EXPECTED"
+          fi
+          ls -lah /Users/runner/work/qs-swift || true
+          ls -lah /Users/runner/work/qs-swift/QsSwift || true
 
       - name: Resolve SPM dependencies (ObjC test project)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   tests:
     name: Swift tests + coverage (${{ matrix.os }}, Swift ${{ matrix.swift }})
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -67,6 +68,7 @@ jobs:
 
   objc-tests:
     name: Objective-C E2E tests (Xcode)
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     needs: tests
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,41 +46,7 @@ jobs:
 
       - name: Collect macOS crash logs
         if: ${{ failure() }}
-        run: |
-          set -euxo pipefail
-          mkdir -p crashlogs
-          # Where crash logs usually live
-          USER_DR="$HOME/Library/Logs/DiagnosticReports"
-          SYS_DR="/Library/Logs/DiagnosticReports"
-
-          # List what’s there (for debugging)
-          for dir in "$USER_DR" "$SYS_DR"; do
-            if [ -d "$dir" ]; then
-              echo "=== Listing $dir ==="
-              ls -lah "$dir" || true
-            fi
-          done
-
-          # Copy recent crash-like files (last 60 minutes, multiple extensions)
-          for dir in "$USER_DR" "$SYS_DR"; do
-            if [ -d "$dir" ]; then
-              # Use sudo for system dir; it’s allowed on macOS runners
-              CP="cp"
-              if [ "$dir" = "$SYS_DR" ]; then CP="sudo cp"; fi
-
-              find "$dir" -type f \
-                \( -name '*.crash' -o -name '*.ips' -o -name '*.hang' -o -name '*.spin' \) \
-                -mmin -60 -print -exec $CP {} crashlogs/ \; || true
-            fi
-          done
-
-          # Always include a unified log snippet around the failure time (very helpful when no .crash exists)
-          /usr/bin/log show --style syslog --last 30m \
-            --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift"' \
-            > crashlogs/unified-log.txt 2>/dev/null || true
-
-          echo "Collected files:"
-          ls -lah crashlogs || true
+        run: bash scripts/collect-macos-crashlogs.sh crashlogs
 
       - name: Upload macOS crash logs (if any)
         if: ${{ failure() }}
@@ -194,31 +160,7 @@ jobs:
 
       - name: Collect macOS crash logs (ObjC job)
         if: ${{ failure() }}
-        run: |
-          set -euxo pipefail
-          mkdir -p crashlogs-objc
-          USER_DR="$HOME/Library/Logs/DiagnosticReports"
-          SYS_DR="/Library/Logs/DiagnosticReports"
-          for dir in "$USER_DR" "$SYS_DR"; do
-            if [ -d "$dir" ]; then
-              echo "=== Listing $dir ==="
-              ls -lah "$dir" || true
-            fi
-          done
-          for dir in "$USER_DR" "$SYS_DR"; do
-            if [ -d "$dir" ]; then
-              CP="cp"
-              if [ "$dir" = "$SYS_DR" ]; then CP="sudo cp"; fi
-              find "$dir" -type f \
-                \( -name '*.crash' -o -name '*.ips' -o -name '*.hang' -o -name '*.spin' \) \
-                -mmin -60 -print -exec $CP {} crashlogs-objc/ \; || true
-            fi
-          done
-          /usr/bin/log show --style syslog --last 30m \
-            --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift"' \
-            > crashlogs-objc/unified-log.txt 2>/dev/null || true
-          echo "Collected files:"
-          ls -lah crashlogs-objc || true
+        run: bash scripts/collect-macos-crashlogs.sh crashlogs-objc
 
       - name: Upload macOS crash logs (ObjC job, if any)
         if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,10 +194,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: ObjC coverage summary (debug)
-        run: |
-          xcrun xccov view --report ObjC-Tests.xcresult || true
-
       - name: Upload ObjC test result bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  actions: read
 
 concurrency:
   group: test-${{ github.ref }}
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   tests:
+    permissions:
+      contents: read
+      actions: write
     name: Swift tests + coverage (${{ matrix.os }}, Swift ${{ matrix.swift }})
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -36,8 +39,10 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
 
-      - name: Show Swift toolchain
-        run: swift --version
+      - name: Show Xcode & Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
 
       - name: Run tests with coverage
         env:
@@ -67,6 +72,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   objc-tests:
+    permissions:
+      contents: read
+      actions: write
     name: Objective-C E2E tests (Xcode)
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -100,6 +108,10 @@ jobs:
           EXPECTED="${PARENT}/QsSwift"
           mkdir -p "$PARENT"
           # Idempotent: force-create/refresh the symlink
+          if [ -e "$EXPECTED" ] && [ ! -L "$EXPECTED" ]; then
+            echo "Warning: $EXPECTED exists and is not a symlink; removing for CI."
+            rm -rf "$EXPECTED"
+          fi
           ln -sfn "$ACTUAL" "$EXPECTED"
           ls -lah "$PARENT" || true
           ls -lah "$EXPECTED" || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,12 +150,24 @@ jobs:
             -resultBundlePath ObjC-Tests.xcresult \
             test
 
+      - name: Zip .xcresult and extract xccov JSON (debug)
+        run: |
+          set -euxo pipefail
+          ls -lah
+          test -d ObjC-Tests.xcresult
+          /usr/bin/zip -qry ObjC-Tests.xcresult.zip ObjC-Tests.xcresult
+          xcrun xccov view --report --json ObjC-Tests.xcresult > objc-coverage.json
+          ls -lah ObjC-Tests.xcresult*
+
       - name: Upload Objective-C coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ${{ github.workspace }}/ObjC-Tests.xcresult
+          files: |
+            ${{ github.workspace }}/ObjC-Tests.xcresult.zip
+            ${{ github.workspace }}/objc-coverage.json
           flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
           name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
+          verbose: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,16 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            .build
+          key: spm-${{ runner.os }}-swift-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-swift-${{ matrix.swift }}-
+
       - name: Run tests with coverage
         env:
           SKIP_EXPENSIVE_TESTS: 1
@@ -67,6 +77,7 @@ jobs:
           files: coverage/info.lcov
           flags: swift,${{ matrix.os }},swift-${{ matrix.swift }}
           name: QsSwift-${{ matrix.os }}-swift-${{ matrix.swift }}
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -107,8 +118,12 @@ jobs:
           mkdir -p "$PARENT"
           # Idempotent: force-create/refresh the symlink
           if [ -e "$EXPECTED" ] && [ ! -L "$EXPECTED" ]; then
-            echo "Warning: $EXPECTED exists and is not a symlink; removing for CI."
-            rm -rf "$EXPECTED"
+            echo "Warning: $EXPECTED exists and is not a symlink; validating path and removing for CI."
+            case "$EXPECTED" in
+              "$PARENT"/*) : ;;
+              *) echo "Refusing to remove non-symlink outside $PARENT: $EXPECTED" >&2; exit 1 ;;
+            esac
+            [ "$EXPECTED" != "/" ] && rm -rf "$EXPECTED"
           fi
           if [ -L "$EXPECTED" ]; then
             TARGET="$(readlink "$EXPECTED")"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: test-${{ github.ref }}
@@ -30,7 +31,7 @@ jobs:
             xcode: '15.4'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Select Xcode ${{ matrix.xcode }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -53,7 +54,7 @@ jobs:
             xcode: '16.3'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode ${{ matrix.xcode }}
         uses: maxim-lobanov/setup-xcode@v1
@@ -123,3 +124,93 @@ jobs:
           name: QsSwift-${{ matrix.os }}-swift-${{ matrix.swift }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  objc-tests:
+    name: Objective-C E2E tests (Xcode)
+    runs-on: ${{ matrix.os }}
+    needs: tests
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            xcode: '16.3'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Select Xcode ${{ matrix.xcode }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+
+      - name: Show Xcode & Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve SPM dependencies (ObjC test project)
+        run: |
+          set -euxo pipefail
+          xcodebuild \
+            -project ObjCE2ETests/ObjCE2ETests.xcodeproj \
+            -scheme ObjCE2ETests \
+            -resolvePackageDependencies
+
+      - name: Run Objective-C tests (macOS)
+        env:
+          NSUnbufferedIO: "YES"
+        run: |
+          set -euxo pipefail
+          xcodebuild \
+            -project ObjCE2ETests/ObjCE2ETests.xcodeproj \
+            -scheme ObjCE2ETests \
+            -configuration Debug \
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            -resultBundlePath ObjC-Tests.xcresult \
+            test
+
+      - name: Upload ObjC test result bundle
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ObjC-Tests-xcode-${{ matrix.xcode }}
+          path: ObjC-Tests.xcresult
+
+      - name: Collect macOS crash logs (ObjC job)
+        if: ${{ failure() }}
+        run: |
+          set -euxo pipefail
+          mkdir -p crashlogs-objc
+          USER_DR="$HOME/Library/Logs/DiagnosticReports"
+          SYS_DR="/Library/Logs/DiagnosticReports"
+          for dir in "$USER_DR" "$SYS_DR"; do
+            if [ -d "$dir" ]; then
+              echo "=== Listing $dir ==="
+              ls -lah "$dir" || true
+            fi
+          done
+          for dir in "$USER_DR" "$SYS_DR"; do
+            if [ -d "$dir" ]; then
+              CP="cp"
+              if [ "$dir" = "$SYS_DR" ]; then CP="sudo cp"; fi
+              find "$dir" -type f \
+                \( -name '*.crash' -o -name '*.ips' -o -name '*.hang' -o -name '*.spin' \) \
+                -mmin -60 -print -exec $CP {} crashlogs-objc/ \; || true
+            fi
+          done
+          /usr/bin/log show --style syslog --last 30m \
+            --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift"' \
+            > crashlogs-objc/unified-log.txt 2>/dev/null || true
+          echo "Collected files:"
+          ls -lah crashlogs-objc || true
+
+      - name: Upload macOS crash logs (ObjC job, if any)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS-crashlogs-objc-xcode-${{ matrix.xcode }}
+          path: crashlogs-objc
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,6 @@ jobs:
       - name: Zip .xcresult and extract xccov JSON
         run: |
           set -euxo pipefail
-          ls -lah
           test -d ObjC-Tests.xcresult
           /usr/bin/zip -qry ObjC-Tests.xcresult.zip ObjC-Tests.xcresult
           xcrun xccov view --report --json ObjC-Tests.xcresult > objc-coverage.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,14 +150,13 @@ jobs:
             -resultBundlePath ObjC-Tests.xcresult \
             test
 
-      - name: Zip .xcresult and extract xccov JSON (debug)
+      - name: Zip .xcresult and extract xccov JSON
         run: |
           set -euxo pipefail
           ls -lah
           test -d ObjC-Tests.xcresult
           /usr/bin/zip -qry ObjC-Tests.xcresult.zip ObjC-Tests.xcresult
           xcrun xccov view --report --json ObjC-Tests.xcresult > objc-coverage.json
-          ls -lah ObjC-Tests.xcresult*
 
       - name: Upload Objective-C coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -167,7 +166,6 @@ jobs:
             ${{ github.workspace }}/objc-coverage.json
           flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
           name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
-          verbose: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,12 @@ jobs:
             echo "Warning: $EXPECTED exists and is not a symlink; removing for CI."
             rm -rf "$EXPECTED"
           fi
+          if [ -L "$EXPECTED" ]; then
+            TARGET="$(readlink "$EXPECTED")"
+            if [ "$TARGET" != "$ACTUAL" ]; then
+              echo "Refreshing symlink: $EXPECTED -> $ACTUAL (was $TARGET)"
+            fi
+          fi
           ln -sfn "$ACTUAL" "$EXPECTED"
           ls -lah "$PARENT" || true
           ls -lah "$EXPECTED" || true
@@ -146,7 +152,7 @@ jobs:
             -scheme ObjCE2ETests \
             -configuration Debug \
             -derivedDataPath .derivedData-objc \
-            -destination "platform=macOS" \
+            -destination "platform=macOS" -sdk macosx \
             CODE_SIGNING_ALLOWED=NO \
             -enableCodeCoverage YES \
             -resultBundlePath ObjC-Tests.xcresult \
@@ -182,6 +188,7 @@ jobs:
         with:
           name: ObjC-Tests-xcode-${{ matrix.xcode }}
           path: ObjC-Tests.xcresult
+          if-no-files-found: warn
 
       - name: Collect macOS crash logs (ObjC job)
         if: ${{ failure() }}
@@ -191,6 +198,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: macOS-crashlogs-objc-xcode-${{ matrix.xcode }}
+          name: macOS-crashlogs-objc-xcode-${{ matrix.xcode }}-${{ matrix.os }}
           path: crashlogs-objc
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,6 @@ jobs:
           files: ${{ github.workspace }}/ObjC-Tests.xcresult
           flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
           name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
-          disable_search: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,14 +127,24 @@ jobs:
       - name: Work around stale local SwiftPM path (symlink)
         run: |
           set -euxo pipefail
-          EXPECTED="/Users/runner/work/qs-swift/QsSwift"
           ACTUAL="${GITHUB_WORKSPACE}"
-          mkdir -p /Users/runner/work/qs-swift
-          if [ ! -e "$EXPECTED" ]; then
-            ln -s "$ACTUAL" "$EXPECTED"
-          fi
-          ls -lah /Users/runner/work/qs-swift || true
-          ls -lah /Users/runner/work/qs-swift/QsSwift || true
+          PARENT="$(dirname "$ACTUAL")"
+          EXPECTED="${PARENT}/QsSwift"
+          mkdir -p "$PARENT"
+          # Idempotent: force-create/refresh the symlink
+          ln -sfn "$ACTUAL" "$EXPECTED"
+          ls -lah "$PARENT" || true
+          ls -lah "$EXPECTED" || true
+
+      - name: Cache SPM (Xcode)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-xcode-${{ matrix.xcode }}-
 
       - name: Resolve SPM dependencies (ObjC test project)
         run: |
@@ -167,6 +177,7 @@ jobs:
           flags: objc,${{ matrix.os }},xcode-${{ matrix.xcode }}
           name: QsSwift-ObjC-${{ matrix.os }}-xcode-${{ matrix.xcode }}
           disable_search: true
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,7 @@ jobs:
           path: |
             ~/.swiftpm
             ~/Library/Developer/Xcode/DerivedData/SourcePackages
+            .derivedData-objc/SourcePackages
           key: spm-${{ runner.os }}-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-xcode-${{ matrix.xcode }}-
@@ -132,6 +133,7 @@ jobs:
           xcodebuild \
             -project ObjCE2ETests/ObjCE2ETests.xcodeproj \
             -scheme ObjCE2ETests \
+            -derivedDataPath .derivedData-objc \
             -resolvePackageDependencies
 
       - name: Run Objective-C tests (macOS)

--- a/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
@@ -199,7 +199,7 @@
         XCTAssertEqualObjects(s, @"a=b");
         [exp fulfill];
     }];
-    [self waitForExpectations:@[exp] timeout:1.0];
+    [self waitForExpectations:@[exp] timeout:2.0]; // macOS runners can be sluggish intermittently. A 2s timeout (like in other async tests) is safer.
 }
 
 - (void)test_decode_async_on_main_queue {
@@ -210,7 +210,7 @@
         XCTAssertEqualObjects(dict[@"a"], @"b");
         [exp fulfill];
     }];
-    [self waitForExpectations:@[exp] timeout:1.0];
+    [self waitForExpectations:@[exp] timeout:2.0]; // macOS runners can be sluggish intermittently. A 2s timeout (like in other async tests) is safer.
 }
 
 #pragma mark - 12) Charset sentinel is present when requested
@@ -299,7 +299,7 @@
     XCTAssertEqualObjects(m[@"K:a%2Eb"], @"V:c");
     // For the bracketed key, the key is decoded *before* splitting, so "K:a[b]"
     // becomes parent "K:a" with child "b".
-    id Ka = m[@"K:a"]; 
+    id Ka = m[@"K:a"];
     XCTAssertTrue([Ka isKindOfClass:[NSDictionary class]]);
     XCTAssertEqualObjects(((NSDictionary *)Ka)[@"b"], @"V:d");
     XCTAssertTrue(sawKey);

--- a/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
@@ -279,11 +279,11 @@
     d.decoderBlock = ^id _Nullable(NSString * _Nullable token,
                                    NSNumber * _Nullable charsetNum,
                                    NSNumber * _Nullable kindNum) {
-        NSInteger kind = kindNum.integerValue; // 0 = key, 1 = value
+        QsDecodeKind kind = (QsDecodeKind)kindNum.integerValue; // enum-backed
         if (kind == 0) {
             sawKey = YES;
             return [NSString stringWithFormat:@"K:%@", token ?: @"<nil>"];
-        } else {
+        } else { // QsDecodeKindValue
             sawValue = YES;
             return [NSString stringWithFormat:@"V:%@", token ?: @"<nil>"];
         }

--- a/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
@@ -53,7 +53,7 @@ static NSDictionary * Qs_DecodeOrDefault(id _Nullable input, QsDecodeOptions * _
     // depthExceeded maps to rawValue 4 (see QsDecodeErrorCodeObjC).
     XCTAssertEqual(err.code, QsDecodeErrorCodeDepthExceeded);
     NSNumber *maxDepth = err.userInfo[QsDecodeErrorInfo.maxDepthKey];
-    XCTAssertEqual(maxDepth.intValue, QsDecodeErrorCodeParameterLimitExceeded);
+    XCTAssertEqual(maxDepth.intValue, 2);
 }
 
 - (void)test_decodeOrEmpty_success_and_failureFallback {

--- a/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
@@ -1,0 +1,109 @@
+@import XCTest;
+@import QsObjC;
+
+#import "ObjCE2ETests-Swift.h"
+
+/// Small Obj-C helpers to mirror Swift convenience semantics.
+static NSDictionary * _Nullable Qs_DecodeOrNil(id _Nullable input, QsDecodeOptions * _Nullable opts) {
+    NSError *err = nil;
+    NSDictionary *out = [Qs decode:input options:opts error:&err];
+    if (err != nil) { return nil; }
+    return out;
+}
+
+static NSDictionary * Qs_DecodeOrEmpty(id _Nullable input, QsDecodeOptions * _Nullable opts) {
+    NSDictionary *out = Qs_DecodeOrNil(input, opts);
+    return out ?: @{};
+}
+
+static NSDictionary * Qs_DecodeOrDefault(id _Nullable input, QsDecodeOptions * _Nullable opts, NSDictionary * _Nonnull def) {
+    NSDictionary *out = Qs_DecodeOrNil(input, opts);
+    return out ?: def;
+}
+
+@interface ObjCDecodeConvenienceTests : XCTestCase
+@end
+
+@implementation ObjCDecodeConvenienceTests
+
+- (void)test_decodeOrNil_success {
+    QsDecodeOptions *o = [QsDecodeOptions new];
+    NSDictionary *m = Qs_DecodeOrNil(@"a=1", o);
+    XCTAssertNotNil(m);
+    XCTAssertEqualObjects(m[@"a"], @"1");
+}
+
+- (void)test_decodeOrNil_failure_returnsNil_andErrorHasDecodeDomain {
+    QsDecodeOptions *o = [QsDecodeOptions new];
+    o.strictDepth = YES; // enforce throwing on overflow
+    o.depth = 2;
+    
+    // This key has 3 bracket groups → exceeds depth=2 in a well‑formed way and should throw.
+    NSError *err = nil;
+    NSDictionary *raw = [Qs decode:@"a[b][c][d]=x" options:o error:&err];
+    XCTAssertNil(raw);
+    XCTAssertNotNil(err);
+    
+    // Our convenience mirror should return nil on the same input.
+    NSDictionary *m = Qs_DecodeOrNil(@"a[b][c][d]=x", o);
+    XCTAssertNil(m);
+    
+    // Sanity: error domain/code and attached metadata.
+    XCTAssertEqualObjects(err.domain, QsDecodeErrorInfo.domain);
+    // depthExceeded maps to rawValue 4 (see QsDecodeErrorCodeObjC).
+    XCTAssertEqual(err.code, 4);
+    NSNumber *maxDepth = err.userInfo[QsDecodeErrorInfo.maxDepthKey];
+    XCTAssertEqual(maxDepth.intValue, 2);
+}
+
+- (void)test_decodeOrEmpty_success_and_failureFallback {
+    QsDecodeOptions *o = [QsDecodeOptions new];
+    
+    NSDictionary *ok = Qs_DecodeOrEmpty(@"a=1", o);
+    XCTAssertEqualObjects(ok[@"a"], @"1");
+    
+    o.strictDepth = YES; o.depth = 2;
+    NSDictionary *empty = Qs_DecodeOrEmpty(@"a[b][c][d]=x", o);
+    XCTAssertEqual(empty.count, (NSUInteger)0);
+}
+
+- (void)test_decodeOrDefault_fallback_used_on_error {
+    QsDecodeOptions *o = [QsDecodeOptions new];
+    o.strictDepth = YES; o.depth = 2;
+    
+    NSDictionary *fallback = @{ @"fallback": @"yes" };
+    NSDictionary *m = Qs_DecodeOrDefault(@"a[b][c][d]=x", o, fallback);
+    XCTAssertEqualObjects(m, fallback);
+}
+
+- (void)test_decodeResult_semantics_success_and_failure {
+    // Success branch
+    QsDecodeOptions *okOpts = [QsDecodeOptions new];
+    NSError *err1 = nil;
+    NSDictionary *m1 = [Qs decode:@"a=1" options:okOpts error:&err1];
+    XCTAssertNil(err1);
+    XCTAssertEqualObjects(m1[@"a"], @"1");
+    
+    // Failure branch mirrors Swift's Result<Success, Failure>
+    QsDecodeOptions *bad = [QsDecodeOptions new];
+    bad.strictDepth = YES; bad.depth = 2;
+    NSError *err2 = nil;
+    NSDictionary *m2 = [Qs decode:@"a[b][c][d]=x" options:bad error:&err2];
+    XCTAssertNil(m2);
+    XCTAssertNotNil(err2);
+    XCTAssertEqualObjects(err2.domain, QsDecodeErrorInfo.domain);
+    XCTAssertEqual(err2.code, 4);
+}
+
+- (void)test_options_propagate_through_helpers_allowDots {
+    QsDecodeOptions *o = [QsDecodeOptions new];
+    o.allowDots = YES;
+    
+    NSDictionary *m = Qs_DecodeOrNil(@"a.b=c", o);
+    XCTAssertNotNil(m);
+    NSDictionary *a = m[@"a"];
+    XCTAssertTrue([a isKindOfClass:NSDictionary.class]);
+    XCTAssertEqualObjects(a[@"b"], @"c");
+}
+
+@end

--- a/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
@@ -51,9 +51,9 @@ static NSDictionary * Qs_DecodeOrDefault(id _Nullable input, QsDecodeOptions * _
     // Sanity: error domain/code and attached metadata.
     XCTAssertEqualObjects(err.domain, QsDecodeErrorInfo.domain);
     // depthExceeded maps to rawValue 4 (see QsDecodeErrorCodeObjC).
-    XCTAssertEqual(err.code, 4);
+    XCTAssertEqual(err.code, QsDecodeErrorCodeDepthExceeded);
     NSNumber *maxDepth = err.userInfo[QsDecodeErrorInfo.maxDepthKey];
-    XCTAssertEqual(maxDepth.intValue, 2);
+    XCTAssertEqual(maxDepth.intValue, QsDecodeErrorCodeParameterLimitExceeded);
 }
 
 - (void)test_decodeOrEmpty_success_and_failureFallback {

--- a/ObjCE2ETests/ObjCE2ETests/ObjCEncodeAsyncTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCEncodeAsyncTests.m
@@ -16,7 +16,7 @@
     QsEncodeOptions *opts = [QsEncodeOptions new];
     opts.sortKeysCaseInsensitively = YES; // ensures a=1&b=2
     
-    [Qs encodeAsyncOnMain:input options:opts completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+    [Qs encodeAsyncOnMain:input options:opts completion:^(NSString * _Nullable s, NSError * _Nullable err) {
         XCTAssertTrue([NSThread isMainThread], @"Completion for encodeAsyncOnMain must run on main thread");
         XCTAssertNil(err);
         XCTAssertNotNil(s);
@@ -34,7 +34,7 @@
     QsEncodeOptions *opts = [QsEncodeOptions new];
     opts.sortKeysCaseInsensitively = YES;
     
-    [Qs encodeAsync:input options:opts completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+    [Qs encodeAsync:input options:opts completion:^(NSString * _Nullable s, NSError * _Nullable err) {
         XCTAssertFalse([NSThread isMainThread], @"Completion for encodeAsync should not run on main thread");
         XCTAssertNil(err);
         XCTAssertNotNil(s);
@@ -54,7 +54,7 @@
     a[@"loop"] = b;
     b[@"loop"] = a;
     
-    [Qs encodeAsync:a options:nil completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+    [Qs encodeAsync:a options:nil completion:^(NSString * _Nullable s, NSError * _Nullable err) {
         XCTAssertFalse([NSThread isMainThread]);
         XCTAssertNil(s);
         XCTAssertNotNil(err);
@@ -74,7 +74,7 @@
     a[@"self"] = b;
     b[@"self"] = a;
     
-    [Qs encodeAsyncOnMain:a options:nil completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+    [Qs encodeAsyncOnMain:a options:nil completion:^(NSString * _Nullable s, NSError * _Nullable err) {
         XCTAssertTrue([NSThread isMainThread]);
         XCTAssertNil(s);
         XCTAssertNotNil(err);

--- a/ObjCE2ETests/ObjCE2ETests/ObjCEncodeAsyncTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCEncodeAsyncTests.m
@@ -1,0 +1,89 @@
+@import XCTest;
+@import QsObjC;
+
+#import "ObjCE2ETests-Swift.h"
+
+@interface ObjCEncodeAsyncTests : XCTestCase
+@end
+
+@implementation ObjCEncodeAsyncTests
+
+- (void)test_encodeAsyncOnMain_success_deliversOnMain {
+    XCTestExpectation *exp = [self expectationWithDescription:@"encodeAsyncOnMain delivers on main and succeeds"];
+    
+    // Use a dictionary with reversed order; enable sorting so output is deterministic.
+    NSDictionary *input = @{ @"b": @"2", @"a": @"1" };
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.sortKeysCaseInsensitively = YES; // ensures a=1&b=2
+    
+    [Qs encodeAsyncOnMain:input options:opts completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+        XCTAssertTrue([NSThread isMainThread], @"Completion for encodeAsyncOnMain must run on main thread");
+        XCTAssertNil(err);
+        XCTAssertNotNil(s);
+        XCTAssertEqualObjects(s, @"a=1&b=2");
+        [exp fulfill];
+    }];
+    
+    [self waitForExpectations:@[exp] timeout:2.0];
+}
+
+- (void)test_encodeAsync_success_deliversOffMain {
+    XCTestExpectation *exp = [self expectationWithDescription:@"encodeAsync delivers off main and succeeds"];
+    
+    NSDictionary *input = @{ @"b": @"2", @"a": @"1" };
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.sortKeysCaseInsensitively = YES;
+    
+    [Qs encodeAsync:input options:opts completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+        XCTAssertFalse([NSThread isMainThread], @"Completion for encodeAsync should not run on main thread");
+        XCTAssertNil(err);
+        XCTAssertNotNil(s);
+        XCTAssertEqualObjects(s, @"a=1&b=2");
+        [exp fulfill];
+    }];
+    
+    [self waitForExpectations:@[exp] timeout:2.0];
+}
+
+- (void)test_encodeAsync_error_cyclic_propagatesOffMain {
+    XCTestExpectation *exp = [self expectationWithDescription:@"encodeAsync propagates cyclicObject error off main"];
+    
+    // Create a reference cycle between two dictionaries
+    NSMutableDictionary *a = [NSMutableDictionary dictionary];
+    NSMutableDictionary *b = [NSMutableDictionary dictionary];
+    a[@"loop"] = b;
+    b[@"loop"] = a;
+    
+    [Qs encodeAsync:a options:nil completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+        XCTAssertFalse([NSThread isMainThread]);
+        XCTAssertNil(s);
+        XCTAssertNotNil(err);
+        XCTAssertTrue([QsEncodeError isCyclicObject:err]);
+        XCTAssertEqualObjects(err.domain, QsEncodeErrorInfo.domain);
+        [exp fulfill];
+    }];
+    
+    [self waitForExpectations:@[exp] timeout:2.0];
+}
+
+- (void)test_encodeAsyncOnMain_error_cyclic_propagatesOnMain {
+    XCTestExpectation *exp = [self expectationWithDescription:@"encodeAsyncOnMain propagates cyclicObject error on main"];
+    
+    NSMutableDictionary *a = [NSMutableDictionary dictionary];
+    NSMutableDictionary *b = [NSMutableDictionary dictionary];
+    a[@"self"] = b;
+    b[@"self"] = a;
+    
+    [Qs encodeAsyncOnMain:a options:nil completion:^(__unsafe_unretained NSString * _Nullable s, NSError * _Nullable err) {
+        XCTAssertTrue([NSThread isMainThread]);
+        XCTAssertNil(s);
+        XCTAssertNotNil(err);
+        XCTAssertTrue([QsEncodeError isCyclicObject:err]);
+        XCTAssertEqualObjects(err.domain, QsEncodeErrorInfo.domain);
+        [exp fulfill];
+    }];
+    
+    [self waitForExpectations:@[exp] timeout:2.0];
+}
+
+@end

--- a/ObjCE2ETests/ObjCE2ETests/ObjCEncodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCEncodeConvenienceTests.m
@@ -56,6 +56,7 @@ static NSString * Qs_EncodeOrEmpty(id _Nullable object, QsEncodeOptions * _Nulla
     XCTAssertNotNil(err);
     XCTAssertEqualObjects(err.domain, QsEncodeErrorInfo.domain);
     XCTAssertTrue([QsEncodeError isCyclicObject:err]);
+    XCTAssertEqual(err.code, QsEncodeErrorCodeCyclicObject);
 }
 
 - (void)test_encodeOrEmpty_failure_cycle_returnsEmptyString {

--- a/ObjCE2ETests/ObjCE2ETests/ObjCEncodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCEncodeConvenienceTests.m
@@ -1,0 +1,84 @@
+@import XCTest;
+@import QsObjC;
+
+#import "ObjCE2ETests-Swift.h"
+
+@interface ObjCEncodeConvenienceTests : XCTestCase
+@end
+
+/// Helpers that mimic Swift Qs.encodeOrNil / encodeOrEmpty using the Obj-C bridge.
+static NSString * _Nullable Qs_EncodeOrNil(id _Nullable object, QsEncodeOptions * _Nullable options) {
+    NSError *err = nil;
+    NSString *out = [Qs encode:object options:options error:&err];
+    return (err != nil) ? nil : out;
+}
+
+static NSString * Qs_EncodeOrEmpty(id _Nullable object, QsEncodeOptions * _Nullable options) {
+    NSString *out = Qs_EncodeOrNil(object, options);
+    return out ?: @"";
+}
+
+@implementation ObjCEncodeConvenienceTests
+
+- (void)test_encodeOrNil_success_basic {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    NSDictionary *input = @{ @"a": @"1" };
+    
+    NSString *s = Qs_EncodeOrNil(input, opts);
+    XCTAssertEqualObjects(s, @"a=1");
+}
+
+- (void)test_encodeOrEmpty_success_basic {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    NSDictionary *input = @{ @"a": @"1" };
+    
+    NSString *s = Qs_EncodeOrEmpty(input, opts);
+    XCTAssertEqualObjects(s, @"a=1");
+}
+
+- (void)test_encodeOrNil_failure_cycle_returnsNil {
+    // Create a tiny identity cycle: d1 → d2 → d1
+    NSMutableDictionary *d1 = [NSMutableDictionary dictionary];
+    NSMutableDictionary *d2 = [NSMutableDictionary dictionary];
+    d1[@"x"] = d2;
+    d2[@"y"] = d1;
+    
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    
+    // Convenience behavior: swallow error → return nil
+    NSString *s = Qs_EncodeOrNil(d1, opts);
+    XCTAssertNil(s);
+    
+    // Ground truth: bridge returns error domain for cyclic objects
+    NSError *err = nil;
+    NSString *direct = [Qs encode:d1 options:opts error:&err];
+    XCTAssertNil(direct);
+    XCTAssertNotNil(err);
+    XCTAssertEqualObjects(err.domain, QsEncodeErrorInfo.domain);
+    XCTAssertTrue([QsEncodeError isCyclicObject:err]);
+}
+
+- (void)test_encodeOrEmpty_failure_cycle_returnsEmptyString {
+    // Same cycle as above
+    NSMutableDictionary *d1 = [NSMutableDictionary dictionary];
+    NSMutableDictionary *d2 = [NSMutableDictionary dictionary];
+    d1[@"x"] = d2;
+    d2[@"y"] = d1;
+    
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    
+    // Convenience behavior: swallow error → return empty string
+    NSString *s = Qs_EncodeOrEmpty(d1, opts);
+    XCTAssertEqualObjects(s, @"");
+}
+
+- (void)test_encodeOrNil_respectsOptions_addQueryPrefix {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.addQueryPrefix = YES; // ensure options are honored by the convenience flow
+    
+    NSDictionary *input = @{ @"a": @"1" };
+    NSString *s = Qs_EncodeOrNil(input, opts);
+    XCTAssertEqualObjects(s, @"?a=1");
+}
+
+@end

--- a/ObjCE2ETests/ObjCE2ETests/ObjCExampleTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCExampleTests.m
@@ -1,0 +1,779 @@
+@import XCTest;
+@import QsObjC;
+
+#import "ObjCE2ETests-Swift.h"
+
+@interface ObjCExampleTests : XCTestCase
+@end
+
+@implementation ObjCExampleTests
+
+#pragma mark - Simple examples
+
+- (void)test_simple_decode {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=c" options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"c");
+}
+
+- (void)test_simple_encode {
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"c"} options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=c");
+}
+
+#pragma mark - Decoding • Maps
+
+- (void)test_maps_nested {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"foo[bar]=baz" options:nil error:&err];
+    XCTAssertNil(err);
+    NSDictionary *foo = r[@"foo"];
+    XCTAssertEqualObjects(foo[@"bar"], @"baz");
+}
+
+- (void)test_maps_uriEncodedKeys {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a%5Bb%5D=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"b"], @"c");
+}
+
+- (void)test_maps_deepNest {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"foo[bar][baz]=foobarbaz"
+                         options:nil
+                           error:&err];
+    XCTAssertNil(err);
+    NSDictionary *foo = r[@"foo"];
+    NSDictionary *bar = foo[@"bar"];
+    XCTAssertEqualObjects(bar[@"baz"], @"foobarbaz");
+}
+
+- (void)test_maps_defaultDepthTrims {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[b][c][d][e][f][g][h][i]=j"
+                         options:nil
+                           error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    NSDictionary *b = a[@"b"];
+    NSDictionary *c = b[@"c"];
+    NSDictionary *d = c[@"d"];
+    NSDictionary *e = d[@"e"];
+    NSDictionary *f = e[@"f"];
+    XCTAssertEqualObjects(f[@"[g][h][i]"], @"j");
+}
+
+- (void)test_maps_overrideDepth {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.depth = 1;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[b][c][d][e][f][g][h][i]=j"
+                         options:opts
+                           error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    NSDictionary *b = a[@"b"];
+    XCTAssertEqualObjects(b[@"[c][d][e][f][g][h][i]"], @"j");
+}
+
+- (void)test_maps_parameterLimit {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.parameterLimit = 1;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=b&c=d" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"b");
+    XCTAssertNil(r[@"c"]);
+}
+
+- (void)test_maps_ignorePrefix {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.ignoreQueryPrefix = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"?a=b&c=d" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"b");
+    XCTAssertEqualObjects(r[@"c"], @"d");
+}
+
+- (void)test_maps_allowDots {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.allowDots = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a.b=c" options:opts error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"b"], @"c");
+}
+
+- (void)test_maps_decodeDotInKeys {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.decodeDotInKeys = YES; // implies allowDots
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"name%252Eobj.first=John&name%252Eobj.last=Doe"
+                         options:opts
+                           error:&err];
+    XCTAssertNil(err);
+    NSDictionary *nameObj = r[@"name.obj"];
+    XCTAssertEqualObjects(nameObj[@"first"], @"John");
+    XCTAssertEqualObjects(nameObj[@"last"], @"Doe");
+}
+
+- (void)test_maps_allowEmptyLists {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.allowEmptyLists = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"foo[]&bar=baz" options:opts error:&err];
+    XCTAssertNil(err);
+    NSArray *foo = r[@"foo"];
+    XCTAssertNotNil(foo);
+    XCTAssertEqual(foo.count, 0);
+    XCTAssertEqualObjects(r[@"bar"], @"baz");
+}
+
+- (void)test_maps_duplicatesDefault {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"foo=bar&foo=baz" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *arr = r[@"foo"];
+    XCTAssertEqual(arr.count, 2);
+    XCTAssertEqualObjects(arr.firstObject, @"bar");
+    XCTAssertEqualObjects(arr.lastObject, @"baz");
+}
+
+- (void)test_maps_duplicatesModes {
+    NSError *err = nil;
+    
+    QsDecodeOptions *c = [QsDecodeOptions new];
+    c.duplicates = QsDuplicatesCombine;
+    NSDictionary *r = [Qs decode:@"foo=bar&foo=baz" options:c error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqual([r[@"foo"] count], 2);
+    
+    QsDecodeOptions *f = [QsDecodeOptions new];
+    f.duplicates = QsDuplicatesFirst;
+    r = [Qs decode:@"foo=bar&foo=baz" options:f error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"foo"], @"bar");
+    
+    QsDecodeOptions *l = [QsDecodeOptions new];
+    l.duplicates = QsDuplicatesLast;
+    r = [Qs decode:@"foo=bar&foo=baz" options:l error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"foo"], @"baz");
+}
+
+#pragma mark - Decoding • Lists
+
+- (void)test_lists_brackets {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[]=b&a[]=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a = r[@"a"];
+    XCTAssertEqual(a.count, 2);
+    XCTAssertEqualObjects(a.firstObject, @"b");
+    XCTAssertEqualObjects(a.lastObject, @"c");
+}
+
+- (void)test_lists_indices {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[1]=c&a[0]=b" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a = r[@"a"];
+    XCTAssertEqual(a.count, 2);
+    XCTAssertEqualObjects(a[0], @"b");
+    XCTAssertEqualObjects(a[1], @"c");
+}
+
+- (void)test_lists_compactSparse {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[1]=b&a[15]=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a = r[@"a"];
+    XCTAssertEqual(a.count, 2);
+    XCTAssertEqualObjects(a.firstObject, @"b");
+    XCTAssertEqualObjects(a.lastObject, @"c");
+}
+
+- (void)test_lists_preserveEmptyStrings {
+    NSError *err = nil;
+    
+    NSDictionary *r0 = [Qs decode:@"a[]=&a[]=b" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a0 = r0[@"a"];
+    XCTAssertEqualObjects(a0[0], @"");
+    XCTAssertEqualObjects(a0[1], @"b");
+    
+    NSDictionary *r1 = [Qs decode:@"a[0]=b&a[1]=&a[2]=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a1 = r1[@"a"];
+    XCTAssertEqualObjects(a1[0], @"b");
+    XCTAssertEqualObjects(a1[1], @"");
+    XCTAssertEqualObjects(a1[2], @"c");
+}
+
+- (void)test_lists_highIndexToMap {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[100]=b" options:nil error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"100"], @"b");
+}
+
+- (void)test_lists_overrideListLimit0 {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.listLimit = 0;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[1]=b" options:opts error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"1"], @"b");
+}
+
+- (void)test_lists_disableParsing {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.parseLists = NO;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[]=b" options:opts error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"0"], @"b");
+}
+
+- (void)test_lists_mixedNotations {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[0]=b&a[b]=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSDictionary *a = r[@"a"];
+    XCTAssertEqualObjects(a[@"0"], @"b");
+    XCTAssertEqualObjects(a[@"b"], @"c");
+}
+
+- (void)test_lists_ofMaps {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a[][b]=c" options:nil error:&err];
+    XCTAssertNil(err);
+    NSArray *a = r[@"a"];
+    NSDictionary *first = a.firstObject;
+    XCTAssertEqualObjects(first[@"b"], @"c");
+}
+
+- (void)test_lists_commaOption {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.comma = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=b,c" options:opts error:&err];
+    XCTAssertNil(err);
+    NSArray *a = r[@"a"];
+    XCTAssertEqualObjects(a, (@[ @"b", @"c" ]));
+}
+
+#pragma mark - Decoding • Primitive/Scalar
+
+- (void)test_scalars_asStrings {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=15&b=true&c=null" options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"15");
+    XCTAssertEqualObjects(r[@"b"], @"true");
+    XCTAssertEqualObjects(r[@"c"], @"null");
+}
+
+#pragma mark - Null values
+
+- (void)test_nulls_decodeEmptyStrings {
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a&b=" options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"");
+    XCTAssertEqualObjects(r[@"b"], @"");
+}
+
+- (void)test_nulls_decodeStrictNulls {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.strictNullHandling = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a&b=" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertTrue([r[@"a"] isKindOfClass:[NSNull class]]);
+    XCTAssertEqualObjects(r[@"b"], @"");
+}
+
+#pragma mark - Decoding • Maps (extras)
+
+- (void)test_maps_customDelimiter_string {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.delimiter = [QsDelimiter semicolon];
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=b;c=d" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"b");
+    XCTAssertEqualObjects(r[@"c"], @"d");
+}
+
+- (void)test_maps_regexDelimiter {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.delimiter = [QsDelimiter commaOrSemicolon]; // /[;,]/
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=b;c=d" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"b");
+    XCTAssertEqualObjects(r[@"c"], @"d");
+}
+
+- (void)test_maps_latin1_charset {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=%A7" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"§");
+}
+
+- (void)test_maps_charsetSentinel_latin1 {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    opts.charsetSentinel = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"utf8=%E2%9C%93&a=%C3%B8"
+                         options:opts
+                           error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"ø");
+}
+
+- (void)test_maps_charsetSentinel_utf8 {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.charset = NSUTF8StringEncoding;
+    opts.charsetSentinel = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"utf8=%26%2310003%3B&a=%F8"
+                         options:opts
+                           error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"ø");
+}
+
+- (void)test_maps_interpretNumericEntities_isoLatin1 {
+    QsDecodeOptions *opts = [QsDecodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    opts.interpretNumericEntities = YES;
+    NSError *err = nil;
+    NSDictionary *r = [Qs decode:@"a=%26%239786%3B" options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(r[@"a"], @"☺");
+}
+
+#pragma mark - Encoding
+
+- (void)test_encode_maps_basic {
+    NSError *err = nil;
+    NSString *s1 = [Qs encode:@{@"a" : @"b"} options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s1, @"a=b");
+    
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    NSString *s2 = [Qs encode:@{@"a" : @{@"b" : @"c"}} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s2, @"a%5Bb%5D=c");
+}
+
+- (void)test_encode_disableEncoding_leavesBrackets {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @{@"b" : @"c"}} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a[b]=c");
+}
+
+- (void)test_encode_valuesOnly {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encodeValuesOnly = YES;
+    NSError *err = nil;
+    NSDictionary *input = @{
+        @"a" : @"b",
+        @"c" : @[ @"d", @"e=f" ],
+        @"f" : @[ @[ @"g" ], @[ @"h" ] ]
+    };
+    NSString *s = [Qs encode:input options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=b&c[0]=d&c[1]=e%3Df&f[0][0]=g&f[1][0]=h");
+}
+
+- (void)test_encode_customEncoder {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.valueEncoderBlock =
+    ^NSString *(id value, NSNumber *charsetNum, NSNumber *formatNum) {
+        id v = value ?: @"";
+        if ([v isKindOfClass:[NSString class]] &&
+            [(NSString *)v isEqualToString:@"č"]) {
+            return @"c";
+        }
+        return [NSString stringWithFormat:@"%@", v];
+    };
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @{@"b" : @"č"}} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a[b]=c");
+}
+
+- (void)test_encode_listsDefault_indices_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @[ @"b", @"c", @"d" ]}
+                     options:opts
+                       error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a[0]=b&a[1]=c&a[2]=d");
+}
+
+- (void)test_encode_indicesFalse_repeatKey_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.indices = @(NO);
+    opts.encode = NO;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @[ @"b", @"c", @"d" ]}
+                     options:opts
+                       error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=b&a=c&a=d");
+}
+
+- (void)test_encode_listFormats_all {
+    NSError *err = nil;
+    
+    QsEncodeOptions *idx = [QsEncodeOptions new];
+    idx.listFormat = @(QsListFormatIndices);
+    idx.encode = NO;
+    NSString *s1 = [Qs encode:@{@"a" : @[ @"b", @"c" ]} options:idx error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s1, @"a[0]=b&a[1]=c");
+    
+    QsEncodeOptions *br = [QsEncodeOptions new];
+    br.listFormat = @(QsListFormatBrackets);
+    br.encode = NO;
+    NSString *s2 = [Qs encode:@{@"a" : @[ @"b", @"c" ]} options:br error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s2, @"a[]=b&a[]=c");
+    
+    QsEncodeOptions *rep = [QsEncodeOptions new];
+    rep.listFormat = @(QsListFormatRepeatKey);
+    rep.encode = NO;
+    NSString *s3 = [Qs encode:@{@"a" : @[ @"b", @"c" ]} options:rep error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s3, @"a=b&a=c");
+    
+    QsEncodeOptions *cm = [QsEncodeOptions new];
+    cm.listFormat = @(QsListFormatComma);
+    cm.encode = NO;
+    NSString *s4 = [Qs encode:@{@"a" : @[ @"b", @"c" ]} options:cm error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s4, @"a=b,c");
+}
+
+- (void)test_encode_bracketNotationForMaps_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    NSDictionary *input = @{@"a" : @{@"b" : @{@"c" : @"d", @"e" : @"f"}}};
+    NSError *err = nil;
+    NSString *s = [Qs encode:input options:opts error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"a[b][c]=d", @"a[b][e]=f" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_allowDots_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.allowDots = YES;
+    opts.encode = NO;
+    NSDictionary *input = @{@"a" : @{@"b" : @{@"c" : @"d", @"e" : @"f"}}};
+    NSError *err = nil;
+    NSString *s = [Qs encode:input options:opts error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"a.b.c=d", @"a.b.e=f" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_encodeDotInKeys_true {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.allowDots = YES; // required when encodeDotInKeys = YES
+    opts.encodeDotInKeys = YES;
+    NSError *err = nil;
+    NSString *s =
+    [Qs encode:@{@"name.obj" : @{@"first" : @"John", @"last" : @"Doe"}}
+       options:opts
+         error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[
+        @"name%252Eobj.first=John", @"name%252Eobj.last=Doe"
+    ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_allowEmptyLists_true_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.allowEmptyLists = YES;
+    opts.encode = NO;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"foo" : @[], @"bar" : @"baz"}
+                     options:opts
+                       error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"foo[]", @"bar=baz" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_emptyAndNull_values {
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @""} options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=");
+}
+
+- (void)test_encode_emptyCollections_emitEmptyString {
+    NSError *err = nil;
+    XCTAssertEqualObjects([Qs encode:@{@"a" : @[]} options:nil error:&err], @"");
+    XCTAssertEqualObjects([Qs encode:@{@"a" : @{}} options:nil error:&err], @"");
+    XCTAssertEqualObjects([Qs encode:@{@"a" : @[ @[] ]} options:nil error:&err],
+                          @"");
+    XCTAssertEqualObjects(
+                          [Qs encode:@{@"a" : @{@"b" : @[]}} options:nil error:&err], @"");
+    XCTAssertEqualObjects(
+                          [Qs encode:@{@"a" : @{@"b" : @{}}} options:nil error:&err], @"");
+}
+
+- (void)test_encode_omitsUndefined_properties {
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : [NSNull null], @"b" : [QsUndefined new]}
+                     options:nil
+                       error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=");
+}
+
+- (void)test_encode_addQueryPrefix {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.addQueryPrefix = YES;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"b", @"c" : @"d"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertTrue([s hasPrefix:@"?"]);
+    NSSet *parts = [NSSet
+                    setWithArray:[[s substringFromIndex:1] componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"a=b", @"c=d" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_overrideDelimiter_string {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.delimiter = @";";
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"b", @"c" : @"d"} options:opts error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@";"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"a=b", @"c=d" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_date_default_encodeFalse_ISO8601ms {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0.007];
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : date} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=1970-01-01T00:00:00.007Z");
+}
+
+- (void)test_encode_date_customMillis_encodeFalse {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    opts.dateSerializerBlock = ^NSString *(NSDate *d) {
+        long long ms = llround([d timeIntervalSince1970] * 1000.0);
+        return [NSString stringWithFormat:@"%lld", ms];
+    };
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0.007];
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : date} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=7");
+}
+
+- (void)test_encode_sortKeys_withComparator {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    opts.sortComparatorBlock = ^NSInteger(id a, id b) {
+        NSString *sa = a ? [NSString stringWithFormat:@"%@", a] : @"";
+        NSString *sb = b ? [NSString stringWithFormat:@"%@", b] : @"";
+        NSComparisonResult c = [sa compare:sb];
+        if (c == NSOrderedAscending)
+            return -1;
+        if (c == NSOrderedDescending)
+            return 1;
+        return 0;
+    };
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"c", @"z" : @"y", @"b" : @"f"}
+                     options:opts
+                       error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=c&b=f&z=y");
+}
+
+- (void)test_encode_filter_withFunction {
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:0.123];
+    NSDictionary *input =
+    @{@"a" : @"b", @"c" : @"d", @"e" : @{@"f" : date, @"g" : @[ @2 ]}};
+    
+    QsFunctionFilter *ff =
+    [[QsFunctionFilter alloc] init:^id(NSString *prefix, id value) {
+        if ([prefix isEqualToString:@"b"]) {
+            return [QsUndefined new]; // drop
+        } else if ([prefix isEqualToString:@"e[f]"]) {
+            long long ms = llround([value timeIntervalSince1970] * 1000.0);
+            return @(ms);
+        } else if ([prefix isEqualToString:@"e[g][0]"]) {
+            if ([value isKindOfClass:[NSNumber class]])
+                return @([value intValue] * 2);
+            return value;
+        }
+        return value;
+    }];
+    
+    QsFilter *filter = [QsFilter function:ff];
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.encode = NO;
+    opts.filter = filter;
+    NSError *err = nil;
+    NSString *s = [Qs encode:input options:opts error:&err];
+    XCTAssertNil(err);
+    NSSet *parts = [NSSet setWithArray:[s componentsSeparatedByString:@"&"]];
+    NSSet *expected = [NSSet setWithArray:@[ @"a=b", @"c=d", @"e[f]=123", @"e[g][0]=4" ]];
+    XCTAssertEqualObjects(parts, expected);
+}
+
+- (void)test_encode_filter_withIterable {
+    NSError *err = nil;
+    
+    // Only keys a and e
+    QsEncodeOptions *opts1 = [QsEncodeOptions new];
+    opts1.encode = NO;
+    opts1.filter = [QsFilter
+                    iterable:[[QsIterableFilter alloc] initWithIterable:@[ @"a", @"e" ]]];
+    NSString *s1 = [Qs encode:@{@"a" : @"b", @"c" : @"d", @"e" : @"f"}
+                      options:opts1
+                        error:&err];
+    XCTAssertNil(err);
+    NSSet *set1 = [NSSet setWithArray:[s1 componentsSeparatedByString:@"&"]];
+    NSSet *expected1 = [NSSet setWithArray:@[ @"a=b", @"e=f" ]];
+    XCTAssertEqualObjects(set1, expected1);
+    
+    // Mixed: only a, and indices 0 and 2 under a
+    QsEncodeOptions *opts2 = [QsEncodeOptions new];
+    opts2.encode = NO;
+    opts2.filter = [QsFilter
+                    iterable:[[QsIterableFilter alloc] initWithIterable:@[ @"a", @0, @2 ]]];
+    NSString *s2 = [Qs encode:@{@"a" : @[ @"b", @"c", @"d" ], @"e" : @"f"}
+                      options:opts2
+                        error:&err];
+    XCTAssertNil(err);
+    NSSet *set2 = [NSSet setWithArray:[s2 componentsSeparatedByString:@"&"]];
+    NSSet *expected2 = [NSSet setWithArray:@[ @"a[0]=b", @"a[2]=d" ]];
+    XCTAssertEqualObjects(set2, expected2);
+}
+
+#pragma mark - Charset (encoding)
+
+- (void)test_charset_encodeLatin1 {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"æ" : @"æ"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"%E6=%E6");
+}
+
+- (void)test_charset_numericEntitiesWhenNeeded {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"☺"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=%26%239786%3B");
+}
+
+- (void)test_charset_sentinelUtf8 {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.charsetSentinel = YES;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"☺"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"utf8=%E2%9C%93&a=%E2%98%BA");
+}
+
+- (void)test_charset_sentinelLatin1 {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.charset = NSISOLatin1StringEncoding;
+    opts.charsetSentinel = YES;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"æ"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"utf8=%26%2310003%3B&a=%E6");
+}
+
+- (void)test_charset_customEncoderMock {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.valueEncoderBlock =
+    ^NSString *(id value, NSNumber *charsetNum, NSNumber *formatNum) {
+        NSString *sv = value ? [NSString stringWithFormat:@"%@", value] : @"";
+        if ([sv isEqualToString:@"a"])
+            return @"%61";
+        if ([sv isEqualToString:@"hello"])
+            return @"%68%65%6c%6c%6f";
+        return sv;
+    };
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"hello"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"%61=%68%65%6c%6c%6f");
+}
+
+#pragma mark - RFC 3986 vs RFC 1738 space encoding
+
+- (void)test_spaces_default3986 {
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"b c"} options:nil error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=b%20c");
+}
+
+- (void)test_spaces_explicit3986 {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.format = QsFormatRfc3986;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"b c"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=b%20c");
+}
+
+- (void)test_spaces_rfc1738 {
+    QsEncodeOptions *opts = [QsEncodeOptions new];
+    opts.format = QsFormatRfc1738;
+    NSError *err = nil;
+    NSString *s = [Qs encode:@{@"a" : @"b c"} options:opts error:&err];
+    XCTAssertNil(err);
+    XCTAssertEqualObjects(s, @"a=b+c");
+}
+
+@end

--- a/Sources/QsObjC/Enums/DecodeKindObjC.swift
+++ b/Sources/QsObjC/Enums/DecodeKindObjC.swift
@@ -1,0 +1,43 @@
+#if canImport(ObjectiveC) && QS_OBJC_BRIDGE
+    import QsSwift
+
+    /// Objective-C mirror of Swift ``QsSwift.DecodeKind``.
+    ///
+    /// Indicates the decoding context for a scalar token:
+    /// - `key`:    decode a key (or key segment); implementations often *preserve*
+    ///             percent-encoded dots (`%2E`/`%2e`) until after key splitting.
+    /// - `value`:  decode a value normally (regular percent-decoding / charset rules).
+    ///
+    /// Raw values are stable and bridge cleanly via `NSNumber` in Obj-C.
+    @objc(QsDecodeKind)
+    public enum DecodeKindObjC: Int {
+        case key
+        case value
+
+        /// Bridge to the Swift counterpart.
+        var swift: QsSwift.DecodeKind {
+            switch self {
+            case .key: return .key
+            case .value: return .value
+            }
+        }
+
+        /// Create from the Swift counterpart (round-trip convenience).
+        public init(_ swift: QsSwift.DecodeKind) {
+            switch swift {
+            case .key: self = .key
+            case .value: self = .value
+            }
+        }
+    }
+
+    /// Nice string for logs / debugging parity with Swift.
+    extension DecodeKindObjC: CustomStringConvertible {
+        public var description: String {
+            switch self {
+            case .key: return "key"
+            case .value: return "value"
+            }
+        }
+    }
+#endif

--- a/Sources/QsObjC/Enums/DecodeKindObjC.swift
+++ b/Sources/QsObjC/Enums/DecodeKindObjC.swift
@@ -15,7 +15,7 @@
         case value
 
         /// Bridge to the Swift counterpart.
-        var swift: QsSwift.DecodeKind {
+        public var swift: QsSwift.DecodeKind {
             switch self {
             case .key: return .key
             case .value: return .value

--- a/Sources/QsObjC/Models/DecodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/DecodeOptionsObjC.swift
@@ -47,7 +47,7 @@
         public var decoderBlock: DecoderBlock?
 
         /// Back‑compat: legacy two‑argument decoder, mirroring Swift `LegacyDecoder` (deprecated).
-        /// Prefer `valueDecoderBlock`, which also receives `DecodeKind` on the Swift side.
+        /// Prefer `decoderBlock` (the KEY/VALUE‑aware 3‑argument variant).
         /// Returning `nil` produces an absent value; the core will not fall back.
         public typealias LegacyDecoderBlock = (NSString?, NSNumber?) -> Any?
         public var legacyDecoderBlock: LegacyDecoderBlock?

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -190,8 +190,10 @@
                 let obj = a as AnyObject
                 let id = ObjectIdentifier(obj)
                 if seen.contains(id) { return a }
-                seen.insert(id)
-                return a.map { _bridgeInputForEncode($0, seen: &seen) }
+                let inserted = seen.insert(id).inserted
+                let mapped = a.map { _bridgeInputForEncode($0, seen: &seen) }
+                if inserted { seen.remove(id) }
+                return mapped
 
             // Plain Swift dict → OrderedDictionary<String, Any>
             case let d as [String: Any]:

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -257,12 +257,13 @@
                 let obj = d as AnyObject
                 let id = ObjectIdentifier(obj)
                 if seen.contains(id) { return d }  // keep cycles
-                seen.insert(id)
+                let inserted = seen.insert(id).inserted
                 var out = OrderedDictionary<String, Any>()
                 out.reserveCapacity(d.count)
                 d.forEach { (k, val) in
                     out[stringifyKey(k)] = _bridgeUndefinedPreservingOrder(val, seen: &seen) ?? val
                 }
+                if inserted { seen.remove(id) }
                 return out
 
             // NSArray → [Any]
@@ -270,8 +271,10 @@
                 let obj = a as AnyObject
                 let id = ObjectIdentifier(obj)
                 if seen.contains(id) { return a }
-                seen.insert(id)
-                return a.map { _bridgeUndefinedPreservingOrder($0, seen: &seen) ?? $0 }
+                let inserted = seen.insert(id).inserted
+                let mapped = a.map { _bridgeUndefinedPreservingOrder($0, seen: &seen) ?? $0 }
+                if inserted { seen.remove(id) }
+                return mapped
 
             // Plain Swift dict → OrderedDictionary<String, Any>
             case let d as [String: Any]:

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -106,13 +106,15 @@
                 if !forceReduce, let cast = d as? [AnyHashable: Any] {
                     return cast
                 }
-                return d.reduce(into: [AnyHashable: Any]()) { acc, kv in
-                    if let (k, v) = kv as? (AnyHashable, Any) {
-                        acc[k] = v
+                var out: [AnyHashable: Any] = [:]
+                d.forEach { key, value in
+                    if let hk = key as? AnyHashable {
+                        out[hk] = value
                     } else {
-                        acc[AnyHashable(stringifyKey(kv.key))] = kv.value
+                        out[AnyHashable(stringifyKey(key))] = value
                     }
                 }
+                return out
             }
 
             // NSArray → [Any]

--- a/Sources/QsSwift/Enums/DecodeKind.swift
+++ b/Sources/QsSwift/Enums/DecodeKind.swift
@@ -1,0 +1,27 @@
+/// Indicates the decoding context for a scalar token.
+///
+/// Use ``DecodeKind/key`` when decoding a key or key segment so the decoder can apply
+/// key-specific rules (for example, preserving percent-encoded dots ``%2E``/``%2e``
+/// until after key splitting). Use ``DecodeKind/value`` for normal value decoding.
+public enum DecodeKind: Int, Sendable, CustomStringConvertible {
+    /// The token is a **key** (or a key segment).
+    ///
+    /// Implementations typically avoid turning ``%2E``/``%2e`` into a literal dot
+    /// before key splitting when this kind is used, to match the semantics of the
+    /// reference `qs` library.
+    case key
+
+    /// The token is a **value**.
+    ///
+    /// Values are decoded normally (e.g., percent-decoding and charset handling)
+    /// without any key-specific protections.
+    case value
+
+    /// Human-readable label for logging/debugging.
+    public var description: String {
+        switch self {
+        case .key: return "key"
+        case .value: return "value"
+        }
+    }
+}

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -45,7 +45,9 @@ internal enum Decoder {
         if let s = value as? String, !s.isEmpty, options.comma, s.contains(",") {
             let splitVal = s.split(separator: ",", omittingEmptySubsequences: false).map(
                 String.init)
-            if options.throwOnLimitExceeded, splitVal.count > options.listLimit {
+            if options.throwOnLimitExceeded,
+                (currentListLength + splitVal.count) > options.listLimit
+            {
                 throw DecodeError.listLimitExceeded(limit: options.listLimit)
             }
             return splitVal

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -92,9 +92,12 @@ internal enum Decoder {
         var obj: OrderedDictionary<String, Any> = [:]
 
         // Strip "?" if requested, and normalize bracket encodings
-        let cleanStr = (options.ignoreQueryPrefix ? String(str.drop(while: { $0 == "?" })) : str)
-            .replacingOccurrences(of: "%5B", with: "[", options: [.caseInsensitive])
-            .replacingOccurrences(of: "%5D", with: "]", options: [.caseInsensitive])
+        let cleanStr =
+            options.ignoreQueryPrefix && str.hasPrefix("?")
+            ? String(str.dropFirst())
+            : str
+                .replacingOccurrences(of: "%5B", with: "[", options: [.caseInsensitive])
+                .replacingOccurrences(of: "%5D", with: "]", options: [.caseInsensitive])
 
         // Parameter limit handling (Int.max == effectively unlimited)
         let limit: Int? = (options.parameterLimit == .max) ? nil : options.parameterLimit

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -42,6 +42,12 @@ internal enum Decoder {
         options: DecodeOptions,
         currentListLength: Int
     ) throws -> Any? {
+        if options.throwOnLimitExceeded, options.listLimit <= 0 {
+            // Defer to existing global validation or treat as exceeded uniformly.
+            if currentListLength >= options.listLimit {
+                throw DecodeError.listLimitExceeded(limit: options.listLimit)
+            }
+        }
         if let s = value as? String, !s.isEmpty, options.comma, s.contains(",") {
             let splitVal = s.split(separator: ",", omittingEmptySubsequences: false).map(
                 String.init)

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -58,15 +58,6 @@ internal enum Decoder {
         return value
     }
 
-    // MARK: - Cached regexes
-
-    /// Legacy regex for dot‑notation (`.segment` → `[segment]`).
-    /// Kept for historical reference/benchmarks; **not used** by the current path
-    /// which performs a depth‑aware, top‑level only scan in `dotToBracket(...)`.
-    private static let dotRegex = try! NSRegularExpression(
-        pattern: #"\.([^.\[]+)"#, options: []
-    )
-
     // MARK: - Public-ish internals
 
     /// Parses a raw query string into an ordered map of `key → value`, where `value` may be:

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -159,8 +159,16 @@ internal enum Decoder {
                 return bracketEqualsPos
             }()
 
-            // Track if the raw part literally had "[]="
-            let hadBracketedEmpty = part.contains("[]=")
+            // Detect literal "[]" in the key only; support encoded forms.
+            let hadBracketedEmpty: Bool = {
+                if pos == -1 { return false }
+                let keyOnly = String(part.prefix(pos))
+                let normalized =
+                    keyOnly
+                    .replacingOccurrences(of: "%5B", with: "[", options: .caseInsensitive)
+                    .replacingOccurrences(of: "%5D", with: "]", options: .caseInsensitive)
+                return normalized.hasSuffix("[]")
+            }()
 
             let key: String
             var value: Any?

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -482,6 +482,8 @@ internal enum Decoder {
                         of: "%2E", with: ".", options: .caseInsensitive)
                     : cleanRoot
 
+                // Parity: when list parsing is disabled or listLimit < 0,
+                // treat "[]" as a dictionary key "0".
                 if (!options.parseLists || options.listLimit < 0) && decodedRoot.isEmpty {
                     // Treat "[]" as dictionary key "0"
                     mutableObj["0"] = (leaf ?? NSNull())

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -91,13 +91,11 @@ internal enum Decoder {
     ) throws -> OrderedDictionary<String, Any> {
         var obj: OrderedDictionary<String, Any> = [:]
 
-        // Strip "?" if requested, and normalize bracket encodings
+        // Strip "?" if requested (do not globally normalize %5B/%5D; normalize only within the key slice).
         let cleanStr =
-            options.ignoreQueryPrefix && str.hasPrefix("?")
+            (options.ignoreQueryPrefix && str.hasPrefix("?"))
             ? String(str.dropFirst())
             : str
-                .replacingOccurrences(of: "%5B", with: "[", options: [.caseInsensitive])
-                .replacingOccurrences(of: "%5D", with: "]", options: [.caseInsensitive])
 
         // Parameter limit handling (Int.max == effectively unlimited)
         let limit: Int? = (options.parameterLimit == .max) ? nil : options.parameterLimit

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -140,7 +140,14 @@ internal enum Decoder {
 
             let part = parts[i]
 
-            // Special handling when "]=" is present (prioritize that '=')
+            // IMPORTANT: We prefer the '=' that immediately follows a closing bracket (']=')
+            // when present anywhere in the token. Some inputs legitimately contain multiple
+            // '=' characters (e.g. values like "c=d"). Choosing the very first '=' can
+            // mis-split keys like "a[b]=c=d". Keeping this heuristic preserves historical
+            // qs behavior across ports.
+            //
+            // Also note: we *only* normalize %5B/%5D within the **key slice** after we find
+            // `pos`, so scanning for "]=" here does not interact with percent-decoding.
             let bracketEqualsPos: Int = {
                 if let range = part.range(of: "]=") {
                     return part.distance(from: part.startIndex, to: range.lowerBound) + 1

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -204,8 +204,8 @@ internal enum Decoder {
                 // IMPORTANT: distinguish custom decoder vs default decoder
                 if let arr = parsed as? [String] {
                     if let custom = options._decoder {
-                        // preserve element-level nils from custom decoder
-                        value = arr.map { custom($0, charset, .value) } as [Any?]
+                        let mapped = arr.map { custom($0, charset, .value) }
+                        value = mapped.map { $0 ?? NSNull() } as [Any]
                     } else {
                         // default decoder: fall back to original literal when decoding fails
                         value = arr.map { Utils.decode($0, charset: charset) ?? $0 } as [Any]

--- a/Sources/QsSwift/Internal/Decoder.swift
+++ b/Sources/QsSwift/Internal/Decoder.swift
@@ -221,7 +221,19 @@ internal enum Decoder {
                 }
             }
 
-            // Interpret numeric entities if asked, only in ISO-8859-1 mode
+            // Interpret numeric entities if asked (ISO‑8859‑1 only).
+            //
+            // Behavioral note / Kotlin & reference‑port parity:
+            // When `comma == true` has produced an *array* at this point, we intentionally
+            // collapse that array into a single **comma‑joined String** and interpret HTML
+            // numeric entities on that scalar. If the key was written as `a[]=...`, the
+            // scalar result is then wrapped by the `[]` handling to yield a **single‑element
+            // list** (e.g., ["1,☺"]). This matches the semantics in the Kotlin port and
+            // keeps the decode pipeline deterministic even when values contained commas.
+            //
+            // If you need to preserve array shape while also interpreting numeric entities,
+            // do not enable `interpretNumericEntities`, or pre‑decode/transform your data
+            // before passing it to Qs.
             if let v = value, !Utils.isEmpty(v), options.interpretNumericEntities,
                 charset == .isoLatin1
             {

--- a/Sources/QsSwift/Models/DecodeOptions.swift
+++ b/Sources/QsSwift/Models/DecodeOptions.swift
@@ -226,6 +226,9 @@ public struct DecodeOptions: @unchecked Sendable {
 
     /// Convenience back‑compat entry point (treat as VALUE decoding).
     /// Prefer `decodeValue(_:charset:)` in new code. Custom decoders still receive `kind = .value`.
+    @available(
+        *, deprecated, message: "Use decodeValue(_:charset:) or decodeKey(_:charset:) instead"
+    )
     public func getDecoder(_ value: String?, charset: String.Encoding? = nil) -> Any? {
         // Back‑compat: treat this as a VALUE decode.
         return decode(value, charset ?? self.charset, .value)

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1135,7 +1135,7 @@ struct DecodeTests {
 
     @Test("decode - custom number decoder with comma=true")
     func testDecode_NumberDecoder_Comma() async throws {
-        let numberDecoder: ValueDecoder = { s, _ in
+        let numberDecoder: ScalarDecoder = { s, _, _ in
             if let s, let n = Int(s) { return n }
             return Utils.decode(s, charset: .utf8)
         }
@@ -1533,7 +1533,7 @@ struct DecodeTests {
 struct CustomDecoderTests {
     @Test("decode - custom decoder (toy kanji example)")
     func testDecode_CustomDecoder() async throws {
-        let custom: ValueDecoder = { s, _ in
+        let custom: ScalarDecoder = { s, _, _ in
             s?
                 .replacingOccurrences(of: "%8c%a7", with: "県")
                 .replacingOccurrences(of: "%91%e5%8d%e3%95%7b", with: "大阪府")
@@ -1746,7 +1746,7 @@ struct CharsetDecodeTests {
 
     @Test("custom decoder may return nil (iso-8859-1 + interpretNumericEntities)")
     func customDecoderReturningNilIso() throws {
-        let decoder: ValueDecoder = { str, charset in
+        let decoder: ScalarDecoder = { str, charset, _ in
             guard let s = str, !s.isEmpty else { return nil }
             return Utils.decode(s, charset: charset ?? .utf8)
         }
@@ -2785,7 +2785,7 @@ extension DecodeTests {
 
     @Test("parse: number decoder")
     func parse_numberDecoder() throws {
-        let numberDecoder: ValueDecoder = { value, _ in
+        let numberDecoder: ScalarDecoder = { value, _, _ in
             if let v = value, let n = Int(v) { return "[\(n)]" }
             return value
         }
@@ -2915,7 +2915,7 @@ extension DecodeTests {
         }
 
         // Make the closure type explicitly @Sendable.
-        let decoder: @Sendable (String?, String.Encoding?) -> Any? = { s, _ in
+        let decoder: @Sendable (String?, String.Encoding?, DecodeKind?) -> Any? = { s, _, _ in
             guard let s else { return nil }
             return percentDecode(s, encoding: .shiftJIS) ?? s
         }
@@ -3008,7 +3008,7 @@ extension DecodeTests {
 
     @Test("parse: allow decoding keys and values")
     func parse_keyValueDecoder() throws {
-        let dec: ValueDecoder = { s, _ in s?.lowercased() }
+        let dec: ScalarDecoder = { s, _, _ in s?.lowercased() }
         let opt = DecodeOptions(decoder: dec)
 
         let r = try Qs.decode("KeY=vAlUe", options: opt)
@@ -3067,6 +3067,557 @@ extension DecodeTests {
 
         let r2 = try Qs.decode("%5B0%5D=a&%5B1%5D=b")
         #expect(NSDictionary(dictionary: r2).isEqual(to: ["0": "a", "1": "b"]))
+    }
+}
+
+// MARK: - DecodeOptions.defaultDecode (Kotlin parity — behavior-level port)
+
+@Suite("DecodeOptions.defaultDecode — key protections (behavioral parity)")
+struct DecodeOptionsDefaultDecodeBehaviorTests {
+    let charsets: [String.Encoding] = [.utf8, .isoLatin1]
+
+    @Test("KEY maps %2E/%2e inside brackets to '.' when allowDots=true (UTF-8/ISO-8859-1)")
+    func keyMapsEncodedDotInsideBrackets_allowDotsTrue() throws {
+        for cs in charsets {
+            let r1 = try Qs.decode("a[%2E]=x", options: .init(allowDots: true, charset: cs))
+            #expect(((r1["a"] as? [String: Any])?["."] as? String) == "x")
+
+            let r2 = try Qs.decode("a[%2e]=x", options: .init(allowDots: true, charset: cs))
+            #expect(((r2["a"] as? [String: Any])?["."] as? String) == "x")
+        }
+    }
+
+    @Test(
+        "KEY maps %2E outside brackets to '.' when allowDots=true; independent of decodeDotInKeys (UTF-8/ISO)"
+    )
+    func keyMapsEncodedDotTopLevel_allowDotsTrue_independentOfDecodeDotInKeys() throws {
+        for cs in charsets {
+            var r = try Qs.decode(
+                "a%2Eb=c",
+                options: .init(allowDots: true, decodeDotInKeys: false, charset: cs))
+            #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+
+            r = try Qs.decode(
+                "a%2Eb=c",
+                options: .init(allowDots: true, decodeDotInKeys: true, charset: cs))
+            #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+        }
+    }
+
+    @Test("non-KEY decodes %2E to '.' (control)")
+    func valueDecodesEncodedDot() throws {
+        for cs in charsets {
+            let r = try Qs.decode("x=%2E", options: .init(charset: cs))
+            #expect(r["x"] as? String == ".")
+        }
+    }
+
+    @Test("KEY maps %2E/%2e inside brackets even when allowDots=false")
+    func keyMapsEncodedDotInsideBrackets_allowDotsFalse() throws {
+        for cs in charsets {
+            let r1 = try Qs.decode("a[%2E]=x", options: .init(allowDots: false, charset: cs))
+            #expect(((r1["a"] as? [String: Any])?["."] as? String) == "x")
+
+            let r2 = try Qs.decode("a[%2e]=x", options: .init(allowDots: false, charset: cs))
+            #expect(((r2["a"] as? [String: Any])?["."] as? String) == "x")
+        }
+    }
+
+    @Test("KEY outside %2E decodes to '.' when allowDots=false (no protection outside brackets)")
+    func keyTopLevelEncodedDot_allowDotsFalse() throws {
+        for cs in charsets {
+            let r = try Qs.decode("a%2Eb=c", options: .init(allowDots: false, charset: cs))
+            #expect(r["a.b"] as? String == "c")
+        }
+    }
+}
+
+// MARK: - DecodeOptions interplay
+
+@Suite("DecodeOptions: allowDots / decodeDotInKeys interplay")
+struct DecodeOptionsInterplayTests_Parity {
+    @Test(
+        "decodeDotInKeys=true implies effective dot-splitting when allowDots is not explicitly false"
+    )
+    func decodeDotInKeysImpliesEffectiveAllowDots() throws {
+        // When only decodeDotInKeys=true is provided, the implementation should behave as if top-level
+        // dot-splitting were enabled.
+        let r = try Qs.decode("a.b=c", options: .init(decodeDotInKeys: true))
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+    }
+}
+
+// MARK: - DecodeOptions key/value decoding + custom decoder behavior (C# parity)
+
+@Suite("DecodeOptions: key/value decoding + custom decoder behavior")
+struct DecodeOptionsCustomDecoderParity {
+
+    @Test("kind-aware decoder receives KEY for top-level and bracketed keys")
+    func kindAwareDecoderReceivesKey() throws {
+        // Thread-safe, sendable sink that avoids capturing a non-sendable mutable array.
+        final class CallSink: @unchecked Sendable {
+            private var _items: [(String?, DecodeKind)] = []
+            private let lock = NSLock()
+            func add(_ s: String?, _ k: DecodeKind?) {
+                lock.lock()
+                defer { lock.unlock() }
+                _items.append((s, k ?? .value))
+            }
+            var items: [(String?, DecodeKind)] {
+                lock.lock()
+                defer { lock.unlock() }
+                return _items
+            }
+        }
+
+        let sink = CallSink()
+
+        let dec: ScalarDecoder = { s, _, k in
+            sink.add(s, k)
+            return s  // echo back
+        }
+
+        _ = try Qs.decode(
+            "a%2Eb=c&a[b]=d",
+            options: .init(allowDots: true, decoder: dec, decodeDotInKeys: true)
+        )
+
+        #expect(
+            sink.items.contains {
+                $0.1 == .key && ($0.0 == "a%2Eb" || $0.0 == "a[b]")
+            })
+        #expect(
+            sink.items.contains {
+                $0.1 == .value && ($0.0 == "c" || $0.0 == "d")
+            })
+    }
+
+    @Test(
+        "Single decoder acts like 'legacy' when ignoring kind (no default percent-decoding first)")
+    func singleDecoderLegacyBehavior() throws {
+        let dec: ScalarDecoder = { s, _, _ in s?.uppercased() }
+
+        // Keys and values are fed raw to the decoder; no default percent-decoding first.
+        var r = try Qs.decode("abc=def", options: .init(decoder: dec))
+        #expect(r["ABC"] as? String == "DEF")
+
+        // Encoded dot stays encoded because our custom decoder never percent-decodes.
+        r = try Qs.decode("a%2Eb=z", options: .init(allowDots: false, decoder: dec))
+        #expect(r["A%2EB"] as? String == "Z")
+    }
+
+    @Test("decoder wins over legacyDecoder when both are provided")
+    func decoderWinsOverLegacyDecoder() throws {
+        @available(*, deprecated) typealias Legacy = LegacyDecoder
+        let legacy: Legacy = { v, _ in "L:\(v ?? "null")" }
+        let dec: ScalarDecoder = { v, _, k in "K:\(k ?? .value):\(v ?? "null")" }
+        let opt = DecodeOptions(decoder: dec, legacyDecoder: legacy)
+
+        let r = try Qs.decode("x=y", options: opt)
+        #expect(r["K:key:x"] as? String == "K:value:y")
+    }
+
+    @Test("decodeKey coerces non-string decoder result via String(describing:)")
+    func decodeKeyCoercesToString() throws {
+        let dec: ScalarDecoder = { _, _, k in
+            if k == .key { return 42 } else { return "v" }
+        }
+        let r = try Qs.decode("anything=v", options: .init(decoder: dec))
+        #expect(r["42"] as? String == "v")
+    }
+
+    // Note: The Kotlin test that asserts constructor-time validation throwing for
+    // (allowDots=false, decodeDotInKeys=true) is not portable here because Swift enforces
+    // it via a precondition (crash), not a throwable initializer. We already cover this
+    // invalid combo in other suites by marking such tests disabled.
+}
+
+// MARK: - Encoded dot behavior in keys (%2E / %2e) — comprehensive coverage
+
+@Suite("encoded dot behavior in keys (%2E / %2e)")
+struct EncodedDotKeyBehaviorTests {
+
+    @Test(
+        "allowDots=false, decodeDotInKeys=false: encoded dots decode to literal '.'; no dot-splitting"
+    )
+    func encodedDot_noAllow_noDecodeDotKeys() throws {
+        let opt = DecodeOptions(allowDots: false, decodeDotInKeys: false)
+
+        var r = try Qs.decode("a%2Eb=c", options: opt)
+        #expect(r["a.b"] as? String == "c")
+
+        r = try Qs.decode("a%2eb=c", options: opt)
+        #expect(r["a.b"] as? String == "c")
+    }
+
+    @Test(
+        "allowDots=true, decodeDotInKeys=false: double-encoded dots are preserved inside segments; encoded and plain dots split"
+    )
+    func allowDots_true_decodeDotInKeys_false_behavior() throws {
+        // Plain dot splits
+        var r = try Qs.decode("a.b=c", options: .init(allowDots: true, decodeDotInKeys: false))
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+
+        // Double-encoded dot stays encoded inside first segment (no extra split for that part)
+        r = try Qs.decode(
+            "name%252Eobj.first=John",
+            options: .init(allowDots: true, decodeDotInKeys: false))
+        let seg = r["name%2Eobj"] as? [String: Any]
+        #expect((seg?["first"] as? String) == "John")
+
+        // Lowercase single-encoded inside the *first* segment → upstream percent-decoding
+        // exposes the '.'; allowDots splits: "a%2eb.c=d" → a → b → c
+        r = try Qs.decode(
+            "a%2eb.c=d",
+            options: .init(allowDots: true, decodeDotInKeys: false))
+        let a = r["a"] as? [String: Any]
+        let b = a?["b"] as? [String: Any]
+        #expect((b?["c"] as? String) == "d")
+    }
+
+    @Test(
+        "allowDots=true, decodeDotInKeys=true: encoded dots become literal '.' inside a segment (no extra split)"
+    )
+    func allowDots_true_decodeDotInKeys_true_behavior() throws {
+        var r = try Qs.decode(
+            "name%252Eobj.first=John",
+            options: .init(allowDots: true, decodeDotInKeys: true))
+        #expect(((r["name.obj"] as? [String: Any])?["first"] as? String) == "John")
+
+        // Double-encoded single segment becomes a literal dot
+        r = try Qs.decode(
+            "a%252Eb=c",
+            options: .init(allowDots: true, decodeDotInKeys: true))
+        #expect(r["a.b"] as? String == "c")
+
+        // Lowercase variant inside brackets
+        r = try Qs.decode(
+            "a[%2e]=x",
+            options: .init(allowDots: true, decodeDotInKeys: true))
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    @Test("bracket segment: %2E mapped based on decodeDotInKeys; case-insensitive")
+    func bracketSegment_mapping_caseInsensitive() throws {
+        // When disabled, keep '.' result (percent-decoding inside bracket) without further mapping
+        var r = try Qs.decode(
+            "a[%2E]=x",
+            options: .init(allowDots: false, decodeDotInKeys: false))
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+
+        r = try Qs.decode(
+            "a[%2e]=x",
+            options: .init(allowDots: true, decodeDotInKeys: false))
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+
+        // When enabled, convert to '.' regardless of case
+        r = try Qs.decode(
+            "a[%2E]=x",
+            options: .init(allowDots: true, decodeDotInKeys: true))
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    /// Invalid combination (decodeDotInKeys=true while allowDots=false) is enforced by a precondition
+    /// in DecodeOptions init; cannot be caught here. See dedicated disabled test below.
+    @Test(
+        "allowDots=false, decodeDotInKeys=true is invalid (precondition in initializer)",
+        .enabled(if: false, "initializer precondition; cannot be caught with #expect(throws:)")
+    )
+    func parity_invalidCombo_PRECONDITION() throws {
+        _ = try Qs.decode(
+            "a[%2e]=x",
+            options: .init(allowDots: false, decodeDotInKeys: true)
+        )
+    }
+
+    @Test("bare-key (no '='): behavior matches key decoding path")
+    func bareKey_behavesLikeKeyDecoding() throws {
+        // allowDots=false → %2E becomes '.'; no splitting; strictNullHandling → NSNull
+        var r = try Qs.decode(
+            "a%2Eb",
+            options: .init(
+                allowDots: false,
+                decodeDotInKeys: false,
+                strictNullHandling: true))
+        #expect(r.keys.contains("a.b"))
+        #expect((r["a.b"] is NSNull))
+
+        // allowDots=true & decodeDotInKeys=false — upstream exposes '.'; split on dot; empty value
+        r = try Qs.decode(
+            "a%2Eb",
+            options: .init(allowDots: true, decodeDotInKeys: false))
+        let a = r["a"] as? [String: Any]
+        #expect((a?["b"] as? String) == "")
+    }
+
+    @Test("depth=0 with allowDots=true: do not split key")
+    func depthZero_disablesTopLevelDotSplitting() throws {
+        let r = try Qs.decode("a.b=c", options: .init(allowDots: true, depth: 0))
+        #expect(r["a.b"] as? String == "c")
+    }
+
+    @Test("top-level dot→bracket conversion guardrails: leading/trailing/double dots")
+    func dotToBracket_guardrails() throws {
+        // Leading dot: ".a" → { "a": "x" } (when allowDots=true)
+        var r = try Qs.decode(".a=x", options: .init(allowDots: true, decodeDotInKeys: false))
+        #expect(((r["a"] as? String) == "x"))
+
+        // Trailing dot: "a." remains literal
+        r = try Qs.decode("a.=x", options: .init(allowDots: true, decodeDotInKeys: false))
+        #expect(r["a."] as? String == "x")
+
+        // Double dots: only the second dot (before a token) causes a split; middle dot is literal
+        r = try Qs.decode("a..b=x", options: .init(allowDots: true, decodeDotInKeys: false))
+        let a = r["a."] as? [String: Any]
+        #expect((a?["b"] as? String) == "x")
+    }
+
+    // --- C# parity subset (top-level + bracket + charset) ---
+
+    @Test(
+        "top-level: allowDots=true, decodeDotInKeys=true → plain & encoded dots split (upper/lower)"
+    )
+    func parity_topLevel_allowDots_decodeDotInKeys_true() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+
+        var r = try Qs.decode("a.b=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+
+        r = try Qs.decode("a%2Eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+
+        r = try Qs.decode("a%2eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+    }
+
+    @Test(
+        "top-level: allowDots=true, decodeDotInKeys=false → encoded dot also splits (upper/lower)")
+    func parity_topLevel_allowDots_true_decodeDotInKeys_false() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: false)
+
+        var r = try Qs.decode("a%2Eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+
+        r = try Qs.decode("a%2eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+    }
+
+    // FIXME: this one fails the precondition
+    @Test(
+        "allowDots=false, decodeDotInKeys=true is invalid",
+        .enabled(if: false, "initializer precondition; cannot be caught with #expect(throws:)")
+    )
+    func parity_invalidCombo() throws {
+        _ = try Qs.decode(
+            "a%2Eb=c",
+            options: .init(allowDots: false, decodeDotInKeys: true)
+        )
+    }
+
+    @Test("bracket segment: maps to '.' when decodeDotInKeys=true (case-insensitive)")
+    func parity_bracket_mapsToDot_whenDecodeDotInKeysTrue() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+        var r = try Qs.decode("a[%2E]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+        r = try Qs.decode("a[%2e]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    @Test(
+        "bracket segment: when decodeDotInKeys=false, percent-decoding inside brackets yields '.' (case-insensitive)"
+    )
+    func parity_bracket_percentDecoding_whenDecodeDotInKeysFalse() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: false)
+        var r = try Qs.decode("a[%2E]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+        r = try Qs.decode("a[%2e]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    @Test("value tokens always decode %2E → '.'")
+    func parity_valueTokens_decode_percentDot() throws {
+        let r = try Qs.decode("x=%2E")
+        #expect(r["x"] as? String == ".")
+    }
+
+    @Test("latin1: allowDots=true, decodeDotInKeys=true behaves like UTF-8 for top-level & bracket")
+    func parity_latin1_allowDots_true_decodeDotInKeys_true() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true, charset: .isoLatin1)
+        var r = try Qs.decode("a%2Eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+        r = try Qs.decode("a[%2E]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    @Test(
+        "latin1: allowDots=true, decodeDotInKeys=false also splits top-level and decodes inside brackets"
+    )
+    func parity_latin1_allowDots_true_decodeDotInKeys_false() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: false, charset: .isoLatin1)
+        var r = try Qs.decode("a%2Eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+        r = try Qs.decode("a[%2E]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["."] as? String) == "x")
+    }
+
+    @Test(
+        "mixed-case encoded brackets + encoded dot after brackets (allowDots=true, decodeDotInKeys=true)"
+    )
+    func parity_mixedCase_encodedBrackets_plus_encodedDot_after() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+        var r = try Qs.decode("a%5Bb%5D%5Bc%5D%2Ed=x", options: opt)
+        #expect(
+            (((r["a"] as? [String: Any])?["b"] as? [String: Any])?["c"] as? [String: Any])?["d"]
+                as? String == "x")
+        r = try Qs.decode("a%5bb%5d%5bc%5d%2ed=x", options: opt)
+        #expect(
+            (((r["a"] as? [String: Any])?["b"] as? [String: Any])?["c"] as? [String: Any])?["d"]
+                as? String == "x")
+    }
+
+    @Test("nested brackets inside a bracket segment (balanced as one segment)")
+    func parity_nestedBrackets_insideSegment() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+        // "a[b%5Bc%5D].e=x" → key "b[c]" stays one segment; then ".e" splits
+        let r = try Qs.decode("a[b%5Bc%5D].e=x", options: opt)
+        let a = r["a"] as? [String: Any]
+        #expect(((a?["b[c]"] as? [String: Any])?["e"] as? String) == "x")
+    }
+
+    // FIXME: this one fails the precondition
+    @Test(
+        "mixed-case encoded brackets + encoded dot with allowDots=false & decodeDotInKeys=true throws",
+        .enabled(if: false, "initializer precondition; cannot be caught with #expect(throws:)")
+    )
+    func parity_mixedCase_invalidCombo_throws() throws {
+        _ = try Qs.decode(
+            "a%5Bb%5D%5Bc%5D%2Ed=x",
+            options: .init(allowDots: false, decodeDotInKeys: true)
+        )
+    }
+
+    @Test("bracket then encoded dot to next segment with allowDots=true")
+    func parity_bracket_then_encodedDot_nextSegment() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+        var r = try Qs.decode("a[b]%2Ec=x", options: opt)
+        #expect((((r["a"] as? [String: Any])?["b"] as? [String: Any])?["c"] as? String) == "x")
+        r = try Qs.decode("a[b]%2ec=x", options: opt)
+        #expect((((r["a"] as? [String: Any])?["b"] as? [String: Any])?["c"] as? String) == "x")
+    }
+
+    @Test("mixed-case: top-level encoded dot then bracket with allowDots=true")
+    func parity_topLevel_encodedDot_then_bracket() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: true)
+        let r = try Qs.decode("a%2E[b]=x", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "x")
+    }
+
+    @Test("top-level lowercase encoded dot splits when allowDots=true (decodeDotInKeys=false)")
+    func parity_lowercaseEncodedDot_allowDots_true_decodeDotInKeys_false() throws {
+        let opt = DecodeOptions(allowDots: true, decodeDotInKeys: false)
+        let r = try Qs.decode("a%2eb=c", options: opt)
+        #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
+    }
+
+    @Test("dot before index with allowDots=true: index remains index")
+    func parity_dotBeforeIndex_allowDots_true() throws {
+        let opt = DecodeOptions(allowDots: true)
+        let r = try Qs.decode("foo[0].baz[0]=15&foo[0].bar=2", options: opt)
+        let foo = r["foo"] as? [Any]
+        let zero = foo?.first as? [String: Any]
+        #expect((zero?["bar"] as? String) == "2")
+        #expect((zero?["baz"] as? [String]) == ["15"])
+    }
+
+    @Test("trailing dot ignored when allowDots=true")
+    func parity_trailingDot_ignored_allowDots_true() throws {
+        let r = try Qs.decode("user.email.=x", options: .init(allowDots: true))
+        #expect(((r["user"] as? [String: Any])?["email"] as? String) == "x")
+    }
+
+    // NOTE: The Kotlin test "kind-aware decoder receives KEY ..." is omitted here:
+    // Swift's ValueDecoder currently has the signature (String?, String.Encoding?) -> Any?
+    // and does not receive a DecodeKind. Once you add a kind-aware hook, you can port that test.
+}
+
+// MARK: - Remainder wrapping & strictDepth behavior (ported expectations)
+
+@Suite("splitKeyIntoSegments — remainder wrapping & strictDepth behavior")
+struct RemainderWrappingStrictDepthTests {
+
+    @Test(
+        "allowDots=true, depth=1: wrap the remainder from the next unprocessed bracket"
+    )
+    func remainderWrapped_allowDots_depth1() throws {
+        let segs = try QsSwift.Decoder.splitKeyIntoSegments(
+            originalKey: "a.b.c",
+            allowDots: true,
+            maxDepth: 1,
+            strictDepth: false
+        )
+        #expect(segs == ["a", "[b]", "[[c]]"])  // Kotlin: ["a","[b]","[[c]]"]
+    }
+
+    @Test(
+        "bracketed input, depth=2: collect two groups, wrap remainder as a single synthetic segment"
+    )
+    func remainderWrapped_bracketed_depth2() throws {
+        let segs = try QsSwift.Decoder.splitKeyIntoSegments(
+            originalKey: "a[b][c][d]",
+            allowDots: false,
+            maxDepth: 2,
+            strictDepth: false
+        )
+        #expect(segs == ["a", "[b]", "[c]", "[[d]]"])  // Kotlin: ["a","[b]","[c]","[[d]]"]
+    }
+
+    @Test(
+        "unterminated bracket group: do not throw even with strictDepth=true; wrap raw remainder"
+    )
+    func unterminatedBracket_noThrowStrict() throws {
+        // Unterminated after first '[': "a[b[c" -> ["a", "[[b[c]"]
+        let segs = try QsSwift.Decoder.splitKeyIntoSegments(
+            originalKey: "a[b[c",
+            allowDots: false,
+            maxDepth: 5,
+            strictDepth: true
+        )
+        #expect(segs == ["a", "[[b[c]"])
+    }
+
+    @Test("strictDepth=true: well-formed depth overflow throws")
+    func wellFormedDepthOverflow_throws() {
+        var didThrow = false
+        do {
+            _ = try QsSwift.Decoder.splitKeyIntoSegments(
+                originalKey: "a[b][c][d]",
+                allowDots: false,
+                maxDepth: 2,
+                strictDepth: true
+            )
+        } catch {
+            didThrow = true
+        }
+        #expect(didThrow)
+    }
+
+    @Test("depth=0: never split; return the original key as a single segment")
+    func depthZero_neverSplit() throws {
+        var segs = try QsSwift.Decoder.splitKeyIntoSegments(
+            originalKey: "a.b.c",
+            allowDots: true,
+            maxDepth: 0,
+            strictDepth: false
+        )
+        #expect(segs == ["a.b.c"])  // depth=0: never split
+
+        segs = try QsSwift.Decoder.splitKeyIntoSegments(
+            originalKey: "a[b][c]",
+            allowDots: false,
+            maxDepth: 0,
+            strictDepth: false
+        )
+        #expect(segs == ["a[b][c]"])  // depth=0: never split
     }
 }
 

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -3135,7 +3135,7 @@ struct DecodeOptionsDefaultDecodeBehaviorTests {
 // MARK: - DecodeOptions interplay
 
 @Suite("DecodeOptions: allowDots / decodeDotInKeys interplay")
-struct DecodeOptionsInterplayTests_Parity {
+struct DecodeOptionsInterplayParityTests {
     @Test(
         "decodeDotInKeys=true implies effective dot-splitting when allowDots is not explicitly false"
     )

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -3402,7 +3402,7 @@ struct EncodedDotKeyBehaviorTests {
         #expect(((r["a"] as? [String: Any])?["b"] as? String) == "c")
     }
 
-    // FIXME: this one fails the precondition
+    // NOTE: intentionally disabled — this combination violates a precondition in the initializer
     @Test(
         "allowDots=false, decodeDotInKeys=true is invalid",
         .enabled(if: false, "initializer precondition; cannot be caught with #expect(throws:)")
@@ -3484,7 +3484,7 @@ struct EncodedDotKeyBehaviorTests {
         #expect(((a?["b[c]"] as? [String: Any])?["e"] as? String) == "x")
     }
 
-    // FIXME: this one fails the precondition
+    // NOTE: intentionally disabled — this combination violates a precondition in the initializer
     @Test(
         "mixed-case encoded brackets + encoded dot with allowDots=false & decodeDotInKeys=true throws",
         .enabled(if: false, "initializer precondition; cannot be caught with #expect(throws:)")

--- a/Tests/QsSwiftTests/ExampleTests.swift
+++ b/Tests/QsSwiftTests/ExampleTests.swift
@@ -600,7 +600,7 @@ struct ExampleTests {
 
     @Test("charset: custom decoder for different charsets (mock)")
     func charset_customDecoderMock() throws {
-        let dec: ValueDecoder = { str, _ in
+        let dec: ScalarDecoder = { str, _, _ in
             switch str {
             case "%61": return "a"
             case "%68%65%6c%6c%6f": return "hello"

--- a/scripts/collect-macos-crashlogs.sh
+++ b/scripts/collect-macos-crashlogs.sh
@@ -19,7 +19,7 @@ SYS_DR="/Library/Logs/DiagnosticReports"
 for dir in "$USER_DR" "$SYS_DR"; do
   if [ -d "$dir" ]; then
     echo "=== Listing $dir ==="
-    ls -lah "$dir" || true
+    ls -lah "$dir" | tail -n 200 || true
   fi
 done
 
@@ -52,7 +52,7 @@ done
 # Ignore errors if log show is unavailable or lacks permission.
 if command -v log >/dev/null 2>&1; then
   /usr/bin/log show --style syslog --last "${MINUTES}m" \
-    --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift"' \
+    --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift" OR process CONTAINS[c] "xcodebuild" OR process CONTAINS[c] "CoreSimulator"' \
     > "$DEST/unified-log.txt" 2>/dev/null || true
 fi
 

--- a/scripts/collect-macos-crashlogs.sh
+++ b/scripts/collect-macos-crashlogs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Collect recent macOS crash-style logs into a destination folder.
+# Usage: collect-macos-crashlogs.sh [DEST_DIR] [MINUTES]
+#  - DEST_DIR: output folder (default: crashlogs)
+#  - MINUTES : look back this many minutes (default: 60)
+#
+# This script is intended for CI use on GitHub macOS runners, but also works locally.
+set -euxo pipefail
+
+DEST="${1:-crashlogs}"
+MINUTES="${2:-60}"
+
+mkdir -p "$DEST"
+
+USER_DR="$HOME/Library/Logs/DiagnosticReports"
+SYS_DR="/Library/Logs/DiagnosticReports"
+
+# List directories for debugging context
+for dir in "$USER_DR" "$SYS_DR"; do
+  if [ -d "$dir" ]; then
+    echo "=== Listing $dir ==="
+    ls -lah "$dir" || true
+  fi
+done
+
+# Copy recent crash-like files (multiple common extensions)
+for dir in "$USER_DR" "$SYS_DR"; do
+  if [ -d "$dir" ]; then
+    # Use sudo for system dir on CI; runners allow it.
+    CP="cp"
+    if [ "$dir" = "$SYS_DR" ]; then CP="sudo cp"; fi
+
+    # -mmin filters by modification time in minutes
+    find "$dir" -type f \
+      \( -name '*.crash' -o -name '*.ips' -o -name '*.hang' -o -name '*.spin' \) \
+      -mmin "-$MINUTES" -print -exec $CP {} "$DEST"/ \; || true
+  fi
+done
+
+# Include a unified log snippet around the failure window (helpful when no .crash exists)
+# Filter for xctest/swift-related messages.
+# Ignore errors if log show is unavailable or lacks permission.
+if command -v log >/dev/null 2>&1; then
+  /usr/bin/log show --style syslog --last "${MINUTES}m" \
+    --predicate 'eventMessage CONTAINS[c] "xctest" OR process CONTAINS[c] "xctest" OR process CONTAINS[c] "swift"' \
+    > "$DEST/unified-log.txt" 2>/dev/null || true
+fi
+
+echo "Collected files in $DEST:"
+ls -lah "$DEST" || true


### PR DESCRIPTION
This pull request adds new Objective-C E2E tests and enhances the Objective-C bridge for the query string library, focusing on improved decoding/encoding customization and convenience methods. It also updates the CI workflow to support these new tests and modernizes some GitHub Actions. The most important changes are grouped below.

**Testing and CI workflow improvements:**

* Added a new `objc-tests` job to `.github/workflows/test.yml` to run Objective-C E2E tests on macOS with Xcode 16.3, including steps for dependency resolution, test execution, artifact upload, and crash log collection.
* Updated `actions/checkout` usage to v5 in all jobs and granted `actions: write` permissions for workflow actions. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R12) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-R34) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L56-R57)

**Objective-C bridge enhancements:**

* Introduced `DecodeKindObjC` enum to mirror Swift’s `DecodeKind`, allowing decoder blocks to distinguish between key and value decoding contexts.
* Added a new three-argument `decoderBlock` to `QsDecodeOptions` for KEY/VALUE-aware decoding, along with a legacy two-argument block for backward compatibility.
* Clarified the behavior of decoder blocks: returning `nil` now always produces an absent value, with no fallback to default decoding.

**New and expanded test coverage:**

* Added comprehensive Objective-C tests for decode/encode convenience helpers (`ObjCDecodeConvenienceTests.m`, `ObjCEncodeConvenienceTests.m`), async encoding (`ObjCEncodeAsyncTests.m`), and advanced decoding scenarios (custom decoder blocks, dot syntax, error propagation, etc.) in `ObjCBridgeExtrasTests.m`. [[1]](diffhunk://#diff-94b1fed92b49d8d7d9832cefb323aa605f2a9fc44f7b0a38201d757a7c0e404eR271-R439) [[2]](diffhunk://#diff-e670e1e9db36536fecc08e34d80309a7b716d309d56837edef2e05fb0dd7577eR1-R84) [[3]](diffhunk://#diff-c29ded57e4a916833a9dd7af2dcfcffda671472bcc20f586332fc43d6685378eR1-R109) [[4]](diffhunk://#diff-f952123b189c37b2ca061df12575a1f5b720179be5aca6f99c73388dd26ff85bR1-R89)

**References:** [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R127-R216) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R12) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-R34) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L56-R57) [[5]](diffhunk://#diff-eb13cb404fd3bd0b27613c54790ffb1db5271f5550e34463fbce1ce436979fc6R1-R43) [[6]](diffhunk://#diff-480fee1d9d0acc71d7491dad9132cfc5fe7d77a08af41ab27bbd8e646c37f299R44-R54) [[7]](diffhunk://#diff-480fee1d9d0acc71d7491dad9132cfc5fe7d77a08af41ab27bbd8e646c37f299L30-R30) [[8]](diffhunk://#diff-94b1fed92b49d8d7d9832cefb323aa605f2a9fc44f7b0a38201d757a7c0e404eR271-R439) [[9]](diffhunk://#diff-e670e1e9db36536fecc08e34d80309a7b716d309d56837edef2e05fb0dd7577eR1-R84) [[10]](diffhunk://#diff-c29ded57e4a916833a9dd7af2dcfcffda671472bcc20f586332fc43d6685378eR1-R109) [[11]](diffhunk://#diff-f952123b189c37b2ca061df12575a1f5b720179be5aca6f99c73388dd26ff85bR1-R89)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Obj‑C bridge: DecodeKind enum and key/value‑aware decoder; Obj‑C convenience helpers for decode/encode.

- **Refactor**
  - Unified 3‑argument scalar decoder model with legacy compatibility; depth‑aware key splitting and improved cycle handling.

- **Tests**
  - Extensive new/expanded Swift and Objective‑C test suites (including async and E2E) and added coverage artifacts.

- **Chores**
  - CI updates: added macOS Obj‑C E2E job, bumped checkout, longer timeouts, consolidated crash‑log collection script, and Codecov upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->