### PR TITLE
:construction_worker: add Xcode 26 + Swift 6.2 test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,29 @@ jobs:
   tests:
     permissions:
       contents: read
-    name: Swift tests + coverage (macOS, Xcode)
+    name: ${{ format('Swift tests + coverage ({0}, Xcode {1}, Swift {2}{3})', matrix.runner, matrix.xcode, matrix.swift, matrix.experimental && ' — experimental' || '') }}
     timeout-minutes: 45
-    runs-on: macos-15
+    runs-on: ${{ matrix.runner }}
     needs: analyze
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            xcode: '16.3'
+            swift: '6.1'
+            experimental: false
+          - runner: macos-26
+            xcode: '26'
+            swift: '6.2'
+            experimental: true
+
+    env:
+      XCODE_VERSION: ${{ matrix.xcode }}
+      SWIFT_VERSION: ${{ matrix.swift }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -75,6 +94,10 @@ jobs:
         run: |
           xcodebuild -version
           swift --version
+
+      - name: Experimental macOS 26 notice
+        if: ${{ matrix.experimental }}
+        run: echo "::warning::Using macos-26 runner (public preview). This job is marked experimental and allowed to fail."
 
       - name: Cache SwiftPM artifacts
         uses: actions/cache@v4
@@ -101,7 +124,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: macOS-crashlogs-xcode-${{ env.XCODE_VERSION }}-swift-${{ env.SWIFT_VERSION }}
+          name: macOS-crashlogs-${{ matrix.runner }}-xcode-${{ env.XCODE_VERSION }}-swift-${{ env.SWIFT_VERSION }}
           path: crashlogs
           if-no-files-found: ignore
 
@@ -109,8 +132,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage/info.lcov
-          flags: swift,macos-15,xcode-${{ env.XCODE_VERSION }},swift-${{ env.SWIFT_VERSION }}
-          name: QsSwift-macos-15-xcode-${{ env.XCODE_VERSION }}-swift-${{ env.SWIFT_VERSION }}
+          flags: swift,${{ matrix.runner }},xcode-${{ env.XCODE_VERSION }},swift-${{ env.SWIFT_VERSION }}
+          name: QsSwift-${{ matrix.runner }}-xcode-${{ env.XCODE_VERSION }}-swift-${{ env.SWIFT_VERSION }}
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/test.yml` to add support for testing on multiple macOS runners and Xcode/Swift versions, including experimental configurations. The changes enhance flexibility, improve reporting, and allow certain jobs to fail without failing the entire workflow.

**Matrix strategy and experimental job support:**

* Introduced a matrix strategy to run tests on both `macos-15` (Xcode 16.3, Swift 6.1) and `macos-26` (Xcode 26, Swift 6.2), with the latter marked as experimental and allowed to fail. The job name, runner, and environment variables are now dynamically set based on the matrix.
* Added a notice step for experimental runs, which outputs a warning when using the `macos-26` runner to clarify its experimental status.

**Artifact and coverage reporting improvements:**

* Updated artifact and Codecov upload steps to include the runner name in their identifiers, ensuring clearer reporting and traceability for different configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CI to run tests across multiple macOS, Xcode, and Swift versions using a matrix.
  * Added an experimental macOS 26 configuration with a clear notice and continue-on-error behavior.
  * Dynamic job names and runners now reflect the active matrix configuration.

* **Chores**
  * Standardized environment variables for tool versions.
  * Improved artifact naming for crash logs for easier identification.
  * Updated Codecov flags and job names for clearer coverage reporting.
  * Preserved existing steps and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->