### PR TITLE
:white_check_mark: increase unit test coverage

### DIFF
--- a/Sources/QsSwift/Qs+Decode.swift
+++ b/Sources/QsSwift/Qs+Decode.swift
@@ -23,7 +23,7 @@ extension Qs {
     /// - Returns: A plain `[String: Any]`. Insertion order of parsed keys is preserved.
     ///
     /// - Throws:
-    ///   - An `NSError(domain: "Qs.decode")` if `input` has an unsupported type.
+    ///   - An `NSError(domain: DecodeError.errorDomain)` if `input` has an unsupported type.
     ///   - `DecodeError` on limit/depth violations when `strictDepth` / `throwOnLimitExceeded`
     ///     are enabled.
     ///
@@ -143,8 +143,8 @@ extension Qs {
                 || input is [AnyHashable: Any]
         else {
             throw NSError(
-                domain: "Qs.decode",
-                code: 1,
+                domain: DecodeError.errorDomain,
+                code: 1,  // preserve legacy code for unsupported type
                 userInfo: [
                     NSLocalizedDescriptionKey: "The input must be a String or a Map<String, Any?>"
                 ]

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -70,6 +70,24 @@ struct DecodeTests {
         #expect(bridged?[2] is Undefined)
     }
 
+    @Test("Decoder.parseObject maps optional array leaves to NSNull placeholders")
+    func parseObject_optionalArrayLeafProducesNSNulls() throws {
+        let options = DecodeOptions(allowEmptyLists: true)
+        let list: [Any?] = ["first", nil, nil]
+        let parsed = try Decoder.parseObject(
+            chain: ["[]"],
+            value: list,
+            options: options,
+            valuesParsed: true
+        )
+
+        let bridged = parsed as? NSArray
+        #expect(bridged?.count == 3)
+        #expect(bridged?[0] as? String == "first")
+        #expect(bridged?[1] is NSNull)
+        #expect(bridged?[2] is NSNull)
+    }
+
     @Test("Decoder.parseObject reuses nested list length when appending []")
     func parseObject_reusesExistingListLength() throws {
         let nested: [Any?] = [[Any?](["existing", "values"])]

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -659,6 +659,13 @@ struct EncodeTests {
         #expect(out == "a=nil")
     }
 
+    @Test("encode - NSNull value with strictNullHandling renders key/value pair")
+    func encode_NSNullWithStrictNullHandlingProducesPair() async throws {
+        let payload: [String: Any?] = ["a": NSNull()]
+        let out = try Qs.encode(payload, options: EncodeOptions(strictNullHandling: true))
+        #expect(out == "a")
+    }
+
     @Test("encode - nil value with strictNullHandling uses custom encoder when provided")
     func encode_nilWithStrictNullHandlingRespectsCustomEncoder() async throws {
         let payload: [String: Any?] = ["a": nil]

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -652,6 +652,27 @@ struct EncodeTests {
         )
     }
 
+    @Test("encode - nil value with strictNullHandling renders key/value pair")
+    func encode_nilWithStrictNullHandlingProducesPair() async throws {
+        let payload: [String: Any?] = ["a": nil]
+        let out = try Qs.encode(payload, options: EncodeOptions(strictNullHandling: true))
+        #expect(out == "a=nil")
+    }
+
+    @Test("encode - nil value with strictNullHandling uses custom encoder when provided")
+    func encode_nilWithStrictNullHandlingRespectsCustomEncoder() async throws {
+        let payload: [String: Any?] = ["a": nil]
+        let opts = EncodeOptions(
+            encoder: { value, _, _ in
+                guard let token = value as? String else { return "" }
+                return "enc(\(token))"
+            },
+            strictNullHandling: true
+        )
+        let out = try Qs.encode(payload, options: opts)
+        #expect(out == "enc(a)=")
+    }
+
     // MARK: encodeValuesOnly: one item vs multiple items
 
     @Test("encode - non-list item with encodeValuesOnly")

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -652,13 +652,6 @@ struct EncodeTests {
         )
     }
 
-    @Test("encode - nil value with strictNullHandling renders key/value pair")
-    func encode_nilWithStrictNullHandlingProducesPair() async throws {
-        let payload: [String: Any?] = ["a": nil]
-        let out = try Qs.encode(payload, options: EncodeOptions(strictNullHandling: true))
-        #expect(out == "a=nil")
-    }
-
     @Test("encode - NSNull value with strictNullHandling renders key/value pair")
     func encode_NSNullWithStrictNullHandlingProducesPair() async throws {
         let payload: [String: Any?] = ["a": NSNull()]

--- a/Tests/QsSwiftTests/ModelCoverageTests.swift
+++ b/Tests/QsSwiftTests/ModelCoverageTests.swift
@@ -75,6 +75,74 @@ struct ModelCoverageTests {
         #expect((depthNSError.userInfo[DecodeError.userInfoMaxDepthKey] as? Int) == 3)
     }
 
+    @Test("DecodeError surface errorDescription and userInfo for every case")
+    func decodeError_nserrorProperties() {
+        let cases: [(DecodeError, (NSError) -> Void)] = [
+            (
+                .parameterLimitNotPositive,
+                { error in
+                    #expect(error.userInfo.isEmpty)
+                }
+            ),
+            (
+                .parameterLimitExceeded(limit: 9),
+                { error in
+                    #expect((error.userInfo[DecodeError.userInfoLimitKey] as? Int) == 9)
+                }
+            ),
+            (
+                .listLimitExceeded(limit: 4),
+                { error in
+                    #expect((error.userInfo[DecodeError.userInfoLimitKey] as? Int) == 4)
+                }
+            ),
+            (
+                .depthExceeded(maxDepth: 7),
+                { error in
+                    #expect((error.userInfo[DecodeError.userInfoMaxDepthKey] as? Int) == 7)
+                }
+            ),
+        ]
+
+        for (error, validate) in cases {
+            // Touch the bridging helpers to exercise their implementations.
+            #expect(error.errorDescription?.isEmpty == false)
+            let nsError = error as NSError
+            validate(nsError)
+        }
+    }
+
+    @Test("EncodeError bridges NSError metadata")
+    func encodeError_nserrorProperties() {
+        let error = EncodeError.cyclicObject
+        #expect(error.errorDescription == error.description)
+
+        let nsError = error as NSError
+        #expect(nsError.domain == EncodeError.errorDomain)
+        #expect(nsError.code == error.errorCode)
+        #expect((nsError.userInfo[NSLocalizedDescriptionKey] as? String) == error.description)
+    }
+
+    @Test("decodeResult wraps success and failure without throwing")
+    func decodeResult_wrapsSuccessAndFailure() {
+        let success = Qs.decodeResult("foo=bar")
+        switch success {
+        case .success(let value):
+            #expect((value["foo"] as? String) == "bar")
+        case .failure(let error):
+            Issue.record("Unexpected failure: \(error)")
+        }
+
+        let failure = Qs.decodeResult(NSNumber(value: 1))
+        switch failure {
+        case .success:
+            Issue.record("Expected decode failure for unsupported type")
+        case .failure(let error):
+            let nsError = error as NSError
+            #expect(nsError.domain == "Qs.decode")
+        }
+    }
+
     @Test("Unsafe sendable wrapper exposes stored value")
     func unsafeSendable_wrapsValue() {
         let boxed = _UnsafeSendable(["k": "v"])

--- a/Tests/QsSwiftTests/ModelCoverageTests.swift
+++ b/Tests/QsSwiftTests/ModelCoverageTests.swift
@@ -139,7 +139,7 @@ struct ModelCoverageTests {
             Issue.record("Expected decode failure for unsupported type")
         case .failure(let error):
             let nsError = error as NSError
-            #expect(nsError.domain == "Qs.decode")
+            #expect(nsError.domain == DecodeError.errorDomain)
         }
     }
 

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1192,6 +1192,58 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.compact handles Swift [Any] arrays without sparse placeholders")
+    func utils_compact_swiftAnyDense() {
+        let undefined = Undefined.instance
+        let nested: [String: Any?] = ["child": undefined]
+        var root: [String: Any?] = [
+            "list": [Any]([undefined, nested, "tail"])
+        ]
+
+        let compacted = Utils.compact(&root)
+        if let list = compacted["list"] as? [Any] {
+            #expect(list.count == 2)
+            #expect((list.first as? [String: Any])?.isEmpty == true)
+            #expect(list.last as? String == "tail")
+        } else {
+            Issue.record("Dense Swift [Any] branch not compacted as expected")
+        }
+    }
+
+    @Test("Utils.compact preserves Undefined placeholders in Swift [Any] when allowSparse=true")
+    func utils_compact_swiftAnySparse() {
+        let undefined = Undefined.instance
+        var root: [String: Any?] = ["list": [Any]([undefined, "keep"])]
+
+        let compacted = Utils.compact(&root, allowSparseLists: true)
+        if let list = compacted["list"] as? [Any] {
+            #expect(list.count == 2)
+            #expect(list.first is NSNull)
+            #expect(list.last as? String == "keep")
+        } else {
+            Issue.record("Sparse Swift [Any] branch not compacted as expected")
+        }
+    }
+
+    @Test("Utils.compact recurses optional arrays nested inside optional elements")
+    func utils_compact_optionalArraysNestedOptionalElements() {
+        let undefined = Undefined.instance
+        let inner: [Any?] = [undefined, "leaf", nil]
+        let optionalInner: [Any?]? = inner
+        var root: [String: Any?] = ["list": [Any?](arrayLiteral: optionalInner, nil)]
+
+        let compacted = Utils.compact(&root, allowSparseLists: true)
+        if let list = compacted["list"] as? [Any], let nested = list.first as? [Any] {
+            #expect(nested.count == 3)
+            #expect(nested.first is NSNull)
+            #expect(nested[1] as? String == "leaf")
+            #expect(nested.last is NSNull)
+            #expect(list.last is NSNull)
+        } else {
+            Issue.record("Nested optional arrays branch not exercised")
+        }
+    }
+
     @Test("Utils.compact handles Foundation arrays and nested optionals across sparse modes")
     func utils_compact_foundationAndNestedBranches() {
         let undefined = Undefined.instance

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -924,6 +924,16 @@ struct UtilsTests {
         #expect(Utils.isEmpty(emptyOrderedHashable) == true)
         emptyOrderedHashable[AnyHashable("filled")] = 1
         #expect(Utils.isEmpty(emptyOrderedHashable) == false)
+
+        let dict: [AnyHashable: Any] = [1: "value"]
+        #expect(Utils.isEmpty(dict) == false)
+    }
+
+    @Test("Utils.decode - decodes ISO-8859-1 percent bytes via regex branch")
+    func testDecodeIsoLatin1RegexPath() async throws {
+        let input = "%E4%F6%FC+encoded"
+        let decoded = Utils.decode(input, charset: .isoLatin1)
+        #expect(decoded == "äöü encoded")
     }
 
     // MARK: - Utils.deepBridgeToAnyIterative


### PR DESCRIPTION
This pull request adds comprehensive new test coverage for bridging, decoding, encoding, and utility behaviors in the QsSwift and QsObjC libraries. The main focus is on verifying correct normalization of containers, error bridging, optional handling, and decoder/encoder behaviors across edge cases.

**Test Coverage Additions:**

*Bridging and Container Normalization:*
- Added tests in `ObjCModelCoverageTests.swift` to verify that `bridgeUndefinedPreservingOrder` correctly normalizes Swift dictionaries and arrays, preserving order and handling undefined values as expected. [[1]](diffhunk://#diff-5efd98493ba074f61a742eb3fbee474172518f47726edb6333c59f610d28aca7R3) [[2]](diffhunk://#diff-5efd98493ba074f61a742eb3fbee474172518f47726edb6333c59f610d28aca7R335-R371)

*Decoder and Encoder Behaviors:*
- Introduced tests in `DecodeTests.swift` to check:
  - Handling of empty segments as dictionary keys when lists are disabled.
  - Normalization of optional arrays into `NSNull` placeholders.
  - Reuse of nested list lengths when appending new elements.
  - Application of custom decoders to comma-separated lists. [[1]](diffhunk://#diff-fe91969cf1b138a968e35fb47d5dc84502a34db7639ca644d5f8039e4de92f00R41-R90) [[2]](diffhunk://#diff-fe91969cf1b138a968e35fb47d5dc84502a34db7639ca644d5f8039e4de92f00R115-R130)
- Added tests in `ModelCoverageTests.swift` to ensure:
  - `DecodeError` and `EncodeError` properly surface `NSError` properties and metadata.
  - `decodeResult` wraps both success and failure cases without throwing.

*Utility Functions:*
- Added tests in `UtilsTests.swift` to verify:
  - `Utils.compact` correctly normalizes nested optional arrays and handles optional elements.
  - `Utils.apply` returns `nil` when a type mismatch occurs in the transformation closure. [[1]](diffhunk://#diff-3a675646ac78081063e5d58c1ea32ceb077df2212ae7a15cac7c0548d950e4aeR1177-R1194) [[2]](diffhunk://#diff-3a675646ac78081063e5d58c1ea32ceb077df2212ae7a15cac7c0548d950e4aeR1612-R1617)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded coverage for preserving container order and undefined placeholders when bridging between Swift and Objective‑C.
  - Added parsing tests for empty-segment keys, optional array normalization, nested list reuse, and custom comma-list decoding.
  - Added encoding tests for strict null handling, including nil/NSNull and custom encoders.
  - Added error bridging and decode-result wrapping tests.
  - Broadened utils coverage: ISO‑8859‑1 decoding, compacting with optionals/sparse modes, and apply-type safety.

- Bug Fixes
  - Standardized the decode error domain for more consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->