### PR TITLE
:sparkles: add `EncodeOptions.commaCompactNulls`

### DIFF
--- a/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
@@ -171,6 +171,19 @@
     XCTAssertEqualObjects(got, @"a=x");
 }
 
+- (void)test_encode_comma_list_compact_nulls {
+    QsEncodeOptions *o = [self optsNoEncode];
+    o.listFormat = @(QsListFormatComma);
+
+    NSArray *payload = @[ @"one", [NSNull null], @"two" ];
+    NSString *baseline = [QsObjCTestHelpers encode:OD(@[@"a"], @[ payload ]) options:o];
+    XCTAssertEqualObjects(baseline, @"a=one,,two");
+
+    o.commaCompactNulls = YES;
+    NSString *compact = [QsObjCTestHelpers encode:OD(@[@"a"], @[ payload ]) options:o];
+    XCTAssertEqualObjects(compact, @"a=one,two");
+}
+
 #pragma mark - 10) allowDots vs encodeDotInKeys
 
 - (void)test_allowDots_vs_encodeDotInKeys {

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ try Qs.encode(["a": ["b", "c"]], options: .init(listFormat: .comma, encode: fals
 // "a=b,c"
 ```
 
-_Note:_ When you select `.comma`, you can also set `commaRoundTrip` to `true` to append `[]` for single-element lists so they can decode back into arrays. Set `commaCompactNulls = true` alongside the comma format to drop `NSNull` entries before joining (for example, `["one", NSNull(), "two"]` encodes as `one,two`).
+_Note:_ When you select `.comma`, you can set `commaRoundTrip = true` to append `[]` for single‑element lists so they can decode back into arrays. Set `commaCompactNulls = true` to drop `NSNull`/`nil` entries before joining (e.g., `["one", NSNull(), nil, "two"]` → `one,two`). If all entries are `NSNull`/`nil`, the key is omitted; if filtering leaves a single item and `commaRoundTrip = true`, `[]` is preserved.
 
 ### Nested maps and dot notation
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ try Qs.encode(["a": ["b", "c"]], options: .init(listFormat: .comma, encode: fals
 // "a=b,c"
 ```
 
+_Note:_ When you select `.comma`, you can also set `commaRoundTrip` to `true` to append `[]` for single-element lists so they can decode back into arrays. Set `commaCompactNulls = true` alongside the comma format to drop `NSNull` entries before joining (for example, `["one", NSNull(), "two"]` encodes as `one,two`).
+
 ### Nested maps and dot notation
 
 ```swift

--- a/Sources/QsObjC/Models/EncodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/EncodeOptionsObjC.swift
@@ -101,6 +101,9 @@
         /// to allow it to round-trip back to an array on decode.
         public var commaRoundTrip: Bool = false
 
+        /// Only meaningful with `.comma` list format: when true, drop `null` entries before joining.
+        public var commaCompactNulls: Bool = false
+
         /// Convenience: provide a predictable case-insensitive A→Z sort (ties broken case-sensitively
         /// so `"A"` sorts before `"a"`). Ignored if `sortComparatorBlock` is set.
         public var sortKeysCaseInsensitively: Bool = false
@@ -176,6 +179,7 @@
                 skipNulls: skipNulls,
                 strictNullHandling: strictNullHandling,
                 commaRoundTrip: commaRoundTrip,
+                commaCompactNulls: commaCompactNulls,
 
                 // Sorting
                 sort: swiftSorter

--- a/Sources/QsObjC/README.md
+++ b/Sources/QsObjC/README.md
@@ -126,7 +126,8 @@ o.encodeDotInKeys = NO;                 // if YES, '.' in keys is percent‑enco
 o.listFormat      = QsListFormatIndices;
 o.indices         = @(YES);              // only used when listFormat is nil (deprecated)
 o.allowEmptyLists = NO;
-o.commaRoundTrip  = NO;                  // append [] for singletons under .comma
+    o.commaRoundTrip  = NO;                  // append [] for singletons under .comma
+    o.commaCompactNulls = NO;                // drop NSNull entries when using .comma
 
 // Nulls
 // - strictNullHandling: key with nil value → "key" (no '=')

--- a/Sources/QsObjC/README.md
+++ b/Sources/QsObjC/README.md
@@ -126,8 +126,8 @@ o.encodeDotInKeys = NO;                 // if YES, '.' in keys is percent‑enco
 o.listFormat      = QsListFormatIndices;
 o.indices         = @(YES);              // only used when listFormat is nil (deprecated)
 o.allowEmptyLists = NO;
-    o.commaRoundTrip  = NO;                  // append [] for singletons under .comma
-    o.commaCompactNulls = NO;                // drop NSNull entries when using .comma
+o.commaRoundTrip  = NO;                  // append [] for singletons under .comma
+o.commaCompactNulls = NO;                // drop NSNull entries when using .comma; omit key if all entries are null
 
 // Nulls
 // - strictNullHandling: key with nil value → "key" (no '=')

--- a/Sources/QsSwift/Models/EncodeOptions.swift
+++ b/Sources/QsSwift/Models/EncodeOptions.swift
@@ -114,6 +114,9 @@ public struct EncodeOptions: @unchecked Sendable {
     /// so they round-trip back to a list on decode (e.g. `a[]=x` instead of `a=x`).
     public let commaRoundTrip: Bool?
 
+    /// If `.comma` list format is used, drop `nil`/`NSNull` items before joining to produce a compact payload.
+    public let commaCompactNulls: Bool
+
     /// Sort function for keys when you want deterministic output independent of input order.
     ///
     /// If `nil`, the encoder preserves the input traversal order (see note above).
@@ -158,6 +161,7 @@ public struct EncodeOptions: @unchecked Sendable {
     ///   - skipNulls: Omit keys with `nil` values.
     ///   - strictNullHandling: Distinguish `nil` (`a`) from empty `""` (`a=`).
     ///   - commaRoundTrip: With `.comma`, ensure single-element lists keep `[]` for round-trip.
+    ///   - commaCompactNulls: With `.comma`, drop `nil` entries before joining to avoid empty slots.
     ///   - sort: Optional comparator for deterministic key ordering.
     public init(
         encoder: ValueEncoder? = nil,
@@ -178,6 +182,7 @@ public struct EncodeOptions: @unchecked Sendable {
         skipNulls: Bool = false,
         strictNullHandling: Bool = false,
         commaRoundTrip: Bool? = nil,
+        commaCompactNulls: Bool = false,
         sort: Sorter? = nil
     ) {
         // Validate charset (.utf8 or .isoLatin1)
@@ -201,6 +206,7 @@ public struct EncodeOptions: @unchecked Sendable {
         self.skipNulls = skipNulls
         self.strictNullHandling = strictNullHandling
         self.commaRoundTrip = commaRoundTrip
+        self.commaCompactNulls = commaCompactNulls
         self.sort = sort
     }
 
@@ -282,6 +288,7 @@ public struct EncodeOptions: @unchecked Sendable {
         skipNulls: Bool? = nil,
         strictNullHandling: Bool? = nil,
         commaRoundTrip: Bool?? = nil,
+        commaCompactNulls: Bool? = nil,
         sort: Sorter?? = nil
     ) -> EncodeOptions {
         @inline(__always)
@@ -310,6 +317,7 @@ public struct EncodeOptions: @unchecked Sendable {
             skipNulls: skipNulls ?? self.skipNulls,
             strictNullHandling: strictNullHandling ?? self.strictNullHandling,
             commaRoundTrip: pick(commaRoundTrip, self.commaRoundTrip),
+            commaCompactNulls: commaCompactNulls ?? self.commaCompactNulls,
             sort: pick(sort, self.sort)
         )
     }

--- a/Sources/QsSwift/Qs+Encode.swift
+++ b/Sources/QsSwift/Qs+Encode.swift
@@ -204,6 +204,8 @@ extension Qs {
                     listFormat: options.getListFormat,
                     commaRoundTrip: (options.getListFormat == .comma)
                         && (options.commaRoundTrip == true),
+                    commaCompactNulls: (options.getListFormat == .comma)
+                        && options.commaCompactNulls,
                     allowEmptyLists: options.allowEmptyLists,
                     strictNullHandling: options.strictNullHandling,
                     skipNulls: options.skipNulls,

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -3160,6 +3160,14 @@ struct EncodeTests {
         #expect(compact == "a[]=foo")
     }
 
+    @Test("encode: .comma + encode=true + valuesOnly + commaCompactNulls")
+    func comma_compactNulls_valuesOnly_encodes_once() throws {
+        let payload: [String: Any] = ["a": ["c,d", NSNull(), "e%"]]
+        let opts = EncodeOptions(listFormat: .comma, encode: true, encodeValuesOnly: true, commaCompactNulls: true)
+        // Expect comma preserved as %2C and '%' encoded once
+        #expect(try Qs.encode(payload, options: opts) == "a=c%2Cd,e%25")
+    }
+
     @Test("encode: allowEmptyLists renders foo[] for empty arrays")
     func empty_list_emits_brackets() throws {
         let opts = EncodeOptions(allowEmptyLists: true)

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -3001,8 +3001,8 @@ struct EncodeTests {
         #expect(out == "a%5B%5D=x")
     }
 
-    @Test("encode: .comma + commaCompactNulls drops null entries before joining")
-    func comma_compactNulls_drops_null_entries() throws {
+    @Test("encode: .comma + commaCompactNulls drops NSNull entries before joining")
+    func comma_compactNulls_drops_NSNull_entries() throws {
         let payload: [String: Any] = [
             "a": ["b": ["one", NSNull(), "two", NSNull(), "three"]]
         ]
@@ -3024,8 +3024,29 @@ struct EncodeTests {
         #expect(compact == "a[b]=one,two,three")
     }
 
+    @Test("encode: .comma + commaCompactNulls drops optional nil entries before joining")
+    func comma_compactNulls_drops_optional_nil_entries() throws {
+        let payload: [String: Any] = ["a": ["one", nil, "two", nil, "three"] as [String?]]
+
+        let baseline = try Qs.encode(
+            payload,
+            options: EncodeOptions(listFormat: .comma, encode: false)
+        )
+        #expect(baseline == "a=one,,two,,three")
+
+        let compact = try Qs.encode(
+            payload,
+            options: EncodeOptions(
+                listFormat: .comma,
+                encode: false,
+                commaCompactNulls: true
+            )
+        )
+        #expect(compact == "a=one,two,three")
+    }
+
     @Test("encode: .comma + commaCompactNulls omits the key when all entries are null")
-    func comma_compactNulls_omits_all_nulls() throws {
+    func comma_compactNulls_omits_all_NSNulls() throws {
         let payload: [String: Any] = ["a": [NSNull(), NSNull()]]
 
         let baseline = try Qs.encode(
@@ -3045,9 +3066,77 @@ struct EncodeTests {
         #expect(compact.isEmpty)
     }
 
+    @Test("encode: .comma + commaCompactNulls omits the key when all entries are null")
+    func comma_compactNulls_omits_all_nil() throws {
+        let payload: [String: Any] = ["a": [nil, nil]]
+
+        let baseline = try Qs.encode(
+            payload,
+            options: EncodeOptions(listFormat: .comma, encode: false)
+        )
+        #expect(baseline == "a=,")
+
+        let compact = try Qs.encode(
+            payload,
+            options: EncodeOptions(
+                listFormat: .comma,
+                encode: false,
+                commaCompactNulls: true
+            )
+        )
+        #expect(compact.isEmpty)
+    }
+
+    @Test("encode: .comma + commaCompactNulls omits the key when all entries are null")
+    func comma_compactNulls_omits_all_NSNull_and_nil() throws {
+        let payload: [String: Any] = ["a": [NSNull(), nil]]
+
+        let baseline = try Qs.encode(
+            payload,
+            options: EncodeOptions(listFormat: .comma, encode: false)
+        )
+        #expect(baseline == "a=,")
+
+        let compact = try Qs.encode(
+            payload,
+            options: EncodeOptions(
+                listFormat: .comma,
+                encode: false,
+                commaCompactNulls: true
+            )
+        )
+        #expect(compact.isEmpty)
+    }
+
     @Test("encode: .comma + commaCompactNulls preserves round-trip marker after filtering")
-    func comma_compactNulls_preserves_round_trip_marker() throws {
+    func comma_compactNulls_preserves_round_trip_marker_NSNull() throws {
         let payload: [String: Any] = ["a": [NSNull(), "foo"]]
+
+        let baseline = try Qs.encode(
+            payload,
+            options: EncodeOptions(
+                listFormat: .comma,
+                encode: false,
+                commaRoundTrip: true
+            )
+        )
+        #expect(baseline == "a=,foo")
+
+        let compact = try Qs.encode(
+            payload,
+            options: EncodeOptions(
+                listFormat: .comma,
+                encode: false,
+                commaRoundTrip: true,
+                commaCompactNulls: true
+            )
+        )
+        #expect(compact == "a[]=foo")
+    }
+
+    @Test("encode: .comma + commaCompactNulls preserves round-trip marker after filtering")
+    func comma_compactNulls_preserves_round_trip_marker_nil() throws {
+        let payload: [String: Any] = ["a": [nil, "foo"]]
 
         let baseline = try Qs.encode(
             payload,


### PR DESCRIPTION
This pull request introduces a new option, `commaCompactNulls`, for the `.comma` list encoding format in the Qs encoder. This option enables dropping `nil`/`NSNull` entries from arrays before joining them into a comma-separated string, resulting in more compact and predictable encoded output. The change is implemented across both Swift and Objective-C codebases, with updates to documentation and comprehensive tests to validate the new behavior.

### Feature: Compact comma-separated lists

* Added the `commaCompactNulls` option to `EncodeOptions` in both Swift (`EncodeOptions.swift`) and Objective-C (`EncodeOptionsObjC.swift`). When enabled with `.comma` list format, it removes `nil` and `NSNull` entries before joining, omits the key if all entries are null, and preserves round-trip markers if only one item remains. [[1]](diffhunk://#diff-24cb3e5d76e0174a6617c9927f81cdae7167d7e588e5729b0e103e34ec96a0e3R104-R106) [[2]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R117-R119) [[3]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R209) [[4]](diffhunk://#diff-24cb3e5d76e0174a6617c9927f81cdae7167d7e588e5729b0e103e34ec96a0e3R182) [[5]](diffhunk://#diff-a3ab4a5643ee930da20ee31a148d9c0f254d0f1ff769142124f43f7707783ab1R44) [[6]](diffhunk://#diff-a3ab4a5643ee930da20ee31a148d9c0f254d0f1ff769142124f43f7707783ab1L185-R212) [[7]](diffhunk://#diff-0886378c565b4fb9c5bf2f15a4f3f3406f45479fc928de97baf9b9d1887d672bR207-R208) [[8]](diffhunk://#diff-711b1e86863f218196f3e46c3170eabbdf3892bd91d8f2bcb79182f058971d35R130)

### Documentation

* Updated `README.md` and Objective-C `README.md` to describe the new `commaCompactNulls` option, including usage notes and expected output for various edge cases. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R328-R329) [[2]](diffhunk://#diff-711b1e86863f218196f3e46c3170eabbdf3892bd91d8f2bcb79182f058971d35R130)

### Encoder logic

* Modified the encoder implementation in Swift to filter out `nil`/`NSNull` values when `commaCompactNulls` is set, and added a helper to detect optionals. Ensured correct handling for round-trip markers and values-only encoding. [[1]](diffhunk://#diff-a3ab4a5643ee930da20ee31a148d9c0f254d0f1ff769142124f43f7707783ab1L185-R212) [[2]](diffhunk://#diff-a3ab4a5643ee930da20ee31a148d9c0f254d0f1ff769142124f43f7707783ab1R491-R495) [[3]](diffhunk://#diff-a3ab4a5643ee930da20ee31a148d9c0f254d0f1ff769142124f43f7707783ab1R406)

### Test coverage

* Added extensive tests in both Swift (`EncodeTests.swift`) and Objective-C (`ObjCBridgeExtrasTests.m`) to verify the new option's behavior with arrays containing `nil`, `NSNull`, and mixed values, including edge cases for round-trip and omission scenarios. [[1]](diffhunk://#diff-9fb9a3985794c8ade88d3dbb16734d232d8451917d659b17f123260250512390R3004-R3170) [[2]](diffhunk://#diff-94b1fed92b49d8d7d9832cefb323aa605f2a9fc44f7b0a38201d757a7c0e404eR174-R186)

### API consistency

* Updated initializers and option-merging logic for `EncodeOptions` in Swift to support the new `commaCompactNulls` property, ensuring it is correctly propagated and defaults are handled. [[1]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R164) [[2]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R185) [[3]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R291) [[4]](diffhunk://#diff-24a5c08e3de44b88409ec84ba85b3ef9279b833fe0a0690758c333133f4b4ee3R320)

This change improves the flexibility and usability of comma-separated list encoding, especially when working with data that may contain nulls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commaCompactNulls option to drop null entries when using comma-delimited list formatting, producing "one,two" instead of "one,,two" (available in Swift and Objective-C).

* **Documentation**
  * Updated docs to explain commaCompactNulls and its interaction with commaRoundTrip and round-trip behavior.

* **Tests**
  * Added comprehensive tests covering commaCompactNulls behavior, nil/NSNull filtering, round-trip interactions, and values-only encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->