### PR TITLE
:white_check_mark: add more tests

### DIFF
--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -161,6 +161,15 @@
                 for (key, value) in od { out[key] = _bridgeInputForEncode(value, seen: &seen) }
                 return out
 
+            // Ordered Swift dict with heterogeneous Hashable keys → stringify deterministically
+            case let od as OrderedDictionary<AnyHashable, Any>:
+                var out = OrderedDictionary<String, Any>()
+                out.reserveCapacity(od.count)
+                for (key, value) in od {
+                    out[stringifyKey(key)] = _bridgeInputForEncode(value, seen: &seen)
+                }
+                return out
+
             // Already ordered Swift dict (NSString keys)
             case let od as OrderedDictionary<NSString, Any>:
                 var out = OrderedDictionary<String, Any>()

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -261,6 +261,16 @@
                 }
                 return out
 
+            // Ordered Swift dict (AnyHashable keys) → normalize to String keys
+            case let od as OrderedDictionary<AnyHashable, Any>:
+                var out = OrderedDictionary<String, Any>()
+                out.reserveCapacity(od.count)
+                for (key, val) in od {
+                    let stringKey = stringifyKey(key)
+                    out[stringKey] = _bridgeUndefinedPreservingOrder(val, seen: &seen) ?? val
+                }
+                return out
+
             // NSDictionary → OrderedDictionary<String, Any>
             case let dict as NSDictionary:
                 let obj = dict as AnyObject

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -28,6 +28,7 @@ extension Utils {
                 return out
             }
 
+            // Array branches – tolerate both [Any] and [Any?] shapes.
             if let arrOpt = value as? [Any?] {
                 var out: [Any] = []
                 out.reserveCapacity(arrOpt.count)

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -28,35 +28,6 @@ extension Utils {
                 return out
             }
 
-            // Array branches – tolerate both [Any] and [Any?] shapes.
-            if let arr = value as? [Any] {
-                var out: [Any] = []
-                out.reserveCapacity(arr.count)
-                for element in arr {
-                    if element is Undefined {
-                        if allowSparse { out.append(NSNull()) }
-                        // else: drop it
-                        continue
-                    }
-                    if let subDict = element as? [String: Any?] {
-                        if let cv = compactValue(subDict, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArr = element as? [Any] {
-                        if let cv = compactValue(subArr, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArrOpt = element as? [Any?] {
-                        if let cv = compactValue(subArrOpt, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else {
-                        out.append(element)
-                    }
-                }
-                return out
-            }
-
             if let arrOpt = value as? [Any?] {
                 var out: [Any] = []
                 out.reserveCapacity(arrOpt.count)
@@ -83,6 +54,34 @@ extension Utils {
                         }
                     } else {
                         out.append(unwrapped)
+                    }
+                }
+                return out
+            }
+
+            if let arr = value as? [Any] {
+                var out: [Any] = []
+                out.reserveCapacity(arr.count)
+                for element in arr {
+                    if element is Undefined {
+                        if allowSparse { out.append(NSNull()) }
+                        // else: drop it
+                        continue
+                    }
+                    if let subDict = element as? [String: Any?] {
+                        if let cv = compactValue(subDict, allowSparse: allowSparse) {
+                            out.append(cv)
+                        }
+                    } else if let subArr = element as? [Any] {
+                        if let cv = compactValue(subArr, allowSparse: allowSparse) {
+                            out.append(cv)
+                        }
+                    } else if let subArrOpt = element as? [Any?] {
+                        if let cv = compactValue(subArrOpt, allowSparse: allowSparse) {
+                            out.append(cv)
+                        }
+                    } else {
+                        out.append(element)
                     }
                 }
                 return out

--- a/Tests/QsObjCTests/ObjCBridgeTests.swift
+++ b/Tests/QsObjCTests/ObjCBridgeTests.swift
@@ -4,6 +4,7 @@
     import Testing
 
     @testable import QsObjC
+    @testable import QsSwift
 
     struct ObjCBridgeTests {
         @Test("encode → decode round-trip (flat)")
@@ -106,6 +107,24 @@
             #expect(out?["k"] as? String == "v")
         }
 
+        @Test("bridgeInputForDecode: NSDictionary stringifies non-AnyHashable keys when not forcing reduce")
+        func decode_dictionary_stringifies_nonHashable_keys() {
+            let arrayKey: NSArray = ["k"]
+            let dict = NSMutableDictionary()
+            dict[arrayKey] = "value"
+
+            let bridged = QsBridge.bridgeInputForDecode(dict)
+
+            if let out = bridged as? [AnyHashable: Any] {
+                #expect(out.count == 1)
+                let firstKeyDescription = out.keys.first.map { String(describing: $0) } ?? ""
+                #expect(firstKeyDescription.contains("k"))
+                #expect(out.values.first as? String == "value")
+            } else {
+                Issue.record("Unexpected bridged type: \(type(of: bridged))")
+            }
+        }
+
         @Test("bridgeInputForDecode: NSArray → [Any]")
         func decode_nsarray_maps_to_swift_array() {
             let a: NSArray = ["x" as NSString, NSNumber(value: 42), NSNull()]
@@ -165,6 +184,189 @@
             #expect((arr?[0] as? NSNumber)?.intValue == 1)
             let s1 = (arr?[1] as? String) ?? (arr?[1] as? NSString).map(String.init)
             #expect(s1 == "z")
+        }
+
+        @Test("bridgeInputForEncode: Swift [String: Any] produces OrderedDictionary")
+        func encode_swiftDictionary_bridgesToOrdered() {
+            let payload: [String: Any] = [
+                "alpha": 1,
+                "sentinel": UndefinedObjC()
+            ]
+
+            let bridged = QsBridge.bridgeInputForEncode(payload)
+
+            if let out = bridged as? OrderedDictionary<String, Any> {
+                #expect(out["alpha"] as? Int == 1)
+                #expect(out["sentinel"] is UndefinedObjC)
+            } else {
+                Issue.record("Unexpected bridged type: \(type(of: bridged))")
+            }
+        }
+
+        @Test("bridgeInputForEncode handles Swift-only values that cannot bridge to NSDictionary")
+        func encode_swiftDictionary_withSwiftOnlyValues() {
+            struct SwiftOnly: CustomStringConvertible {
+                let id: Int
+                var description: String { "swift-\(id)" }
+            }
+
+            let payload: [String: Any] = [
+                "custom": SwiftOnly(id: 1),
+                "sentinel": UndefinedObjC()
+            ]
+
+            let bridged = QsBridge.bridgeInputForEncode(payload)
+            if let out = bridged as? OrderedDictionary<String, Any> {
+                #expect(out["custom"] is SwiftOnly)
+                #expect(out["sentinel"] is UndefinedObjC)
+            } else {
+                Issue.record("Swift-only dictionary branch not exercised: \(type(of: bridged))")
+            }
+        }
+
+        @Test("bridgeInputForEncode: Swift [Any] bridges elements recursively")
+        func encode_swiftArray_bridgesElements() {
+            let payload: [Any] = [UndefinedObjC(), ["key": "value"]]
+            let bridged = QsBridge.bridgeInputForEncode(payload)
+
+            if let out = bridged as? [Any] {
+                #expect(out.first is UndefinedObjC)
+                let nested = out.dropFirst().first as? OrderedDictionary<String, Any>
+                #expect(nested?["key"] as? String == "value")
+            } else {
+                Issue.record("Unexpected bridged type: \(type(of: bridged))")
+            }
+        }
+
+        @Test("bridgeInputForEncode: OrderedDictionary<NSString, Any> normalizes keys")
+        func encode_orderedDictionaryNSString_keys() {
+            let od = OrderedDictionary<NSString, Any>(uniqueKeysWithValues: [
+                ("one" as NSString, 1),
+                ("two" as NSString, 2)
+            ])
+
+            let bridged = QsBridge.bridgeInputForEncode(od)
+            let out = bridged as? OrderedDictionary<String, Any>
+            #expect(out?.keys.elementsEqual(["one", "two"]) == true)
+            #expect(out?["one"] as? Int == 1)
+        }
+
+        @Test("bridgeInputForEncode: OrderedDictionary<String, Any> preserves ordering")
+        func encode_orderedDictionaryString_keys() {
+            var od = OrderedDictionary<String, Any>()
+            od["first"] = 1
+            od["second"] = OrderedDictionary<NSString, Any>(uniqueKeysWithValues: [
+                ("nested" as NSString, UndefinedObjC())
+            ])
+
+            let bridged = QsBridge.bridgeInputForEncode(od)
+
+            if let out = bridged as? OrderedDictionary<String, Any> {
+                #expect(out["first"] as? Int == 1)
+                let nested = out["second"] as? OrderedDictionary<String, Any>
+                let nestedValue = nested?["nested"]
+                let unwrapped: Any?
+                if let value = nestedValue {
+                    let mirror = Mirror(reflecting: value)
+                    unwrapped = mirror.displayStyle == .optional ? mirror.children.first?.value : value
+                } else {
+                    unwrapped = nil
+                }
+                #expect((unwrapped is UndefinedObjC) || (unwrapped is QsSwift.Undefined))
+            } else {
+                Issue.record("Unexpected bridged type: \(type(of: bridged))")
+            }
+        }
+
+        @Test("bridgeInputForEncode: OrderedDictionary<AnyHashable, Any> stringifies mixed keys")
+        func encode_orderedDictionaryAnyHashable_keys() {
+            let entries: [(AnyHashable, Any)] = [
+                (AnyHashable(42), "answer"),
+                (AnyHashable("two"), 2)
+            ]
+            let od = OrderedDictionary<AnyHashable, Any>(uniqueKeysWithValues: entries)
+
+            let bridged = QsBridge.bridgeInputForEncode(od)
+
+            if let out = bridged as? OrderedDictionary<String, Any> {
+                #expect(out["42"] as? String == "answer")
+                #expect(out["two"] as? Int == 2)
+            } else if let dict = bridged as? [String: Any] {
+                #expect(dict["42"] as? String == "answer")
+                #expect(dict["two"] as? Int == 2)
+            } else if let od = bridged as? OrderedDictionary<AnyHashable, Any> {
+                #expect(od[AnyHashable("42")] as? String == "answer")
+                #expect(od[AnyHashable("two")] as? Int == 2)
+            } else {
+                Issue.record("Unexpected bridged type: \(type(of: bridged))")
+            }
+        }
+
+        @Test("bridgeUndefinedPreservingOrder bridges OrderedDictionary<NSString, Any>")
+        func bridgeUndefined_handlesOrderedNSStringDictionary() {
+            let ordered = OrderedDictionary<NSString, Any>(uniqueKeysWithValues: [
+                ("u" as NSString, UndefinedObjC())
+            ])
+
+            let bridged = QsBridge.bridgeUndefinedPreservingOrder(ordered)
+            let out = bridged as? OrderedDictionary<String, Any>
+            #expect(out?["u"] is QsSwift.Undefined)
+        }
+
+        @Test("bridgeUndefinedPreservingOrder replaces sentinels and keeps identity")
+        func bridgeUndefined_rewritesContainers() {
+            let innerArray: NSMutableArray = [UndefinedObjC()]
+            innerArray.add(innerArray)  // cycle
+
+            var ordered = OrderedDictionary<String, Any>()
+            ordered["u"] = UndefinedObjC()
+            ordered["array"] = innerArray
+
+            let bridged = QsBridge.bridgeUndefinedPreservingOrder(ordered)
+            let out = bridged as? OrderedDictionary<String, Any>
+            #expect(out?["u"] is QsSwift.Undefined)
+
+            let bridgedArray = out?["array"] as? [Any]
+            #expect(bridgedArray?.first is QsSwift.Undefined)
+            #expect((bridgedArray?[1] as AnyObject?) === innerArray)
+        }
+
+        @Test("bridgeUndefinedPreservingOrder bridges NSDictionary values")
+        func bridgeUndefined_handlesNSDictionary() {
+            let dict: NSDictionary = [
+                "u": UndefinedObjC(),
+                "value": "v"
+            ]
+
+            let bridged = QsBridge.bridgeUndefinedPreservingOrder(dict)
+            let out = bridged as? OrderedDictionary<String, Any>
+            #expect(out?["u"] is QsSwift.Undefined)
+            #expect(out?["value"] as? String == "v")
+        }
+
+        @Test("bridgeUndefinedPreservingOrder handles Swift dictionaries and arrays without ObjC bridging")
+        func bridgeUndefined_swiftContainersNoObjCBridge() {
+            var seen = Set<ObjectIdentifier>()
+            let swiftDict: [String: Any] = [
+                "value": 42,
+                "sentinel": UndefinedObjC()
+            ]
+
+            if let bridgedDict = QsBridge._bridgeUndefinedPreservingOrder(swiftDict, seen: &seen) as? OrderedDictionary<String, Any> {
+                #expect(bridgedDict["value"] as? Int == 42)
+                #expect(bridgedDict["sentinel"] is QsSwift.Undefined)
+            } else {
+                Issue.record("Swift dictionary branch not exercised")
+            }
+
+            let swiftArray: [Any] = ["first", UndefinedObjC()]
+            seen.removeAll()
+            if let bridgedArray = QsBridge._bridgeUndefinedPreservingOrder(swiftArray, seen: &seen) as? [Any] {
+                #expect(bridgedArray[0] as? String == "first")
+                #expect(bridgedArray[1] is QsSwift.Undefined)
+            } else {
+                Issue.record("Swift array branch not exercised")
+            }
         }
 
         // MARK: - _bridgeUndefined via encode() (private helper exercised transitively)

--- a/Tests/QsObjCTests/ObjCBridgeTests.swift
+++ b/Tests/QsObjCTests/ObjCBridgeTests.swift
@@ -313,6 +313,25 @@
             #expect(out?["u"] is QsSwift.Undefined)
         }
 
+        @Test("bridgeUndefinedPreservingOrder bridges OrderedDictionary<AnyHashable, Any>")
+        func bridgeUndefined_handlesOrderedAnyHashableDictionary() {
+            let entries: [(AnyHashable, Any)] = [
+                (AnyHashable("u"), UndefinedObjC()),
+                (AnyHashable(7), "v")
+            ]
+            let ordered = OrderedDictionary<AnyHashable, Any>(uniqueKeysWithValues: entries)
+
+            let bridged = QsBridge.bridgeUndefinedPreservingOrder(ordered)
+            guard let out = bridged as? OrderedDictionary<String, Any> else {
+                Issue.record("Expected OrderedDictionary<String, Any>, got \(String(describing: bridged))")
+                return
+            }
+
+            #expect(Array(out.keys) == ["u", "7"])
+            #expect(out["u"] is QsSwift.Undefined)
+            #expect(out["7"] as? String == "v")
+        }
+
         @Test("bridgeUndefinedPreservingOrder replaces sentinels and keeps identity")
         func bridgeUndefined_rewritesContainers() {
             let innerArray: NSMutableArray = [UndefinedObjC()]

--- a/Tests/QsObjCTests/ObjCModelCoverageTests.swift
+++ b/Tests/QsObjCTests/ObjCModelCoverageTests.swift
@@ -155,7 +155,7 @@
         @Test("DecodeOptionsObjC bridges core properties")
         func decodeOptionsSwiftBridgeProperties() {
             let opts = DecodeOptionsObjC().with {
-                $0.allowDots = false
+                $0.allowDots = true
                 $0.decodeDotInKeys = true
                 $0.allowEmptyLists = true
                 $0.allowSparseLists = true

--- a/Tests/QsObjCTests/ObjCModelCoverageTests.swift
+++ b/Tests/QsObjCTests/ObjCModelCoverageTests.swift
@@ -66,6 +66,14 @@
             }
         }
 
+        @Test("DecodeErrorObjC returns nil for mismatched domain")
+        func decodeErrorNilCases() {
+            let error = NSError(domain: "other", code: 1, userInfo: [:])
+            #expect(DecodeErrorObjC.kind(from: error) == nil)
+            #expect(DecodeErrorObjC.limit(from: error) == nil)
+            #expect(DecodeErrorObjC.maxDepth(from: error) == nil)
+        }
+
         @Test("EncodeErrorObjC identifies cyclic graphs")
         func encodeErrorBridging() {
             let dict = NSMutableDictionary()
@@ -82,6 +90,43 @@
             #expect(error.domain == EncodeErrorInfoObjC.domain)
             #expect(EncodeErrorObjC.kind(from: error) == .cyclicObject)
             #expect(EncodeErrorObjC.isCyclicObject(error))
+        }
+
+        @Test("EncodeErrorObjC returns nil for unrelated errors")
+        func encodeErrorNilCases() {
+            let error = NSError(domain: "other", code: 99)
+            #expect(EncodeErrorObjC.kind(from: error) == nil)
+            #expect(EncodeErrorObjC.isCyclicObject(error) == false)
+        }
+
+        @Test("DecodeErrorObjC reads userInfo values")
+        func decodeErrorUserInfo() {
+            let userInfo: [String: Any] = [
+                DecodeErrorInfoObjC.limitKey: 5,
+                DecodeErrorInfoObjC.maxDepthKey: 2
+            ]
+            let mock = NSError(
+                domain: DecodeErrorInfoObjC.domain,
+                code: DecodeErrorCodeObjC.listLimitExceeded.rawValue,
+                userInfo: userInfo
+            )
+
+            #expect(DecodeErrorObjC.kind(from: mock) == .listLimitExceeded)
+            #expect(DecodeErrorObjC.limit(from: mock) == 5)
+            #expect(DecodeErrorObjC.maxDepth(from: mock) == 2)
+        }
+
+        @Test("DecodeErrorCodeObjC descriptions mirror Swift cases")
+        func decodeErrorCode_descriptions() {
+            #expect(DecodeErrorCodeObjC.parameterLimitNotPositive.description == "parameterLimitNotPositive")
+            #expect(DecodeErrorCodeObjC.parameterLimitExceeded.description == "parameterLimitExceeded")
+            #expect(DecodeErrorCodeObjC.listLimitExceeded.description == "listLimitExceeded")
+            #expect(DecodeErrorCodeObjC.depthExceeded.description == "depthExceeded")
+        }
+
+        @Test("EncodeErrorCodeObjC description mirrors Swift case")
+        func encodeErrorCode_description() {
+            #expect(EncodeErrorCodeObjC.cyclicObject.description == "cyclicObject")
         }
 
         @Test("DelimiterObjC wraps string and regex delimiters")

--- a/Tests/QsObjCTests/ObjCModelCoverageTests.swift
+++ b/Tests/QsObjCTests/ObjCModelCoverageTests.swift
@@ -1,0 +1,290 @@
+#if canImport(ObjectiveC) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    import Foundation
+
+    @testable import QsObjC
+    @testable import QsSwift
+
+    #if canImport(Testing)
+        import Testing
+    #else
+        #error("The swift-testing package is required to build tests on Swift 5.x")
+    #endif
+
+    @Suite("objc-model-coverage")
+    struct ObjCModelCoverageTests {
+
+        @Test("Bridged enums expose Swift parity")
+        func enumBridges() {
+            #expect(DecodeKindObjC.key.swift == .key)
+            #expect(DecodeKindObjC(.value) == .value)
+            #expect(DecodeKindObjC.value.description == "value")
+
+            #expect(DuplicatesObjC.combine.swift == .combine)
+            #expect(DuplicatesObjC.first.description == "first")
+            #expect(DuplicatesObjC.last.swift == .last)
+
+            #expect(FormatObjC.rfc3986.swift == .rfc3986)
+            #expect(FormatObjC.rfc1738.description == "rfc1738")
+
+            #expect(ListFormatObjC.brackets.swift == .brackets)
+            #expect(ListFormatObjC.indices.description == "indices")
+            #expect(ListFormatObjC.repeatKey.swift == .repeatKey)
+            #expect(ListFormatObjC.comma.swift == .comma)
+        }
+
+        @Test("DecodeErrorObjC surfaces NSError metadata")
+        func decodeErrorBridging() {
+            let opts = DecodeOptionsObjC().with {
+                $0.parameterLimit = 1
+                $0.throwOnLimitExceeded = true
+            }
+
+            var err: NSError?
+            let output = QsBridge.decode("a=1&b=2" as NSString, options: opts, error: &err)
+            #expect(output == nil, Comment("Parameter limit exceedance should return nil result"))
+            #expect(err != nil, Comment("Expected NSError for parameter limit"))
+            guard let error = err else { return }
+
+            #expect(error.domain == DecodeErrorInfoObjC.domain)
+            #expect(DecodeErrorObjC.kind(from: error) == .parameterLimitExceeded)
+            #expect(DecodeErrorObjC.limit(from: error) == 1)
+
+            let depthOpts = DecodeOptionsObjC().with {
+                $0.depth = 1
+                $0.strictDepth = true
+                $0.throwOnLimitExceeded = true
+            }
+
+            err = nil
+            let depthOutput = QsBridge.decode("a[b][c]=d" as NSString, options: depthOpts, error: &err)
+            #expect(depthOutput == nil, Comment("Strict depth should throw instead of returning a value"))
+            #expect(err != nil, Comment("Expected depth error"))
+
+            if let depthError = err {
+                #expect(DecodeErrorObjC.kind(from: depthError) == .depthExceeded)
+                #expect(DecodeErrorObjC.maxDepth(from: depthError) == 1)
+            }
+        }
+
+        @Test("EncodeErrorObjC identifies cyclic graphs")
+        func encodeErrorBridging() {
+            let dict = NSMutableDictionary()
+            dict["self"] = dict
+
+            var err: NSError?
+            let encoded = QsBridge.encode(dict, options: nil, error: &err)
+            #expect(encoded == nil)
+            guard let error = err else {
+                Issue.record("Expected encode NSError")
+                return
+            }
+
+            #expect(error.domain == EncodeErrorInfoObjC.domain)
+            #expect(EncodeErrorObjC.kind(from: error) == .cyclicObject)
+            #expect(EncodeErrorObjC.isCyclicObject(error))
+        }
+
+        @Test("DelimiterObjC wraps string and regex delimiters")
+        func delimiterBridging() {
+            let stringDelimiter = DelimiterObjC(string: "&")
+            #expect(stringDelimiter.swift.split(input: "a&b") == ["a", "b"])
+
+            let regexDelimiter = DelimiterObjC(regexPattern: #"\s*[,;]\s*"#)
+            #expect(regexDelimiter != nil)
+            #expect(regexDelimiter?.swift.split(input: "a ; b, c") == ["a", "b", "c"])
+
+            let invalid = DelimiterObjC(regexPattern: "[")
+            #expect(invalid == nil)
+
+            #expect(DelimiterObjC.commaOrSemicolon.swift.split(input: "x;y") == ["x", "y"])
+        }
+
+        @Test("DecodedMapObjC round-trips Swift DecodedMap")
+        func decodedMapBridging() {
+            let swiftMap = DecodedMap(["a": "b"])
+            let objcMap = DecodedMapObjC(swift: swiftMap)
+            #expect((objcMap.value["a"] as? String) == "b")
+            #expect(objcMap.swift.value["a"] as? String == "b")
+        }
+
+        @Test("DecodeOptionsObjC bridges core properties")
+        func decodeOptionsSwiftBridgeProperties() {
+            let opts = DecodeOptionsObjC().with {
+                $0.allowDots = false
+                $0.decodeDotInKeys = true
+                $0.allowEmptyLists = true
+                $0.allowSparseLists = true
+                $0.listLimit = 2
+                $0.charset = String.Encoding.isoLatin1.rawValue
+                $0.charsetSentinel = true
+                $0.comma = true
+                $0.delimiter = .commaOrSemicolon
+                $0.depth = 1
+                $0.parameterLimit = 2
+                $0.duplicates = .last
+                $0.ignoreQueryPrefix = true
+                $0.interpretNumericEntities = true
+                $0.parseLists = false
+                $0.strictDepth = true
+                $0.strictNullHandling = true
+                $0.throwOnLimitExceeded = true
+            }
+
+            let swift = opts.swift
+            #expect(swift.getAllowDots)
+            #expect(swift.getDecodeDotInKeys)
+            #expect(swift.allowEmptyLists)
+            #expect(swift.allowSparseLists)
+            #expect(swift.listLimit == 2)
+            #expect(swift.charset == .isoLatin1)
+            #expect(swift.charsetSentinel)
+            #expect(swift.comma)
+            #expect(swift.delimiter.split(input: "a ; b").count == 2)
+            #expect(swift.depth == 1)
+            #expect(swift.parameterLimit == 2)
+            #expect(swift.duplicates == .last)
+            #expect(swift.ignoreQueryPrefix)
+            #expect(swift.interpretNumericEntities)
+            #expect(swift.parseLists == false)
+            #expect(swift.strictDepth)
+            #expect(swift.strictNullHandling)
+            #expect(swift.throwOnLimitExceeded)
+        }
+
+        @Test("DecodeOptionsObjC bridges decoder blocks in priority order")
+        func decodeOptionsCustomBlocks() {
+        var seenKinds: [Int] = []
+        let opts = DecodeOptionsObjC()
+        opts.decoderBlock = { token, charset, kind in
+            seenKinds.append(kind?.intValue ?? -1)
+            guard let token else { return nil }
+            let utf8Raw = Int(String.Encoding.utf8.rawValue)
+            let suffix = (charset?.intValue ?? utf8Raw) == utf8Raw ? "!" : "?"
+            return ((token as String) + suffix) as NSString
+        }
+
+        let swiftDecoder = opts.swift.decoder
+        let keyResult = swiftDecoder?("a", .utf8, .key) as? String
+        let valueResult = swiftDecoder?("b", .utf8, .value) as? String
+        #expect(seenKinds == [0, 1])
+        #expect(keyResult == "a!")
+        #expect(valueResult == "b!")
+
+        let valueOnly = DecodeOptionsObjC()
+        valueOnly.valueDecoderBlock = { token, _ in
+            (token as String?)?.uppercased()
+        }
+        let swiftValueDecoder = valueOnly.swift.decoder
+        #expect(swiftValueDecoder?("c", .isoLatin1, nil) as? String == "C")
+
+        let legacy = DecodeOptionsObjC()
+        legacy.legacyDecoderBlock = { token, _ in
+            token?.appending("?")
+        }
+        let swiftLegacy = legacy.swift.legacyDecoder
+        #expect(swiftLegacy?("e", .utf8) as? String == "e?")
+        }
+
+        @Test("EncodeOptionsObjC bridges configuration and custom blocks")
+        func encodeOptionsSwiftBridgeAndBlocks() {
+            let opts = EncodeOptionsObjC().with {
+                $0.addQueryPrefix = true
+                $0.allowDots = true
+                $0.encodeDotInKeys = true
+                $0.allowEmptyLists = true
+                $0.charset = String.Encoding.isoLatin1.rawValue
+                $0.charsetSentinel = true
+                $0.delimiter = ";"
+                $0.encode = true
+                $0.encodeValuesOnly = true
+                $0.format = .rfc1738
+                $0.indices = NSNumber(value: false)
+                $0.listFormat = .brackets
+                $0.skipNulls = true
+                $0.strictNullHandling = true
+                $0.commaRoundTrip = true
+                $0.sortKeysCaseInsensitively = true
+                $0.filter = FilterObjC.excluding { $0 == "skip" }
+                $0.valueEncoderBlock = { value, _, _ in
+                    if let string = value as? String { return (string + "!") as NSString }
+                    return "encoded" as NSString
+                }
+                $0.dateSerializerBlock = { date in
+                    "d_\(Int(date.timeIntervalSince1970))" as NSString
+                }
+                $0.sortComparatorBlock = { lhs, rhs in
+                    let sa = String(describing: lhs ?? "")
+                    let sb = String(describing: rhs ?? "")
+                    return sa.compare(sb).rawValue
+                }
+            }
+
+            let swift = opts.swift
+            #expect(swift.addQueryPrefix)
+            #expect(swift.getAllowDots)
+            #expect(swift.getListFormat == .brackets)
+            #expect(swift.charset == .isoLatin1)
+            #expect(swift.charsetSentinel)
+            #expect(swift.delimiter == ";")
+            #expect(swift.encode)
+            #expect(swift.encodeDotInKeys)
+            #expect(swift.encodeValuesOnly)
+            #expect(swift.format == .rfc1738)
+            #expect(swift.skipNulls)
+            #expect(swift.strictNullHandling)
+            #expect(swift.commaRoundTrip == true)
+            #expect(swift.sort != nil)
+
+            let input: NSDictionary = [
+                "b": "beta",
+                "A": "alpha",
+                "skip": "omitted",
+                "date": Date(timeIntervalSince1970: 123),
+                "list": ["x", "y"],
+            ]
+
+            var err: NSError?
+            guard let encoded = QsBridge.encode(input, options: opts, error: &err) else {
+                Issue.record("Expected encoded string")
+                return
+            }
+
+            let output = encoded as String
+            #expect(output.hasPrefix("?"))
+            #expect(!output.contains("skip"))
+            #expect(output.contains("beta!"))
+            #expect(output.contains("alpha!"))
+            #expect(output.contains("d_123!"))
+            #expect(output.contains("list[]"))
+            #expect(output.contains(";"))
+        }
+
+        @Test("FilterObjC factories wrap Swift filters")
+        func filterObjCFactories() {
+            let functionFilter = FilterObjC.function(FunctionFilterObjC { key, value in
+                key == "drop" ? UndefinedObjC() : value
+            })
+            let iterable = FilterObjC.iterable(IterableFilterObjC(iterable: ["keep", 1]))
+            let excluding = FilterObjC.excluding { $0 == "omit" }
+            let including = FilterObjC.including { $0 == "keep" }
+            let keys = FilterObjC.keys(["name"])
+            let indices = FilterObjC.indices([0, 2])
+            let mixed = FilterObjC.mixed(["name", 3])
+
+            // Bridge through EncodeOptions to ensure filters integrate correctly
+            let opts = EncodeOptionsObjC()
+            opts.filter = functionFilter
+            let dict: NSDictionary = ["drop": "x", "keep": "y"]
+            let encoded = QsBridge.encode(dict, options: opts, error: nil)! as String
+            #expect(!encoded.contains("drop"))
+
+            // Confirm iterable-style filters carry their payloads
+            #expect((iterable.swift as? IterableFilter)?.iterable.count == 2)
+            #expect((excluding.swift as? FunctionFilter) != nil)
+            #expect((including.swift as? FunctionFilter) != nil)
+            #expect((keys.swift as? IterableFilter)?.iterable.first as? String == "name")
+            #expect((indices.swift as? IterableFilter)?.iterable.first as? Int == 0)
+            #expect((mixed.swift as? IterableFilter)?.iterable.last as? Int == 3)
+        }
+    }
+#endif

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -3027,20 +3027,20 @@ extension DecodeTests {
     @Test("parse: custom encoding (Shift_JIS)")
     func parse_customShiftJIS() throws {
         #if os(Linux)
-        // Try a real Shift_JIS decode. If it fails, record as a known issue; if it succeeds, assert normally.
-        let bytes: [UInt8] = [0x91, 0xE5, 0x8D, 0xE3, 0x95, 0x7B]  // "大阪府" in Shift_JIS
-        let decoded = String(data: Data(bytes), encoding: .shiftJIS)
-        if decoded == "大阪府" {
-            // It works on this Linux runtime — pass normally (do not use withKnownIssue).
-            #expect(decoded == "大阪府")
-        } else {
-            try withKnownIssue("Got: \(decoded.debugDescription)") {
-                // Expected failure on Linux today: Shift_JIS decoding often unavailable in corelibs-foundation.
-                // If/when this ever starts working, the branch above will exercise instead.
+            // Try a real Shift_JIS decode. If it fails, record as a known issue; if it succeeds, assert normally.
+            let bytes: [UInt8] = [0x91, 0xE5, 0x8D, 0xE3, 0x95, 0x7B]  // "大阪府" in Shift_JIS
+            let decoded = String(data: Data(bytes), encoding: .shiftJIS)
+            if decoded == "大阪府" {
+                // It works on this Linux runtime — pass normally (do not use withKnownIssue).
                 #expect(decoded == "大阪府")
+            } else {
+                try withKnownIssue("Got: \(decoded.debugDescription)") {
+                    // Expected failure on Linux today: Shift_JIS decoding often unavailable in corelibs-foundation.
+                    // If/when this ever starts working, the branch above will exercise instead.
+                    #expect(decoded == "大阪府")
+                }
             }
-        }
-        return
+            return
         #endif
         // Local helper needs to be @Sendable if captured by a @Sendable closure.
         @Sendable
@@ -3804,36 +3804,37 @@ private func isNSNull(_ v: Any??) -> Bool {
     }
 }
 
-    @Test("parseQueryStringValues throws when parameter limit exceeded")
-    func parseQuery_enforcesParameterLimit() {
-        let options = DecodeOptions(parameterLimit: 1, throwOnLimitExceeded: true)
-        #expect(throws: DecodeError.parameterLimitExceeded(limit: 1)) {
-            _ = try Decoder.parseQueryStringValues("a=1&b=2", options: options)
-        }
+@Test("parseQueryStringValues throws when parameter limit exceeded")
+func parseQuery_enforcesParameterLimit() {
+    let options = DecodeOptions(parameterLimit: 1, throwOnLimitExceeded: true)
+    #expect(throws: DecodeError.parameterLimitExceeded(limit: 1)) {
+        _ = try Decoder.parseQueryStringValues("a=1&b=2", options: options)
     }
+}
 
-    @Test("parseQueryStringValues honors charset sentinel")
-    func parseQuery_honorsCharsetSentinel() throws {
-        let options = DecodeOptions(charsetSentinel: true)
-        let out = try Decoder.parseQueryStringValues(
-            "utf8=%E2%9C%93&value=%E4%B8%AD",
-            options: options
-        )
-        #expect(out["value"] as? String == "中")
-    }
+@Test("parseQueryStringValues honors charset sentinel")
+func parseQuery_honorsCharsetSentinel() throws {
+    let options = DecodeOptions(charsetSentinel: true)
+    let out = try Decoder.parseQueryStringValues(
+        "utf8=%E2%9C%93&value=%E4%B8%AD",
+        options: options
+    )
+    #expect(out["value"] as? String == "中")
+}
 
-    @Test("parseQueryStringValues uses custom scalar decoder")
-    func parseQuery_usesCustomDecoder() throws {
-        let options = DecodeOptions(decoder: { value, _, _ in value?.uppercased() })
-        _ = try Decoder.parseQueryStringValues("key=value", options: options)
-    }
+@Test("parseQueryStringValues uses custom scalar decoder")
+func parseQuery_usesCustomDecoder() throws {
+    let options = DecodeOptions(decoder: { value, _, _ in value?.uppercased() })
+    let out = try Decoder.parseQueryStringValues("key=value", options: options)
+    #expect(out["KEY"] as? String == "VALUE")
+}
 
-    @Test("parseQueryStringValues interprets numeric entities in latin1 mode")
-    func parseQuery_interpretsNumericEntities() throws {
-        let options = DecodeOptions(charset: .isoLatin1, interpretNumericEntities: true)
-        let out = try Decoder.parseQueryStringValues("value=%26%239786%3B", options: options)
-        #expect(out["value"] as? String == "☺")
-    }
+@Test("parseQueryStringValues interprets numeric entities in latin1 mode")
+func parseQuery_interpretsNumericEntities() throws {
+    let options = DecodeOptions(charset: .isoLatin1, interpretNumericEntities: true)
+    let out = try Decoder.parseQueryStringValues("value=%26%239786%3B", options: options)
+    #expect(out["value"] as? String == "☺")
+}
 
 private func isNSNullValue(_ v: Any?) -> Bool { v is NSNull }
 

--- a/Tests/QsSwiftTests/ModelCoverageTests.swift
+++ b/Tests/QsSwiftTests/ModelCoverageTests.swift
@@ -27,7 +27,7 @@ struct ModelCoverageTests {
             "count": { value in (value as? Int).map { $0 * 2 } },
         ])
         #expect(transforming.function("name", "alex") as? String == "ALEX")
-        #expect(transforming.function("count", 3) as? Int == 6)
+        #expect((transforming.function("count", 3) as? Int?).flatMap { $0 } == 6)
         #expect(transforming.function("other", "stay") as? String == "stay")
     }
 

--- a/Tests/QsSwiftTests/ModelCoverageTests.swift
+++ b/Tests/QsSwiftTests/ModelCoverageTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+@testable import QsSwift
+
+#if canImport(Testing)
+    import Testing
+#else
+    #error("The swift-testing package is required to build tests on Swift 5.x")
+#endif
+
+@Suite("model-coverage")
+struct ModelCoverageTests {
+
+    @Test("FunctionFilter factories produce expected behavior and descriptions")
+    func functionFilter_factories() {
+        let excluding = FunctionFilter.excluding { $0.hasPrefix("_") }
+        #expect(excluding.description.contains("FunctionFilter"))
+        #expect(excluding.function("keep", "value") as? String == "value")
+        #expect(excluding.function("_secret", "value") == nil)
+
+        let including = FunctionFilter.including { $0 == "keep" }
+        #expect(including.function("keep", 42) as? Int == 42)
+        #expect(including.function("drop", 42) == nil)
+
+        let transforming = FunctionFilter.transforming([
+            "name": { value in (value as? String)?.uppercased() ?? value },
+            "count": { value in (value as? Int).map { $0 * 2 } },
+        ])
+        #expect(transforming.function("name", "alex") as? String == "ALEX")
+        #expect(transforming.function("count", 3) as? Int == 6)
+        #expect(transforming.function("other", "stay") as? String == "stay")
+    }
+
+    @Test("IterableFilter factories capture provided keys and indices")
+    func iterableFilter_factories() {
+        let keysFilter = IterableFilter.keys("a", "b")
+        #expect((keysFilter.iterable as? [String]) == ["a", "b"])
+        #expect(keysFilter.description.contains("IterableFilter"))
+
+        let indicesFilter = IterableFilter.indices(0, 2)
+        #expect((indicesFilter.iterable as? [Int]) == [0, 2])
+
+        let mixedFilter = IterableFilter.mixed("name", 4)
+        #expect(mixedFilter.iterable.count == 2)
+        #expect(mixedFilter.iterable[0] as? String == "name")
+        #expect(mixedFilter.iterable[1] as? Int == 4)
+    }
+
+    @Test("Duplicates exposes readable descriptions")
+    func duplicates_descriptions() {
+        #expect(Duplicates.combine.description == "combine")
+        #expect(Duplicates.first.description == "first")
+        #expect(Duplicates.last.description == "last")
+    }
+
+    @Test("DecodeError bridged metadata matches expectations")
+    func decodeError_bridging() {
+        let notPositive = DecodeError.parameterLimitNotPositive
+        let exceeding = DecodeError.parameterLimitExceeded(limit: 2)
+        let listLimit = DecodeError.listLimitExceeded(limit: 1)
+        let depthExceeded = DecodeError.depthExceeded(maxDepth: 3)
+
+        #expect(notPositive.description.contains("Parameter limit"))
+        #expect(exceeding.description.contains("Only 2 parameter"))
+        #expect(listLimit.description.contains("List limit"))
+        #expect(depthExceeded.description.contains("strictDepth"))
+
+        let nsError = exceeding as NSError
+        #expect(nsError.domain == DecodeError.errorDomain)
+        #expect(nsError.code == exceeding.errorCode)
+        #expect((nsError.userInfo[DecodeError.userInfoLimitKey] as? Int) == 2)
+
+        let depthNSError = depthExceeded as NSError
+        #expect(depthNSError.code == depthExceeded.errorCode)
+        #expect((depthNSError.userInfo[DecodeError.userInfoMaxDepthKey] as? Int) == 3)
+    }
+
+    @Test("Unsafe sendable wrapper exposes stored value")
+    func unsafeSendable_wrapsValue() {
+        let boxed = _UnsafeSendable(["k": "v"])
+        #expect(boxed.value["k"] == "v")
+
+        let alt = _UnsafeSendable(wrapping: 42)
+        #expect(alt.value == 42)
+    }
+
+    #if canImport(Darwin)
+        @Test("WeakWrapper equality, hashing, and lifecycle semantics")
+        func weakWrapper_semantics() {
+            final class Box {}
+
+            var pair: (WeakWrapper, WeakWrapper)?
+
+            autoreleasepool {
+                let object = Box()
+                let wrapperA = WeakWrapper(object)
+                let wrapperB = WeakWrapper(object)
+
+                #expect(wrapperA.isEqual(wrapperA))
+                #expect(wrapperA.isEqual(wrapperB))
+                #expect(wrapperA.hash == wrapperB.hash)
+                #expect(wrapperA.referent != nil)
+
+                pair = (wrapperA, wrapperB)
+            }
+
+            guard let stored = pair else {
+                Issue.record("Expected wrappers to persist")
+                return
+            }
+
+            let (wrapperA, wrapperB) = stored
+
+            #expect(wrapperA.referent == nil)
+            #expect(wrapperB.referent == nil)
+            #expect(wrapperA.isEqual(wrapperB) == false)
+            #expect(wrapperA.description.contains("<deallocated>"))
+            #expect(wrapperA.debugDescription == wrapperA.description)
+        }
+    #endif
+
+    @Test("Undefined convenience helpers round-trip the singleton")
+    func undefined_singletonHelpers() {
+        #expect(Undefined.instance == Undefined())
+        #expect(Undefined.callAsFunction() == Undefined.instance)
+        #expect(Undefined().description == "Undefined")
+    }
+}


### PR DESCRIPTION
This pull request improves the bridging logic between Objective-C and Swift containers, especially focusing on the handling of `OrderedDictionary` types with various key types and enhancing array compaction logic. It also significantly expands the test coverage for these bridging behaviors to ensure correctness and edge-case handling.

**Bridging and encoding improvements:**

* Added support in `QsBridge._bridgeInputForEncode` for handling `OrderedDictionary<AnyHashable, Any>`, converting keys to deterministic string representations to ensure consistent bridging of heterogeneous key types.
* Refined array handling in `Utils.compactValue` to better tolerate both `[Any]` and `[Any?]` array shapes, ensuring correct compaction and bridging of arrays with optional elements and nested containers.

**Test coverage expansion:**

* Added comprehensive tests in `ObjCBridgeTests.swift` for various bridging scenarios, including:
  - Bridging Swift dictionaries and arrays, including those with Swift-only values and custom types.
  - Handling and normalizing `OrderedDictionary` with different key types (`NSString`, `String`, `AnyHashable`).
  - Ensuring correct handling of undefined/sentinel values and preservation of ordering in both Swift and Objective-C containers.
  - Verifying that non-`AnyHashable` keys in `NSDictionary` are stringified appropriately during decode.
* Enabled testing of Swift internals by importing `QsSwift` in the test target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for encoding/bridging ordered dictionaries with non-string keys while preserving insertion order and identity.
  * DecodeOptions now accepts a legacy decoder and exposes helpers for obtaining/using it.

* **Bug Fixes**
  * Improved array normalization to handle optional elements, nil→null conversion, and sparse/dense semantics with Undefined preserved.

* **Tests**
  * Large expansion of Swift/Objective‑C test coverage for bridging, encode/decode options, query parsing, filters, errors, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->