### PR TITLE
:zap: implement iterative encoder core for Swift and ObjC

### DIFF
--- a/Bench/Makefile
+++ b/Bench/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 
-.PHONY: help clean reset profile
+.PHONY: help clean reset profile perf-snapshot perf-compare
 
 # Apply to all Swift test invocations from this Makefile
 export SWIFT_DETERMINISTIC_HASHING=1
@@ -28,3 +28,12 @@ reset:
 profile:
 	@# Help: Generate profiling data
 	@bash scripts/profile.sh
+
+perf-snapshot:
+	@# Help: Run deep encode perf snapshot (Swift + ObjC bridge)
+	@swift build -c release
+	@.build/release/QsSwiftBench perf
+
+perf-compare:
+	@# Help: Run repeated snapshots and emit JSON summary
+	@bash scripts/perf_compare.sh --runs 3 --output /tmp/qs_swift_perf_$$(date +%Y%m%d_%H%M%S).json

--- a/Bench/Package.swift
+++ b/Bench/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         .executableTarget(
             name: "QsSwiftBench",
             dependencies: [
-                .product(name: "QsSwift", package: "QsSwift")
+                .product(name: "QsSwift", package: "QsSwift"),
+                .product(name: "QsObjC", package: "QsSwift"),
             ]
         )
     ]

--- a/Bench/README.md
+++ b/Bench/README.md
@@ -1,130 +1,82 @@
-# QsBench
+# QsSwiftBench
 
-A tiny, standalone benchmark harness for the `Qs` library. It lets you compare baseline builds vs. builds with optional inlining or other compile-time flags, and quickly see whether micro–optimizations are worth it.
+Standalone benchmark harness for `QsSwift` / `QsObjC`.
 
----
+## Scenarios
 
-## What it benchmarks
+- `list`: large comma-list decode payload.
+- `deep`: deep decode key path payload (`foo[p][p]...`).
+- `perf`: encode deep snapshot parity matrix (Swift + ObjC bridge).
 
-Two simple scenarios:
-
-- **list** – builds a large query string like `a[]=0,1,2&a[]=1,2,3…`, stressing comma-split parsing + decode.
-- **deep** – builds a *very* deep key path like `foo[p][p]...[p]=x`, stressing key–segment splitting and object assembly.
-
-You can tweak these inputs in `Sources/QsBench/main.swift`.
-
----
-
-## Prerequisites
-
-- Swift 5.10+ toolchain (SwiftPM)
-- macOS or Linux shell
-- (Optional) [hyperfine](https://github.com/sharkdp/hyperfine) for nicer A/B comparisons
-  - macOS: `brew install hyperfine`
-  - Debian/Ubuntu: `sudo apt-get install hyperfine`
-
-The provided `Makefile` also exports `SWIFT_DETERMINISTIC_HASHING=1` so runs are stable across processes.
-
----
+`perf` uses:
+- depths: `2000`, `5000`, `12000`
+- iterations: `20`, `20`, `8`
+- statistic: median of `7` samples
 
 ## Quick start
 
 ```bash
 cd Bench
-
-# Build (release)
 swift build -c release
 
-# Run the default scenario (list)
-.build/release/QsBench list
+# Decode micro benches
+.build/release/QsSwiftBench list
+N=5000 .build/release/QsSwiftBench deep
 
-# Run the deep scenario with a larger depth
-N=5000 .build/release/QsBench deep
+# Encode deep snapshot (Swift + ObjC bridge)
+.build/release/QsSwiftBench perf
 ```
 
-You should see the “work” result (count/boolean) and elapsed time printed.
+## Snapshot compare workflow
 
----
-
-## A/B profiling with hyperfine
-
-The repo includes `scripts/profile.sh`, which:
-
-1. Builds a **baseline** release and saves it as `QsBench_base`
-2. Builds an **inline** variant with `-DQSBENCH_INLINE` and saves it as `QsBench_inline`
-3. Benchmarks both with `hyperfine` for **list** and **deep**
-
-Run it via the `Makefile`:
+Run repeated snapshots and emit a JSON summary:
 
 ```bash
-make profile
+Bench/scripts/perf_compare.sh --runs 3 --output /tmp/qs_swift_perf.json
 ```
 
-or directly:
+Compare against committed baseline:
 
 ```bash
-bash scripts/profile.sh
+Bench/scripts/perf_compare.sh \
+  --runs 3 \
+  --output /tmp/qs_swift_perf.json \
+  --compare Bench/baselines/encode_deep_snapshot_baseline.json
 ```
 
-> Tip: The `QSBENCH_INLINE` flag is used inside the benchmark code to toggle “hot path” annotations (`@inline(__always)`/`@inlinable`) so you can verify they actually help.
+Baseline file:
+- `Bench/baselines/encode_deep_snapshot_baseline.json`
 
----
+## Optional perf guardrail tests
 
-## Interpreting results
-
-`hyperfine` prints mean ± σ and range. Differences within ~1–3% are usually noise on a modern laptop. Look for consistent wins across 20+ runs before committing micro-optimizations.
-
-To reduce noise:
-
-- Close background apps; keep CPU frequency stable (plugged in, low thermal load).
-- Run multiple times; consider `--warmup 3 -r 20` (already used in the script).
-
----
-
-## Instruments / Time Profiler (optional)
-
-If you want call-level hotspots:
+These tests are opt-in and intended for release mode.
 
 ```bash
-# Time Profiler from CLI (macOS)
-instruments -t "Time Profiler" .build/release/QsBench --args list
+QS_ENABLE_PERF_GUARDRAILS=1 SWIFT_DETERMINISTIC_HASHING=1 swift test -c release -q \
+  --filter PerformanceGuardrail
 ```
 
-Or open Instruments.app and select the `QsBench` binary manually.
+Debug override:
 
----
+```bash
+QS_ENABLE_PERF_GUARDRAILS=1 QS_PERF_ALLOW_DEBUG=1 SWIFT_DETERMINISTIC_HASHING=1 swift test -q \
+  --filter PerformanceGuardrail
+```
+
+Tolerance override (`20` by default):
+
+```bash
+QS_PERF_REGRESSION_TOLERANCE_PCT=25 QS_ENABLE_PERF_GUARDRAILS=1 swift test -c release -q \
+  --filter PerformanceGuardrail
+```
 
 ## Makefile helpers
 
 ```bash
-make help     # list targets
-make clean    # clean SwiftPM artifacts
-make reset    # clean + reset package
-make profile  # run A/B hyperfine script
+make help
+make clean
+make reset
+make profile
+make perf-snapshot
+make perf-compare
 ```
-
----
-
-## Why this is a separate package
-
-Benchmarks are **not** shipped with the main library product. Keeping them in `Bench/` (their own Swift package) avoids pulling benchmark code or flags into your app/library builds.
-
----
-
-## Customizing workloads
-
-Open `Sources/QsBench/main.swift` and adjust:
-
-- For **list** scenario:
-  - the shape and size of `parts` and the delimiter behavior
-- For **deep** scenario:
-  - the depth `N` (via `N=...`) and the segment name
-
-Then rebuild and re-run:
-
-```bash
-swift build -c release
-.build/release/QsBench list
-```
-
-Happy profiling!

--- a/Bench/Sources/main.swift
+++ b/Bench/Sources/main.swift
@@ -1,6 +1,10 @@
 import Foundation
 import QsSwift
 
+#if canImport(ObjectiveC)
+    import QsObjC
+#endif
+
 func benchCommaList(_ N: Int) throws {
     var parts: [String] = []
     parts.reserveCapacity(N)
@@ -30,11 +34,138 @@ func benchDeep(_ N: Int) throws {
     print(String(format: "elapsed: %.6f s", elapsed))
 }
 
+private struct DeepEncodeCase {
+    let depth: Int
+    let iterations: Int
+}
+
+private let deepEncodeCases: [DeepEncodeCase] = [
+    .init(depth: 2000, iterations: 20),
+    .init(depth: 5000, iterations: 20),
+    .init(depth: 12000, iterations: 8),
+]
+
+private let sampleCount = 7
+private let warmupCount = 5
+
+private enum BenchError: Error {
+    case objcEncodeFailed(depth: Int)
+}
+
+private func median(_ values: [Double]) -> Double {
+    precondition(!values.isEmpty, "median requires at least one value")
+    let sorted = values.sorted()
+    return sorted[sorted.count / 2]
+}
+
+@inline(__always)
+private func runGcPause() {
+    Thread.sleep(forTimeInterval: 0.025)
+}
+
+private func buildNestedSwift(depth: Int) -> [String: Any] {
+    var current: [String: Any] = ["leaf": "x"]
+    for _ in 0..<depth {
+        current = ["a": current]
+    }
+    return current
+}
+
+#if canImport(ObjectiveC)
+    private func buildNestedObjC(depth: Int) -> NSDictionary {
+        var current: Any = NSDictionary(dictionary: ["leaf": "x"])
+        for _ in 0..<depth {
+            current = NSDictionary(object: current, forKey: "a" as NSString)
+        }
+        return current as! NSDictionary
+    }
+#endif
+
+private func measureSwiftEncodeDeep(depth: Int, iterations: Int) throws -> (msPerOp: Double, outLength: Int) {
+    let payload = buildNestedSwift(depth: depth)
+    let options = EncodeOptions(encode: false)
+
+    for _ in 0..<warmupCount {
+        _ = try Qs.encode(payload, options: options)
+    }
+
+    var samples: [Double] = []
+    samples.reserveCapacity(sampleCount)
+    var outLength = 0
+
+    for _ in 0..<sampleCount {
+        runGcPause()
+        let start = DispatchTime.now().uptimeNanoseconds
+        var encoded = ""
+        for _ in 0..<iterations {
+            encoded = try Qs.encode(payload, options: options)
+        }
+        let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0
+        samples.append(elapsedMs / Double(iterations))
+        outLength = encoded.count
+    }
+
+    return (median(samples), outLength)
+}
+
+#if canImport(ObjectiveC)
+    private func measureObjCEncodeDeep(depth: Int, iterations: Int) throws -> (msPerOp: Double, outLength: Int) {
+        let payload = buildNestedObjC(depth: depth)
+        let options = EncodeOptionsObjC()
+        options.encode = false
+
+        for _ in 0..<warmupCount {
+            _ = QsBridge.encode(payload, options: options, error: nil)
+        }
+
+        var samples: [Double] = []
+        samples.reserveCapacity(sampleCount)
+        var outLength = 0
+
+        for _ in 0..<sampleCount {
+            runGcPause()
+            let start = DispatchTime.now().uptimeNanoseconds
+            var encoded: NSString?
+            for _ in 0..<iterations {
+                encoded = QsBridge.encode(payload, options: options, error: nil)
+            }
+            let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0
+            samples.append(elapsedMs / Double(iterations))
+
+            guard let encoded else {
+                throw BenchError.objcEncodeFailed(depth: depth)
+            }
+            outLength = (encoded as String).count
+        }
+
+        return (median(samples), outLength)
+    }
+#endif
+
+private func perfSnapshot() throws {
+    print("QsSwiftBench perf snapshot (median of 7 samples)")
+    print("Encode (encode=false, deep nesting):")
+
+    for c in deepEncodeCases {
+        let (ms, outLength) = try measureSwiftEncodeDeep(depth: c.depth, iterations: c.iterations)
+        print(String(format: "  swift depth=%5d: %8.3f ms/op | len=%d", c.depth, ms, outLength))
+    }
+
+    #if canImport(ObjectiveC)
+        print("Encode via ObjC bridge (QsBridge.encode, deep nesting):")
+        for c in deepEncodeCases {
+            let (ms, outLength) = try measureObjCEncodeDeep(depth: c.depth, iterations: c.iterations)
+            print(String(format: "  objc  depth=%5d: %8.3f ms/op | len=%d", c.depth, ms, outLength))
+        }
+    #endif
+}
+
 // --- entry point ---
 let scenario = CommandLine.arguments.dropFirst().first?.lowercased() ?? "list"
 let N = Int(ProcessInfo.processInfo.environment["N"] ?? "") ?? 2000
 
 switch scenario {
 case "deep": try benchDeep(N)
+case "perf", "perf-encode-deep": try perfSnapshot()
 default: try benchCommaList(N)
 }

--- a/Bench/Sources/main.swift
+++ b/Bench/Sources/main.swift
@@ -73,11 +73,11 @@ private func buildNestedSwift(depth: Int) -> [String: Any] {
 
 #if canImport(ObjectiveC)
     private func buildNestedObjC(depth: Int) -> NSDictionary {
-        var current: Any = NSDictionary(dictionary: ["leaf": "x"])
+        var current: NSDictionary = NSDictionary(dictionary: ["leaf": "x"])
         for _ in 0..<depth {
             current = NSDictionary(object: current, forKey: "a" as NSString)
         }
-        return current as! NSDictionary
+        return current
     }
 #endif
 

--- a/Bench/baselines/encode_deep_snapshot_baseline.json
+++ b/Bench/baselines/encode_deep_snapshot_baseline.json
@@ -1,0 +1,101 @@
+{
+  "cases": [
+    {
+      "depth": 2000,
+      "len": 6006,
+      "ms_per_op_median": 2.261,
+      "ms_per_op_values": [
+        2.204,
+        2.273,
+        2.234,
+        2.264,
+        2.26,
+        2.262,
+        2.261
+      ],
+      "runs": 7,
+      "runtime": "objc"
+    },
+    {
+      "depth": 5000,
+      "len": 15006,
+      "ms_per_op_median": 5.518,
+      "ms_per_op_values": [
+        5.337,
+        5.581,
+        5.374,
+        5.547,
+        5.518,
+        5.385,
+        5.562
+      ],
+      "runs": 7,
+      "runtime": "objc"
+    },
+    {
+      "depth": 12000,
+      "len": 36006,
+      "ms_per_op_median": 12.924,
+      "ms_per_op_values": [
+        12.9,
+        13.37,
+        12.862,
+        12.924,
+        12.897,
+        13.144,
+        13.529
+      ],
+      "runs": 7,
+      "runtime": "objc"
+    },
+    {
+      "depth": 2000,
+      "len": 6006,
+      "ms_per_op_median": 0.321,
+      "ms_per_op_values": [
+        0.327,
+        0.312,
+        0.328,
+        0.323,
+        0.321,
+        0.321,
+        0.315
+      ],
+      "runs": 7,
+      "runtime": "swift"
+    },
+    {
+      "depth": 5000,
+      "len": 15006,
+      "ms_per_op_median": 0.799,
+      "ms_per_op_values": [
+        1.003,
+        0.79,
+        0.81,
+        0.799,
+        0.796,
+        0.804,
+        0.798
+      ],
+      "runs": 7,
+      "runtime": "swift"
+    },
+    {
+      "depth": 12000,
+      "len": 36006,
+      "ms_per_op_median": 2.344,
+      "ms_per_op_values": [
+        2.28,
+        2.055,
+        2.448,
+        2.377,
+        2.344,
+        2.472,
+        2.156
+      ],
+      "runs": 7,
+      "runtime": "swift"
+    }
+  ],
+  "runs": 7
+}

--- a/Bench/scripts/perf_compare.sh
+++ b/Bench/scripts/perf_compare.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: Bench/scripts/perf_compare.sh [--runs N] [--output FILE] [--compare FILE]
+
+Run the QsSwiftBench deep encode snapshot multiple times, summarize medians across
+runs (Swift + ObjC bridge), and optionally compare against a saved baseline JSON.
+
+Options:
+  --runs N       Number of full snapshot runs to execute (default: 3)
+  --output FILE  Where to write summary JSON (default: /tmp/qs_swift_perf_<ts>.json)
+  --compare FILE Compare current summary against a previous summary JSON
+EOF
+}
+
+runs=3
+output=""
+compare=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --runs" >&2
+        exit 2
+      fi
+      runs="${2:-}"
+      shift 2
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --output" >&2
+        exit 2
+      fi
+      output="${2:-}"
+      shift 2
+      ;;
+    --compare)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --compare" >&2
+        exit 2
+      fi
+      compare="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$runs" =~ ^[0-9]+$ ]] || [[ "$runs" -le 0 ]]; then
+  echo "--runs must be a positive integer" >&2
+  exit 2
+fi
+
+if [[ -z "$output" ]]; then
+  output="/tmp/qs_swift_perf_$(date +%Y%m%d_%H%M%S).json"
+fi
+
+if [[ -n "$compare" && ! -f "$compare" ]]; then
+  echo "--compare file does not exist: $compare" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCH_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${BENCH_DIR}/.build/release/QsSwiftBench"
+
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
+raw_jsonl="$tmpdir/raw.jsonl"
+
+echo "Building QsSwiftBench (release) ..."
+swift build -c release --package-path "$BENCH_DIR" >/dev/null
+
+for run in $(seq 1 "$runs"); do
+  echo "Running perf snapshot ($run/$runs) ..."
+  snapshot_file="$tmpdir/snapshot_$run.txt"
+  "$BIN" perf >"$snapshot_file"
+  python3 - "$run" "$snapshot_file" >>"$raw_jsonl" <<'PY'
+import json
+import re
+import sys
+
+run = int(sys.argv[1])
+path = sys.argv[2]
+
+line_re = re.compile(
+    r"^\s*(swift|objc)\s+depth=\s*(\d+):\s*([0-9.]+)\s*ms/op\s*\|\s*len=(\d+)\s*$"
+)
+
+with open(path, "r", encoding="utf-8") as f:
+    for line in f:
+        m = line_re.match(line)
+        if m:
+            runtime, depth, ms, out_len = m.groups()
+            rec = {
+                "run": run,
+                "runtime": runtime,
+                "depth": int(depth),
+                "len": int(out_len),
+                "ms_per_op": float(ms),
+            }
+            print(json.dumps(rec))
+        elif "ms/op" in line:
+            print(
+                f"[perf_compare] warning: run={run} unmatched benchmark line: {line.rstrip()}",
+                file=sys.stderr,
+            )
+PY
+done
+
+python3 - "$raw_jsonl" "$output" "$compare" <<'PY'
+import json
+import statistics
+import sys
+from collections import defaultdict
+
+raw_path, out_path, compare_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+records = []
+with open(raw_path, "r", encoding="utf-8") as f:
+    for line in f:
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+
+if not records:
+    print("No benchmark records were parsed.", file=sys.stderr)
+    sys.exit(1)
+
+groups = defaultdict(list)
+for rec in records:
+    key = (rec["runtime"], rec["depth"], rec["len"])
+    groups[key].append(rec)
+
+cases = []
+for (runtime, depth, out_len), items in sorted(groups.items(), key=lambda x: (x[0][0], x[0][1])):
+    ms_values = [x["ms_per_op"] for x in items]
+    cases.append(
+        {
+            "runtime": runtime,
+            "depth": depth,
+            "len": out_len,
+            "runs": len(items),
+            "ms_per_op_median": statistics.median(ms_values),
+            "ms_per_op_values": ms_values,
+        }
+    )
+
+summary = {
+    "runs": len({r["run"] for r in records}),
+    "cases": cases,
+}
+
+with open(out_path, "w", encoding="utf-8") as f:
+    json.dump(summary, f, indent=2, sort_keys=True)
+
+print(f"\nSaved summary: {out_path}")
+print("\nCurrent medians:")
+for case in cases:
+    print(
+        f"  {case['runtime']:5s} depth={case['depth']:5d},len={case['len']:6d}  "
+        f"ms={case['ms_per_op_median']:.3f}"
+    )
+
+if compare_path:
+    with open(compare_path, "r", encoding="utf-8") as f:
+        baseline = json.load(f)
+
+    baseline_map = {
+        (c["runtime"], c["depth"], c.get("len", -1)): c
+        for c in baseline.get("cases", [])
+    }
+
+    print(f"\nDelta vs baseline: {compare_path}")
+    for case in cases:
+        key_exact = (case["runtime"], case["depth"], case["len"])
+        key_len_agnostic = (case["runtime"], case["depth"], -1)
+        base = baseline_map.get(key_exact) or baseline_map.get(key_len_agnostic)
+        if not base:
+            continue
+
+        base_ms = base.get("ms_per_op_median")
+        if not base_ms:
+            continue
+        delta = ((case["ms_per_op_median"] / base_ms) - 1.0) * 100.0
+        print(
+            f"  {case['runtime']:5s} depth={case['depth']:5d},len={case['len']:6d}  "
+            f"ms={delta:+.2f}%"
+        )
+PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.3.1
+
+- [PERF] refactor `Encoder` to a fully iterative traversal core with linked key-path caching (`KeyPathNode`), immutable per-traversal config (`EncodeConfig`), explicit traversal frames (`EncodeFrame`), and O(1) active-path cycle checks for class-backed containers.
+- [PERF] add a guarded deep linear-chain encode fast path for simple `encode=false` map payloads and optimize iterative single-key frame completion/segment reuse to reduce per-depth overhead at `2000/5000/12000`.
+- [PERF] reduce top-level `Qs.encode` overhead by hoisting encoder/date/list-format option derivations out of the per-key loop.
+- [PERF][ObjC] make encode bridging one-pass (`bridgeInputForEncode(_:bridgeUndefined:)`) so `QsBridge.encode` no longer performs two full-tree conversions before calling the Swift core.
+- [BENCH] add deep-encode snapshot mode to `QsSwiftBench` for parity matrix runs (`2000/5000/12000`, `20/20/8`, median-of-7) including ObjC bridge timings.
+- [BENCH] add `Bench/scripts/perf_compare.sh` JSON summary/delta workflow and commit `Bench/baselines/encode_deep_snapshot_baseline.json`.
+- [BENCH] refresh deep-encode baseline medians after encoder optimizations: Swift `0.321/0.799/2.344 ms/op`, ObjC bridge `2.261/5.518/12.924 ms/op` (`depth=2000/5000/12000`).
+- [TEST] add encoder-internal regression tests (key-path cache behavior + iterative mixed payload traversal) and opt-in Swift/ObjC performance guardrail tests (`QS_ENABLE_PERF_GUARDRAILS=1`).
+- [DOCS] document perf snapshot, compare, and guardrail commands in `Bench/README.md` and add Makefile helpers (`perf-snapshot`, `perf-compare`).
+
 ## 1.3.0
 
 - [FIX] harden deep encoding paths with iterative fallback to prevent stack overflows on very deep nested payloads, while preserving cycle detection and deterministic traversal behavior.
@@ -66,3 +78,6 @@
 ## 1.0.0
 
 - [CHORE] Initial release of the project.
+
+[ObjC]: https://developer.apple.com/documentation/objectivec
+[Linux]: https://www.kernel.org/

--- a/Package.swift
+++ b/Package.swift
@@ -42,9 +42,13 @@ let package = Package(
                 .define("QS_OBJC_BRIDGE", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS]))
             ]
         ),
+        .target(
+            name: "QsTestSupport",
+            path: "Tests/TestSupport"
+        ),
         .testTarget(
             name: "QsSwiftTests",
-            dependencies: ["QsSwift"],
+            dependencies: ["QsSwift", "QsTestSupport"],
             path: "Tests/QsSwiftTests"
         ),
         .testTarget(
@@ -52,6 +56,7 @@ let package = Package(
             dependencies: [
                 "QsSwift",
                 "QsObjC",
+                "QsTestSupport",
             ],
             path: "Tests/QsObjCTests"
         ),

--- a/Sources/QsObjC/Models/FilterObjC.swift
+++ b/Sources/QsObjC/Models/FilterObjC.swift
@@ -49,9 +49,8 @@
                     return value
                 }
                 guard let out else { return nil }
-                // Normalize Obj-C containers to the same Swift encode-side shapes used at entry.
-                let bridged = QsBridge.bridgeInputForEncode(out)
-                return QsBridge.bridgeUndefinedPreservingOrder(bridged) ?? bridged
+                // Normalize Obj-C containers and Undefined in one traversal.
+                return QsBridge.bridgeInputForEncode(out, bridgeUndefined: true)
             }
         }
     }

--- a/Sources/QsSwift/Internal/EncodeConfig.swift
+++ b/Sources/QsSwift/Internal/EncodeConfig.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+internal struct EncodeConfig {
+    let generateArrayPrefix: ListFormatGenerator
+    let listFormat: ListFormat
+    let hasCustomGenerator: Bool
+    let commaRoundTrip: Bool
+    let commaCompactNulls: Bool
+    let allowEmptyLists: Bool
+    let strictNullHandling: Bool
+    let skipNulls: Bool
+    let encodeDotInKeys: Bool
+    let encoder: ValueEncoder?
+    let serializeDate: DateSerializer?
+    let sort: Sorter?
+    let filter: Filter?
+    let allowDots: Bool
+    let format: Format
+    let formatter: Formatter
+    let encodeValuesOnly: Bool
+    let charset: String.Encoding
+
+    var isCommaListFormat: Bool {
+        listFormat == .comma
+    }
+
+    func withEncoder(_ nextEncoder: ValueEncoder?) -> EncodeConfig {
+        EncodeConfig(
+            generateArrayPrefix: generateArrayPrefix,
+            listFormat: listFormat,
+            hasCustomGenerator: hasCustomGenerator,
+            commaRoundTrip: commaRoundTrip,
+            commaCompactNulls: commaCompactNulls,
+            allowEmptyLists: allowEmptyLists,
+            strictNullHandling: strictNullHandling,
+            skipNulls: skipNulls,
+            encodeDotInKeys: encodeDotInKeys,
+            encoder: nextEncoder,
+            serializeDate: serializeDate,
+            sort: sort,
+            filter: filter,
+            allowDots: allowDots,
+            format: format,
+            formatter: formatter,
+            encodeValuesOnly: encodeValuesOnly,
+            charset: charset
+        )
+    }
+}

--- a/Sources/QsSwift/Internal/EncodeFrame.swift
+++ b/Sources/QsSwift/Internal/EncodeFrame.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+internal enum EncodePhase {
+    case start
+    case iterate
+    case awaitChild
+}
+
+internal enum EncodeKeyState {
+    case none
+    case single(Any)
+    case many([Any])
+}
+
+internal enum EncodedValuesBuffer {
+    case empty
+    case single(Any)
+    case many([Any])
+
+    @inline(__always)
+    mutating func append(_ value: Any) {
+        switch self {
+        case .empty:
+            self = .single(value)
+        case .single(let current):
+            self = .many([current, value])
+        case .many(var list):
+            list.append(value)
+            self = .many(list)
+        }
+    }
+
+    @inline(__always)
+    mutating func append(contentsOf values: [Any]) {
+        guard !values.isEmpty else { return }
+
+        switch self {
+        case .empty:
+            if values.count == 1, let first = values.first {
+                self = .single(first)
+            } else {
+                self = .many(values)
+            }
+        case .single(let current):
+            var list = [Any]()
+            list.reserveCapacity(values.count + 1)
+            list.append(current)
+            list.append(contentsOf: values)
+            self = .many(list)
+        case .many(var list):
+            list.append(contentsOf: values)
+            self = .many(list)
+        }
+    }
+
+    @inline(__always)
+    func asArray() -> [Any] {
+        switch self {
+        case .empty:
+            return []
+        case .single(let value):
+            return [value]
+        case .many(let values):
+            return values
+        }
+    }
+}
+
+internal final class EncodeFrame {
+    var object: Any?
+    let undefined: Bool
+    let path: KeyPathNode
+    let config: EncodeConfig
+    let depth: Int
+
+    var phase: EncodePhase = .start
+    var values: EncodedValuesBuffer = .empty
+    var keyState: EncodeKeyState = .none
+    var index: Int = 0
+    var seqList: [Any]?
+    var commaEffectiveLength: Int?
+    var adjustedPath: KeyPathNode?
+    var trackedContainerID: ObjectIdentifier?
+
+    init(
+        object: Any?,
+        undefined: Bool,
+        path: KeyPathNode,
+        config: EncodeConfig,
+        depth: Int
+    ) {
+        self.object = object
+        self.undefined = undefined
+        self.path = path
+        self.config = config
+        self.depth = depth
+    }
+}

--- a/Sources/QsSwift/Internal/Encoder.swift
+++ b/Sources/QsSwift/Internal/Encoder.swift
@@ -285,11 +285,10 @@ internal enum Encoder {
 
                 let pathForChildren = config.encodeDotInKeys ? frame.path.asDotEncoded() : frame.path
                 let shouldAppendRoundTripMarker =
-                    config.commaRoundTrip
+                    config.isCommaListFormat
+                    && config.commaRoundTrip
                     && seqList != nil
-                    && (config.isCommaListFormat && commaEffectiveLength != nil
-                        ? commaEffectiveLength == 1
-                        : (seqList?.count == 1))
+                    && (commaEffectiveLength ?? seqList?.count) == 1
                 let adjustedPath = shouldAppendRoundTripMarker ? pathForChildren.append("[]") : pathForChildren
 
                 if config.allowEmptyLists, let seqList, seqList.isEmpty {

--- a/Sources/QsSwift/Internal/Encoder.swift
+++ b/Sources/QsSwift/Internal/Encoder.swift
@@ -21,32 +21,6 @@ extension Optional: _AnyOptional {
 internal enum Encoder {
     // MARK: - Encode
 
-    /// Encodes the given data into a query string format.
-    ///
-    /// - Parameters:
-    ///   - data: The data to encode; can be any type.
-    ///   - undefined: If true, will not encode undefined values.
-    ///   - sideChannel: A map table for tracking cyclic references.
-    ///   - prefix: An optional prefix for the encoded string.
-    ///   - generateArrayPrefix: A generator for array prefixes.
-    ///   - commaRoundTrip: If true, uses comma for array encoding.
-    ///   - commaCompactNulls: When true, drops `nil` entries before joining comma lists.
-    ///   - allowEmptyLists: If true, allows empty lists in the output.
-    ///   - strictNullHandling: If true, handles nulls strictly.
-    ///   - skipNulls: If true, skips null values in the output.
-    ///   - encodeDotInKeys: If true, encodes dots in keys.
-    ///   - encoder: An optional custom encoder function.
-    ///   - serializeDate: An optional date serializer function.
-    ///   - sort: An optional sorter for keys.
-    ///   - filter: An optional filter to apply to the data.
-    ///   - allowDots: If true, allows dots in keys.
-    ///   - format: The format to use for encoding (default is RFC3986).
-    ///   - formatter: A custom formatter function.
-    ///   - encodeValuesOnly: If true, only encodes values without keys.
-    ///   - charset: The character encoding to use (default is UTF-8).
-    ///   - addQueryPrefix: If true, adds a '?' prefix to the output.
-    ///   - depth: The current depth in the encoding process (used for recursion).
-    /// - Returns: The encoded result as Any (typically a String or [String]).
     @usableFromInline
     static func encode(
         data: Any?,
@@ -73,658 +47,651 @@ internal enum Encoder {
         addQueryPrefix: Bool = false,
         depth: Int = 0
     ) throws -> Any {
-        let generator = generateArrayPrefix ?? listFormat.generator
-        let isComma = (listFormat == .comma)
-        let commaRoundTripEffective = (commaRoundTrip == true)
-        let fmt = formatter ?? format.formatter
-        let keyPrefix = prefix ?? (addQueryPrefix ? "?" : "")
+        // Kept for API compatibility: passed from Qs+Encode and direct tests that still exercise this signature.
+        // Preserve until those call sites and iterative path-tracking expectations are updated in one refactor.
+        _ = sideChannel
 
-        if depth >= iterativeFallbackDepth,
-            canUseIterativeDeepFallback(
-                listFormat: listFormat,
-                commaRoundTrip: commaRoundTrip,
-                commaCompactNulls: commaCompactNulls,
-                allowEmptyLists: allowEmptyLists,
-                strictNullHandling: strictNullHandling,
-                skipNulls: skipNulls,
-                encodeDotInKeys: encodeDotInKeys,
-                sort: sort,
-                filter: filter,
-                allowDots: allowDots,
-                encodeValuesOnly: encodeValuesOnly
-            )
+        let effectiveGenerator = generateArrayPrefix ?? listFormat.generator
+        let rootConfig = EncodeConfig(
+            generateArrayPrefix: effectiveGenerator,
+            listFormat: listFormat,
+            hasCustomGenerator: generateArrayPrefix != nil,
+            commaRoundTrip: commaRoundTrip,
+            commaCompactNulls: commaCompactNulls,
+            allowEmptyLists: allowEmptyLists,
+            strictNullHandling: strictNullHandling,
+            skipNulls: skipNulls,
+            encodeDotInKeys: encodeDotInKeys,
+            encoder: encoder,
+            serializeDate: serializeDate,
+            sort: sort,
+            filter: filter,
+            allowDots: allowDots,
+            format: format,
+            formatter: formatter ?? format.formatter,
+            encodeValuesOnly: encodeValuesOnly,
+            charset: charset
+        )
+
+        let rootPrefix = prefix ?? (addQueryPrefix ? "?" : "")
+        let rootIsContainer = isContainer(data)
+
+        if let fast = try encodeLinearChainIfEligible(
+            data: data, undefined: undefined, prefix: rootPrefix, config: rootConfig)
         {
-            return try encodeIterativeDeepFallback(
-                data: data,
+            return rootIsContainer ? [fast] : fast
+        }
+
+        var stack: [EncodeFrame] = [
+            EncodeFrame(
+                object: data,
                 undefined: undefined,
-                prefix: keyPrefix,
+                path: KeyPathNode.fromMaterialized(rootPrefix),
+                config: rootConfig,
                 depth: depth,
-                generator: generator,
-                encoder: encoder,
-                serializeDate: serializeDate,
-                formatter: fmt,
-                charset: charset
             )
+        ]
+
+        var activeContainers = Set<ObjectIdentifier>()
+        var lastResult: Any?
+        var lastBracketKey: String?
+        var lastBracketSegment = ""
+        var lastDotKey: String?
+        var lastDotSegment = ""
+
+        @inline(__always)
+        func bracketSegment(for encodedKey: String) -> String {
+            if lastBracketKey == encodedKey {
+                return lastBracketSegment
+            }
+            let segment = "[\(encodedKey)]"
+            lastBracketKey = encodedKey
+            lastBracketSegment = segment
+            return segment
         }
 
-        var obj: Any? = data
+        @inline(__always)
+        func dotSegment(for encodedKey: String) -> String {
+            if lastDotKey == encodedKey {
+                return lastDotSegment
+            }
+            let segment = ".\(encodedKey)"
+            lastDotKey = encodedKey
+            lastDotSegment = segment
+            return segment
+        }
 
-        let objWrapper: WeakWrapper? = {
-            guard let objRef = data as? AnyObject else { return nil }
-            // Optional: narrow to Foundation containers if you like
-            if objRef is NSArray || objRef is NSDictionary { return WeakWrapper(objRef) }
-            return nil
-        }()
+        func finishFrame(_ result: Any) {
+            let completed = stack.removeLast()
+            if let tracked = completed.trackedContainerID {
+                activeContainers.remove(tracked)
+            }
+            lastResult = result
+        }
 
-        var tmpSc: NSMapTable<AnyObject, AnyObject>? = sideChannel
-        var step = 0
-        var findFlag = false
+        while let frame = stack.last {
+            let config = frame.config
 
-        // Walk ancestors to detect cycles
-        while !findFlag {
-            guard let next = tmpSc?.object(forKey: SENTINEL) as? NSMapTable<AnyObject, AnyObject>
-            else { break }
-            step += 1
+            switch frame.phase {
+            case .start:
+                var obj = frame.object
+                var pathText: String?
 
-            if let objWrapper = objWrapper, let pos = next.object(forKey: objWrapper) as? NSNumber {
-                if pos.intValue == step {
-                    throw EncodeError.cyclicObject
-                } else {
-                    findFlag = true
+                func materializedPath() -> String {
+                    if let pathText {
+                        return pathText
+                    }
+                    let value = frame.path.materialize()
+                    pathText = value
+                    return value
                 }
-            }
 
-            if next.object(forKey: SENTINEL) == nil {
-                step = 0
-            }
-            // **advance to the parent for the next iteration**
-            tmpSc = next
-        }
-
-        // Apply filter transformation FIRST, with safe adoption rules
-        if let functionFilter = filter as? FunctionFilter {
-            let transformed = functionFilter.function(keyPrefix, obj)
-            if isContainer(obj) {
-                // for containers, adopt whatever the filter returns
-                obj = transformed
-            } else {
-                // for primitives, only adopt if the filter did not return a container
-                if transformed == nil || !isContainer(transformed) {
-                    obj = transformed
+                if let containerID = containerIdentity(obj) {
+                    if activeContainers.contains(containerID) {
+                        throw EncodeError.cyclicObject
+                    }
+                    activeContainers.insert(containerID)
+                    frame.trackedContainerID = containerID
                 }
-            }
-        }
 
-        // Then do type-specific normalization
-        if let date = obj as? Date {
-            obj = serializeDate?(date) ?? Self.iso8601().string(from: date)
-        } else if isComma, let iterable = obj as? [Any] {
-            obj = iterable.map { element -> Any in
-                if let date = element as? Date {
-                    return serializeDate?(date) ?? Self.iso8601().string(from: date)
+                if let functionFilter = config.filter as? FunctionFilter {
+                    let transformed = functionFilter.function(materializedPath(), obj)
+                    // Intentional: filters may edit existing containers, but must not promote a primitive into a container.
+                    if isContainer(obj) {
+                        obj = transformed
+                    } else if transformed == nil || !isContainer(transformed) {
+                        obj = transformed
+                    }
                 }
-                return element
-            }
-        }
 
-        // Handle undefined and null cases
-        if !undefined && obj == nil {
-            if strictNullHandling {
-                if let encoder = encoder, !encodeValuesOnly {
-                    return encoder(prefix, charset, format)
-                }
-                return keyPrefix
-            }
-            obj = ""
-        }
-
-        if skipNulls, obj is NSNull {
-            // Drop direct null payloads entirely when skipNulls is enabled.
-            return []
-        }
-
-        // Special-case NSNull to match original qs.js behavior
-        if obj is NSNull {
-            if strictNullHandling {
-                // key only; encode key if an encoder is provided, otherwise leave it raw
-                if let enc = encoder, !encodeValuesOnly {
-                    return fmt.apply(enc(keyPrefix, nil, nil))
-                } else {
-                    return fmt.apply(keyPrefix)
-                }
-            } else {
-                // key with empty value
-                if let enc = encoder {
-                    let keyPart = encodeValuesOnly ? keyPrefix : enc(keyPrefix, nil, nil)
-                    let valPart = enc("", nil, nil)  // empty string
-                    return "\(fmt.apply(keyPart))=\(fmt.apply(valPart))"
-                } else {
-                    // no encoder -> no percent-encoding for the key
-                    return "\(fmt.apply(keyPrefix))="
-                }
-            }
-        }
-
-        // ---- Normalize the scalar once (unwrap Optional, collapse Optional.none to nil) ----
-        let normalizedScalar: Any? = {
-            guard let some = obj else { return nil }
-            return unwrapOptional(some) ?? some
-        }()
-
-        // Handle primitives
-        if Utils.isNonNullishPrimitive(normalizedScalar, skipNulls: skipNulls)
-            || normalizedScalar is Data
-        {
-            if let enc = encoder {
-                let keyPart = encodeValuesOnly ? keyPrefix : enc(keyPrefix, nil, nil)
-                let valPart = enc(normalizedScalar, nil, nil)  // pass unwrapped
-                return "\(fmt.apply(keyPart))=\(fmt.apply(valPart))"
-            }
-            return "\(fmt.apply(keyPrefix))=\(fmt.apply(describe(normalizedScalar, charset: charset)))"  // unwrapped
-        }
-
-        var values: [Any] = []
-
-        if undefined { return values }
-
-        var arrayView = arrayize(obj)
-
-        // Determine object keys
-        let objKeys: [Any] = {
-            if isComma, let elems0 = arrayView {
-                var elems = elems0
-
-                if commaCompactNulls {
-                    elems = elems.compactMap { element -> Any? in
-                        if element is NSNull { return nil }
-                        if isOptional(element) {
-                            guard let unwrapped = unwrapOptional(element) else { return nil }
-                            if unwrapped is NSNull { return nil }
-                            return unwrapped
+                if let date = obj as? Date {
+                    obj = config.serializeDate?(date) ?? iso8601().string(from: date)
+                } else if config.isCommaListFormat, let iterable = obj as? [Any] {
+                    obj = iterable.map { element -> Any in
+                        if let date = element as? Date {
+                            return config.serializeDate?(date) ?? iso8601().string(from: date)
                         }
                         return element
                     }
-                    arrayView = elems
-                    obj = elems
                 }
 
-                if encodeValuesOnly, let encoder = encoder {
-                    elems = elems.map { el in
-                        encoder(describeForComma(el, charset: charset), nil, nil)
+                if !frame.undefined && obj == nil {
+                    if config.strictNullHandling {
+                        if let enc = config.encoder, !config.encodeValuesOnly {
+                            finishFrame(enc(materializedPath(), config.charset, config.format))
+                        } else {
+                            finishFrame(materializedPath())
+                        }
+                        continue
                     }
-                    obj = elems
-                }
-                arrayView = arrayize(obj)
-
-                if !elems.isEmpty {
-                    let joined = elems.map { describeForComma($0, charset: charset) }.joined(
-                        separator: ",")
-                    // if strictNullHandling and joined is empty, use NSNull() to mean “no value”
-                    let valueForJoin: Any =
-                        joined.isEmpty
-                        ? (strictNullHandling ? NSNull() : "")
-                        : joined
-                    return [["value": valueForJoin] as [String: Any]]
+                    obj = ""
                 }
 
-                return [["value": Undefined.instance] as [String: Any]]
-            } else if let iterableFilter = filter as? IterableFilter {
-                return iterableFilter.iterable
-            } else {
-                let keys: [Any] = {
-                    switch obj {
-                    case let od as OrderedDictionary<String, Any>:
-                        var _keys = [String]()
-                        _keys.reserveCapacity(od.count)
-                        for (_key, _) in od { _keys.append(_key) }  // preserves insertion order
-                        if let sort = sort {
-                            _keys = _keys.sorted { sort($0, $1) < 0 }
-                        } else if depth > 0 {
-                            let split = _keys.stablePartition { key in isContainer(od[key]) }
-                            if encoder != nil {
-                                _keys[..<split].sort()
-                                _keys[split...].sort()
-                            }
-                        }
-                        return _keys
+                if config.skipNulls, obj is NSNull {
+                    finishFrame([Any]())
+                    continue
+                }
 
-                    case let dict as [String: Any]:
-                        // enumerate to preserve insertion order
-                        var _keys = [String]()
-                        _keys.reserveCapacity(dict.count)
-                        for (_key, _) in dict { _keys.append(_key) }
-                        if let sort = sort {
-                            _keys = _keys.sorted { sort($0, $1) < 0 }
-                            return _keys
+                if obj is NSNull {
+                    if config.strictNullHandling {
+                        if let enc = config.encoder, !config.encodeValuesOnly {
+                            finishFrame(config.formatter.apply(enc(materializedPath(), nil, nil)))
+                        } else {
+                            finishFrame(config.formatter.apply(materializedPath()))
                         }
-                        // At nested depths, partition: primitives first, containers later (stable)
-                        if depth > 0, encoder != nil {
-                            let split = _keys.stablePartition { key in isContainer(dict[key]) }  // containers last
-                            _keys[..<split].sort()  // primitives A..Z
-                            _keys[split...].sort()  // containers A..Z
-                        }
-                        return _keys
-
-                    case let nd as NSDictionary:
-                        var ks: [Any] = []
-                        ks.reserveCapacity(nd.count)
-                        nd.forEach { key, _ in ks.append(key) }
-
-                        if let sort = sort {
-                            ks = ks.sorted { sort($0, $1) < 0 }
-                        } else if depth > 0 {
-                            if encoder != nil {
-                                // Partition: primitives first, containers later (stable), like Swift dict.
-                                var prim: [Any] = []
-                                var cont: [Any] = []
-                                prim.reserveCapacity(ks.count)
-                                cont.reserveCapacity(ks.count)
-                                for key in ks {
-                                    let value = nd[key]
-                                    if isContainer(value) {
-                                        cont.append(key)
-                                    } else {
-                                        prim.append(key)
-                                    }
-                                }
-                                prim.sort { String(describing: $0) < String(describing: $1) }
-                                cont.sort { String(describing: $0) < String(describing: $1) }
-                                ks = prim + cont
-                            } else {
-                                // No custom encoder → match the “feel” of Swift dict literals:
-                                // sort lexicographically so "" comes before "a"
-                                ks.sort { String(describing: $0) < String(describing: $1) }
-                            }
-                        }
-                        return ks
-
-                    case _ where arrayView != nil:
-                        if let arr = arrayView {
-                            return Array(0..<arr.count)
-                        }
-                        return []
-
-                    default:
-                        return []
+                    } else if let enc = config.encoder {
+                        let keyPart = config.encodeValuesOnly ? materializedPath() : enc(materializedPath(), nil, nil)
+                        let valPart = enc("", nil, nil)
+                        finishFrame("\(config.formatter.apply(keyPart))=\(config.formatter.apply(valPart))")
+                    } else {
+                        finishFrame("\(config.formatter.apply(materializedPath()))=")
                     }
+                    continue
+                }
+
+                let normalizedScalar: Any? = {
+                    guard let some = obj else { return nil }
+                    return unwrapOptional(some) ?? some
                 }()
 
-                if let sort = sort { return keys.sorted { sort($0, $1) < 0 } }
-                return keys
-            }
-        }()
-
-        let encodedPrefix =
-            encodeDotInKeys
-            ? keyPrefix.replacingOccurrences(of: ".", with: "%2E")
-            : keyPrefix
-
-        let adjustedPrefix: String = {
-            if isComma, commaRoundTrip, let arr = arrayView, arr.count == 1 {
-                return "\(encodedPrefix)[]"
-            }
-            return encodedPrefix
-        }()
-
-        if allowEmptyLists, let arr = arrayView, arr.isEmpty {
-            return "\(adjustedPrefix)[]"
-        }
-
-        // Process each key
-        for index in 0..<objKeys.count {
-            let key = objKeys[index]
-
-            let (value, valueUndefined): (Any?, Bool) = {
-                if let keyDict = key as? [String: Any], let _value = keyDict["value"] {
-                    return (_value is Undefined ? nil : _value, _value is Undefined)
-                } else {
-                    switch obj {
-
-                    case let od as OrderedDictionary<String, Any>:
-                        if let keyString = key as? String {
-                            let value = od[keyString]
-                            let contains = od.index(forKey: keyString) != nil
-                            return (value, value == nil && !contains)
-                        }
-                        return (nil, true)
-
-                    case let dict as [String: Any]:
-                        if let keyString = key as? String {
-                            let value = dict[keyString].flatMap { unwrapOptional($0) } ?? dict[keyString]
-                            return (value, value == nil && !dict.keys.contains(keyString))
-                        }
-                        return (nil, true)
-
-                    case let nd as NSDictionary:
-                        let value = nd[key]
-                        // NSDictionary can’t store nil; nil here means “absent”
-                        return (value, value == nil)
-
-                    default:
-                        if let arr = arrayView, let idx = key as? Int, idx >= 0, idx < arr.count {
-                            return (arr[idx], false)
-                        }
-                        return (nil, true)
+                if Utils.isNonNullishPrimitive(normalizedScalar, skipNulls: config.skipNulls)
+                    || normalizedScalar is Data
+                {
+                    if let enc = config.encoder {
+                        let keyPart = config.encodeValuesOnly ? materializedPath() : enc(materializedPath(), nil, nil)
+                        let valPart = enc(normalizedScalar, nil, nil)
+                        finishFrame("\(config.formatter.apply(keyPart))=\(config.formatter.apply(valPart))")
+                    } else {
+                        finishFrame(
+                            "\(config.formatter.apply(materializedPath()))=\(config.formatter.apply(describe(normalizedScalar, charset: config.charset)))"
+                        )
                     }
+                    continue
                 }
-            }()
 
-            if skipNulls && (value == nil || value is NSNull) {
-                continue
-            }
+                if frame.undefined {
+                    finishFrame([Any]())
+                    continue
+                }
 
-            let rawKey = String(describing: key)
-            let encodedKey: String = {
-                if allowDots && encodeDotInKeys {
-                    return rawKey.replacingOccurrences(of: ".", with: "%2E")
+                var seqList = arrayize(obj)
+                var commaEffectiveLength: Int?
+                let nextKeyState: EncodeKeyState
+
+                if config.isCommaListFormat, var elements = seqList {
+                    if config.commaCompactNulls {
+                        elements = elements.compactMap { element in
+                            if element is NSNull {
+                                return nil
+                            }
+                            if isOptional(element) {
+                                guard let unwrapped = unwrapOptional(element) else {
+                                    return nil
+                                }
+                                if unwrapped is NSNull {
+                                    return nil
+                                }
+                                return unwrapped
+                            }
+                            return element
+                        }
+                        seqList = elements
+                        obj = elements
+                    }
+
+                    if config.encodeValuesOnly, let enc = config.encoder {
+                        elements = elements.map { value in
+                            enc(describeForComma(value, charset: config.charset), nil, nil)
+                        }
+                        seqList = elements
+                        obj = elements
+                    }
+
+                    commaEffectiveLength = elements.count
+
+                    if !elements.isEmpty {
+                        let joined = elements.map { describeForComma($0, charset: config.charset) }.joined(
+                            separator: ",")
+                        let valueForJoin: Any = joined.isEmpty ? (config.strictNullHandling ? NSNull() : "") : joined
+                        nextKeyState = .single(["value": valueForJoin])
+                    } else {
+                        nextKeyState = .single(["value": Undefined.instance])
+                    }
+                } else if let iterableFilter = config.filter as? IterableFilter {
+                    nextKeyState = keyState(from: iterableFilter.iterable)
                 } else {
+                    nextKeyState = objectKeyState(for: obj, seqList: seqList, config: config, depth: frame.depth)
+                }
+
+                let pathForChildren = config.encodeDotInKeys ? frame.path.asDotEncoded() : frame.path
+                let shouldAppendRoundTripMarker =
+                    config.commaRoundTrip
+                    && seqList != nil
+                    && (config.isCommaListFormat && commaEffectiveLength != nil
+                        ? commaEffectiveLength == 1
+                        : (seqList?.count == 1))
+                let adjustedPath = shouldAppendRoundTripMarker ? pathForChildren.append("[]") : pathForChildren
+
+                if config.allowEmptyLists, let seqList, seqList.isEmpty {
+                    finishFrame(adjustedPath.append("[]").materialize())
+                    continue
+                }
+
+                frame.object = obj
+                frame.keyState = nextKeyState
+                frame.index = 0
+                frame.seqList = seqList
+                frame.commaEffectiveLength = commaEffectiveLength
+                frame.adjustedPath = adjustedPath
+                frame.phase = .iterate
+
+            case .iterate:
+                let key: Any
+                switch frame.keyState {
+                case .none:
+                    finishFrame(frame.values.asArray())
+                    continue
+                case .single(let only):
+                    if frame.index > 0 {
+                        finishFrame(frame.values.asArray())
+                        continue
+                    }
+                    key = only
+                    frame.index = 1
+                case .many(let keys):
+                    if frame.index >= keys.count {
+                        finishFrame(frame.values.asArray())
+                        continue
+                    }
+                    key = keys[frame.index]
+                    frame.index += 1
+                }
+
+                let value: Any?
+                let valueUndefined: Bool
+
+                if let keyDict = key as? [String: Any], let keyValue = keyDict["value"], !(keyValue is Undefined) {
+                    value = keyValue
+                    valueUndefined = false
+                } else {
+                    (value, valueUndefined) = resolveValue(from: frame.object, seqList: frame.seqList, key: key)
+                }
+
+                if config.skipNulls && (value == nil || value is NSNull) {
+                    continue
+                }
+
+                let rawKey: String
+                if let stringKey = key as? String {
+                    rawKey = stringKey
+                } else if let intKey = key as? Int {
+                    rawKey = String(intKey)
+                } else {
+                    rawKey = String(describing: key)
+                }
+                let encodedKey: String = {
+                    if config.allowDots && config.encodeDotInKeys {
+                        return rawKey.replacingOccurrences(of: ".", with: "%2E")
+                    }
                     return rawKey
+                }()
+
+                let isCommaSentinel = (key as? [String: Any])?.keys.contains("value") == true
+                guard let adjustedPath = frame.adjustedPath else {
+                    preconditionFailure(
+                        "Invariant violation: EncodeFrame.adjustedPath must be set before .iterate phase")
                 }
-            }()
 
-            let keyPrefix: String = {
-                if arrayView != nil {
-                    return generator(adjustedPrefix, encodedKey)
+                let childPath: KeyPathNode
+                if isCommaSentinel && config.isCommaListFormat {
+                    childPath = adjustedPath
+                } else if frame.seqList != nil {
+                    if !config.hasCustomGenerator {
+                        switch config.listFormat {
+                        case .indices:
+                            childPath = adjustedPath.append(bracketSegment(for: encodedKey))
+                        case .brackets:
+                            childPath = adjustedPath.append("[]")
+                        case .repeatKey, .comma:
+                            childPath = adjustedPath
+                        }
+                    } else {
+                        childPath = KeyPathNode.fromMaterialized(
+                            config.generateArrayPrefix(adjustedPath.materialize(), encodedKey))
+                    }
+                } else if config.allowDots {
+                    childPath = adjustedPath.append(dotSegment(for: encodedKey))
+                } else {
+                    childPath = adjustedPath.append(bracketSegment(for: encodedKey))
                 }
-                return allowDots
-                    ? "\(encodedPrefix).\(encodedKey)"
-                    : "\(encodedPrefix)[\(encodedKey)]"
-            }()
 
-            // Record the current container for cycle detection
-            if let objWrapper = objWrapper, isContainer(obj) {
-                sideChannel.setObject(NSNumber(value: step), forKey: objWrapper)
-            }
+                let childEncoder: ValueEncoder?
+                if config.isCommaListFormat && config.encodeValuesOnly && frame.seqList != nil {
+                    childEncoder = nil
+                } else {
+                    childEncoder = config.encoder
+                }
 
-            // Create child side-channel and link to parent
-            // Link child → parent so ancestor walk can detect cycles via SENTINEL chain.
-            let valueSideChannel = NSMapTable<AnyObject, AnyObject>.weakToWeakObjects()
-            valueSideChannel.setObject(sideChannel, forKey: SENTINEL)
+                frame.phase = .awaitChild
+                stack.append(
+                    EncodeFrame(
+                        object: value,
+                        undefined: valueUndefined,
+                        path: childPath,
+                        config: config.withEncoder(childEncoder),
+                        depth: frame.depth + 1
+                    )
+                )
 
-            let encoded: Any = try encode(
-                data: value,
-                undefined: valueUndefined,
-                sideChannel: valueSideChannel,
-                prefix: keyPrefix,
-                generateArrayPrefix: generator,
-                listFormat: listFormat,
-                commaRoundTrip: commaRoundTripEffective,
-                commaCompactNulls: commaCompactNulls,
-                allowEmptyLists: allowEmptyLists,
-                strictNullHandling: strictNullHandling,
-                skipNulls: skipNulls,
-                encodeDotInKeys: encodeDotInKeys,
-                encoder: (isComma && encodeValuesOnly && obj is [Any]) ? nil : encoder,
-                serializeDate: serializeDate,
-                sort: sort,
-                filter: filter,
-                allowDots: allowDots,
-                format: format,
-                formatter: fmt,
-                encodeValuesOnly: encodeValuesOnly,
-                charset: charset,
-                addQueryPrefix: addQueryPrefix,
-                depth: depth + 1
-            )
+            case .awaitChild:
+                if case .single = frame.keyState {
+                    if let encodedList = lastResult as? [Any] {
+                        finishFrame(encodedList)
+                    } else if let encoded = lastResult {
+                        finishFrame([encoded])
+                    } else {
+                        finishFrame([Any]())
+                    }
+                    continue
+                }
 
-            if let encodedArray = encoded as? [Any] {
-                values.append(contentsOf: encodedArray)
-            } else {
-                values.append(encoded)
+                if let encodedList = lastResult as? [Any] {
+                    frame.values.append(contentsOf: encodedList)
+                } else if let encoded = lastResult {
+                    frame.values.append(encoded)
+                }
+                frame.phase = .iterate
             }
         }
 
-        return values
+        return lastResult ?? [Any]()
     }
 }
 
 extension QsSwift.Encoder {
     // MARK: - Helpers
 
-    /// Use a dedicated class marked @unchecked Sendable to satisfy concurrency checks.
-    private final class Sentinel: NSObject, @unchecked Sendable {}
-
-    /// Top-level unique token for cycle detection
-    private static let SENTINEL = Sentinel()
-    private static let iterativeFallbackDepth = 256
-
-    // swiftlint:disable:next function_parameter_count
-    private static func canUseIterativeDeepFallback(
-        listFormat: ListFormat,
-        commaRoundTrip: Bool,
-        commaCompactNulls: Bool,
-        allowEmptyLists: Bool,
-        strictNullHandling: Bool,
-        skipNulls: Bool,
-        encodeDotInKeys: Bool,
-        sort: Sorter?,
-        filter: Filter?,
-        allowDots: Bool,
-        encodeValuesOnly: Bool
-    ) -> Bool {
-        listFormat == .indices
-            && !commaRoundTrip
-            && !commaCompactNulls
-            && !allowEmptyLists
-            && !strictNullHandling
-            && !skipNulls
-            && !encodeDotInKeys
-            && sort == nil
-            && filter == nil
-            && !allowDots
-            && !encodeValuesOnly
-    }
-
-    private struct IterativeNode {
-        let value: Any?
-        let undefined: Bool
-        let prefix: String
-        let depth: Int
-    }
-
-    private enum IterativeTask {
-        case visit(IterativeNode)
-        case leaveContainer(ObjectIdentifier)
-    }
-
-    // swiftlint:disable:next function_parameter_count
-    private static func encodeIterativeDeepFallback(
+    private static func encodeLinearChainIfEligible(
         data: Any?,
         undefined: Bool,
         prefix: String,
-        depth: Int,
-        generator: ListFormatGenerator,
-        encoder: ValueEncoder?,
-        serializeDate: DateSerializer?,
-        formatter: Formatter,
-        charset: String.Encoding
-    ) throws -> Any {
-        if undefined { return [Any]() }
+        config: EncodeConfig
+    ) throws -> String? {
+        guard !undefined else { return nil }
+        guard config.encoder == nil else { return nil }
+        guard config.sort == nil else { return nil }
+        guard config.filter == nil else { return nil }
+        guard !config.allowDots, !config.encodeDotInKeys else { return nil }
+        guard !config.isCommaListFormat else { return nil }
+        guard !config.commaRoundTrip, !config.commaCompactNulls else { return nil }
+        guard !config.allowEmptyLists else { return nil }
+        guard !config.strictNullHandling else { return nil }
+        guard !config.skipNulls else { return nil }
+        guard !config.encodeValuesOnly else { return nil }
+        guard !config.hasCustomGenerator else { return nil }
+        guard config.listFormat == .indices else { return nil }
 
-        var stack: [IterativeTask] = [
-            .visit(.init(value: data, undefined: undefined, prefix: prefix, depth: depth))
-        ]
-        var values: [Any] = []
-        values.reserveCapacity(32)
-        var activeContainers: Set<ObjectIdentifier> = []
+        var current: Any? = data
+        var path = prefix
+        var seen = Set<ObjectIdentifier>()
 
-        while let task = stack.popLast() {
-            if case .leaveContainer(let containerID) = task {
-                activeContainers.remove(containerID)
-                continue
+        while true {
+            if current == nil {
+                return "\(config.formatter.apply(path))="
             }
-
-            guard case .visit(let node) = task else { continue }
-
-            var current = node.value
 
             if let date = current as? Date {
-                current = serializeDate?(date) ?? iso8601().string(from: date)
-            }
-
-            if !node.undefined && current == nil {
-                current = ""
-            }
-
-            if let containerID = containerIdentity(current) {
-                if activeContainers.contains(containerID) {
-                    throw EncodeError.cyclicObject
-                }
-                activeContainers.insert(containerID)
-                stack.append(.leaveContainer(containerID))
-            }
-
-            if current is NSNull {
-                if let enc = encoder {
-                    let keyPart = enc(node.prefix, nil, nil)
-                    let valPart = enc("", nil, nil)
-                    values.append("\(formatter.apply(keyPart))=\(formatter.apply(valPart))")
-                } else {
-                    values.append("\(formatter.apply(node.prefix))=")
-                }
+                current = config.serializeDate?(date) ?? iso8601().string(from: date)
                 continue
             }
 
-            let normalizedScalar: Any? = {
-                guard let some = current else { return nil }
-                return unwrapOptional(some) ?? some
-            }()
-
-            if Utils.isNonNullishPrimitive(normalizedScalar) || normalizedScalar is Data {
-                if let enc = encoder {
-                    let keyPart = enc(node.prefix, nil, nil)
-                    let valPart = enc(normalizedScalar, nil, nil)
-                    values.append("\(formatter.apply(keyPart))=\(formatter.apply(valPart))")
-                } else {
-                    values.append(
-                        "\(formatter.apply(node.prefix))=\(formatter.apply(describe(normalizedScalar, charset: charset)))"
-                    )
+            if let object = current, type(of: object) is AnyClass {
+                if object is NSNull {
+                    return "\(config.formatter.apply(path))="
                 }
-                continue
+
+                if let dict = object as? NSDictionary {
+                    let id = ObjectIdentifier(dict)
+                    if seen.contains(id) {
+                        throw EncodeError.cyclicObject
+                    }
+                    seen.insert(id)
+
+                    guard dict.count == 1 else { return nil }
+                    guard let key = dict.allKeys.first else { return nil }
+                    path.append("[")
+                    path.append(String(describing: key))
+                    path.append("]")
+                    current = dict[key]
+                    continue
+                }
             }
 
-            if let arr = arrayize(current) {
-                if arr.isEmpty { continue }
-                for idx in stride(from: arr.count - 1, through: 0, by: -1) {
-                    let childPrefix = generator(node.prefix, String(idx))
-                    stack.append(
-                        .visit(
-                            .init(
-                                value: arr[idx],
-                                undefined: false,
-                                prefix: childPrefix,
-                                depth: node.depth + 1
-                            )))
+            switch current {
+            case let map as [String: Any]:
+                guard map.count == 1, let (key, next) = map.first else { return nil }
+                path.append("[")
+                path.append(key)
+                path.append("]")
+                current = next
+
+            case let ordered as OrderedDictionary<String, Any>:
+                guard ordered.count == 1, let key = ordered.keys.first, let next = ordered[key] else {
+                    return nil
                 }
-                continue
-            }
+                path.append("[")
+                path.append(key)
+                path.append("]")
+                current = next
 
-            let entries = orderedEntriesForIterativeFallback(
-                current: current,
-                depth: node.depth,
-                hasEncoder: (encoder != nil)
-            )
+            default:
+                let normalizedScalar: Any? = {
+                    guard let some = current else { return nil }
+                    return unwrapOptional(some) ?? some
+                }()
 
-            for (key, child) in entries.reversed() {
-                let childPrefix = "\(node.prefix)[\(key)]"
-                stack.append(
-                    .visit(
-                        .init(
-                            value: child,
-                            undefined: false,
-                            prefix: childPrefix,
-                            depth: node.depth + 1
-                        )))
+                if Utils.isNonNullishPrimitive(normalizedScalar) || normalizedScalar is Data {
+                    return
+                        "\(config.formatter.apply(path))=\(config.formatter.apply(describe(normalizedScalar, charset: config.charset)))"
+                }
+
+                return nil
             }
         }
-
-        return values
     }
 
     @inline(__always)
-    private static func containerIdentity(_ value: Any?) -> ObjectIdentifier? {
-        guard let value else { return nil }
-
-        // Only track real class-backed containers. Swift value containers can bridge to
-        // transient Foundation wrappers whose object identity is not stable.
-        guard type(of: value) is AnyClass else { return nil }
-
-        if let array = value as? NSArray {
-            return ObjectIdentifier(array)
+    private static func keyState(from keys: [Any]) -> EncodeKeyState {
+        switch keys.count {
+        case 0:
+            return .none
+        case 1:
+            return .single(keys[0])
+        default:
+            return .many(keys)
         }
-        if let dictionary = value as? NSDictionary {
-            return ObjectIdentifier(dictionary)
-        }
-        return nil
     }
 
-    private static func orderedEntriesForIterativeFallback(
-        current: Any?,
-        depth: Int,
-        hasEncoder: Bool
-    ) -> [(String, Any)] {
-        switch current {
-        case let od as OrderedDictionary<String, Any>:
-            var keys = Array(od.keys)
-            if depth > 0 {
-                let split = keys.stablePartition { key in isContainer(od[key]) }
-                if hasEncoder {
-                    keys[..<split].sort()
-                    keys[split...].sort()
-                }
+    private static func resolveValue(from object: Any?, seqList: [Any]?, key: Any) -> (Any?, Bool) {
+        if let seqList {
+            guard let idx = key as? Int, idx >= 0, idx < seqList.count else {
+                return (nil, true)
             }
-            return keys.compactMap { key in od[key].map { (key, $0) } }
+            return (seqList[idx], false)
+        }
+
+        switch object {
+        case let od as OrderedDictionary<String, Any>:
+            guard let keyString = key as? String else {
+                return (nil, true)
+            }
+            guard let raw = od[keyString] else {
+                return (nil, true)
+            }
+            return (unwrapOptional(raw) ?? raw, false)
 
         case let dict as [String: Any]:
-            var keys = [String]()
-            keys.reserveCapacity(dict.count)
-            for (key, _) in dict { keys.append(key) }
-            if depth > 0, hasEncoder {
-                let split = keys.stablePartition { key in isContainer(dict[key]) }
-                keys[..<split].sort()
-                keys[split...].sort()
+            guard let keyString = key as? String else {
+                return (nil, true)
             }
-            return keys.compactMap { key in dict[key].map { (key, $0) } }
+            guard let raw = dict[keyString] else {
+                return (nil, true)
+            }
+            return (unwrapOptional(raw) ?? raw, false)
 
         case let nd as NSDictionary:
-            var keys: [Any] = []
-            keys.reserveCapacity(nd.count)
-            nd.forEach { key, _ in keys.append(key) }
-
-            if depth > 0 {
-                if hasEncoder {
-                    var prim: [Any] = []
-                    var cont: [Any] = []
-                    prim.reserveCapacity(keys.count)
-                    cont.reserveCapacity(keys.count)
-                    for key in keys {
-                        let value = nd[key]
-                        if isContainer(value) {
-                            cont.append(key)
-                        } else {
-                            prim.append(key)
-                        }
-                    }
-                    prim.sort { String(describing: $0) < String(describing: $1) }
-                    cont.sort { String(describing: $0) < String(describing: $1) }
-                    keys = prim + cont
-                } else {
-                    keys.sort { String(describing: $0) < String(describing: $1) }
-                }
-            }
-
-            var out: [(String, Any)] = []
-            out.reserveCapacity(keys.count)
-            for key in keys {
-                if let value = nd[key] {
-                    out.append((String(describing: key), value))
-                }
-            }
-            return out
+            let value = nd[key]
+            return (value, value == nil)
 
         default:
-            return []
+            return (nil, true)
         }
+    }
+
+    private static func objectKeyState(
+        for object: Any?,
+        seqList: [Any]?,
+        config: EncodeConfig,
+        depth: Int
+    ) -> EncodeKeyState {
+        if let seqList {
+            switch seqList.count {
+            case 0:
+                return .none
+            case 1:
+                return .single(0)
+            default:
+                return .many(Array(0..<seqList.count))
+            }
+        }
+
+        switch object {
+        case let od as OrderedDictionary<String, Any>:
+            switch od.count {
+            case 0:
+                return .none
+            case 1:
+                guard let firstKey = od.keys.first else { return .none }
+                return .single(firstKey)
+            default:
+                var result = Array(od.keys)
+                if config.sort == nil, depth > 0 {
+                    result = partitionPrimitiveKeysFirst(result, sortGroups: config.encoder != nil) { key in
+                        isContainer(od[key])
+                    }
+                }
+
+                if let sort = config.sort {
+                    result = result.sorted { first, second in sort(first, second) < 0 }
+                }
+
+                return .many(result.map { $0 })
+            }
+
+        case let dict as [String: Any]:
+            switch dict.count {
+            case 0:
+                return .none
+            case 1:
+                guard let firstKey = dict.keys.first else { return .none }
+                return .single(firstKey)
+            default:
+                var result = [String]()
+                result.reserveCapacity(dict.count)
+                for (key, _) in dict {
+                    result.append(key)
+                }
+
+                if config.sort == nil, depth > 0, config.encoder != nil {
+                    result = partitionPrimitiveKeysFirst(result) { key in
+                        isContainer(dict[key])
+                    }
+                }
+
+                if let sort = config.sort {
+                    result = result.sorted { first, second in sort(first, second) < 0 }
+                }
+
+                return .many(result.map { $0 })
+            }
+
+        case let nd as NSDictionary:
+            switch nd.count {
+            case 0:
+                return .none
+            case 1:
+                guard let key = nd.allKeys.first else { return .none }
+                return .single(key)
+            default:
+                var result: [Any] = []
+                result.reserveCapacity(nd.count)
+                nd.forEach { key, _ in result.append(key) }
+
+                if config.sort == nil, depth > 0 {
+                    if config.encoder != nil {
+                        result = partitionPrimitiveKeysFirst(result) { key in
+                            isContainer(nd[key])
+                        }
+                    } else {
+                        result.sort { String(describing: $0) < String(describing: $1) }
+                    }
+                }
+
+                if let sort = config.sort {
+                    result = result.sorted { first, second in sort(first, second) < 0 }
+                }
+
+                return keyState(from: result)
+            }
+
+        default:
+            return .none
+        }
+    }
+
+    private static func partitionPrimitiveKeysFirst<T>(
+        _ keys: [T],
+        sortGroups: Bool = true,
+        isContainer: (T) -> Bool
+    ) -> [T] {
+        var primitive: [T] = []
+        var containers: [T] = []
+        primitive.reserveCapacity(keys.count)
+
+        for key in keys {
+            if isContainer(key) {
+                containers.append(key)
+            } else {
+                primitive.append(key)
+            }
+        }
+
+        if sortGroups {
+            primitive.sort { String(describing: $0) < String(describing: $1) }
+            containers.sort { String(describing: $0) < String(describing: $1) }
+        }
+
+        return primitive + containers
     }
 
     /// Unwraps an optional value, returning nil if the value is nil or an empty optional.
@@ -740,7 +707,7 @@ extension QsSwift.Encoder {
     @inline(__always)
     private static func describe(_ any: Any?, charset: String.Encoding) -> String {
         guard let any = any else { return "" }
-        if isOptional(any), unwrapOptional(any) == nil { return "" }  // Optional.none
+        if isOptional(any), unwrapOptional(any) == nil { return "" }
         let materialized = unwrapOptional(any) ?? any
         if let data = materialized as? Data {
             return describeData(data, charset: charset)
@@ -761,7 +728,7 @@ extension QsSwift.Encoder {
     private static func describeForComma(_ any: Any?, charset: String.Encoding) -> String {
         guard let any = any else { return "" }
         if any is NSNull { return "" }
-        if isOptional(any), unwrapOptional(any) == nil { return "" }  // Optional.none
+        if isOptional(any), unwrapOptional(any) == nil { return "" }
         let materialized = unwrapOptional(any) ?? any
         if materialized is NSNull { return "" }
         if let data = materialized as? Data {
@@ -776,11 +743,27 @@ extension QsSwift.Encoder {
             return decoded
         }
         if charset == .utf8 {
-            // Keep payload visible for malformed UTF-8 instead of collapsing to empty.
+            // Preserve permissive UTF-8 fallback by replacing invalid byte sequences.
             // swiftlint:disable:next optional_data_string_conversion
             return String(decoding: data, as: UTF8.self)
         }
         return String(describing: data)
+    }
+
+    @inline(__always)
+    private static func containerIdentity(_ value: Any?) -> ObjectIdentifier? {
+        guard let value else { return nil }
+        // Swift value containers bridge through transient Foundation wrappers whose
+        // object identity is not stable. Track only class-backed containers.
+        guard type(of: value) is AnyClass else { return nil }
+
+        if let list = value as? NSArray {
+            return ObjectIdentifier(list)
+        }
+        if let dict = value as? NSDictionary {
+            return ObjectIdentifier(dict)
+        }
+        return nil
     }
 
     /// Checks if the value is a container (array, dictionary, etc.).

--- a/Sources/QsSwift/Internal/KeyPathNode.swift
+++ b/Sources/QsSwift/Internal/KeyPathNode.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Linked-node representation of an encoder key path.
+///
+/// Nodes are structurally immutable; cached views are memoized for fast reuse
+/// during iterative traversal.
+internal final class KeyPathNode {
+    private let parent: KeyPathNode?
+    private let segment: String
+    private let depth: Int
+    private let totalLength: Int
+
+    private var dotEncoded: KeyPathNode?
+    private var dotEncodedIsSelf = false
+    private var materialized: String?
+
+    private init(parent: KeyPathNode?, segment: String) {
+        self.parent = parent
+        self.segment = segment
+        self.depth = (parent?.depth ?? 0) + 1
+        self.totalLength = (parent?.totalLength ?? 0) + segment.count
+    }
+
+    static func fromMaterialized(_ value: String) -> KeyPathNode {
+        KeyPathNode(parent: nil, segment: value)
+    }
+
+    func append(_ value: String) -> KeyPathNode {
+        value.isEmpty ? self : KeyPathNode(parent: self, segment: value)
+    }
+
+    func asDotEncoded() -> KeyPathNode {
+        if dotEncodedIsSelf {
+            return self
+        }
+
+        if let dotEncoded {
+            return dotEncoded
+        }
+
+        let encodedSegment = Self.replaceDots(in: segment)
+
+        let encoded: KeyPathNode
+        if let parent {
+            let encodedParent = parent.asDotEncoded()
+            if encodedParent === parent && encodedSegment == segment {
+                encoded = self
+            } else {
+                encoded = KeyPathNode(parent: encodedParent, segment: encodedSegment)
+            }
+        } else if encodedSegment == segment {
+            encoded = self
+        } else {
+            encoded = KeyPathNode(parent: nil, segment: encodedSegment)
+        }
+
+        if encoded === self {
+            dotEncodedIsSelf = true
+        } else {
+            dotEncoded = encoded
+        }
+        return encoded
+    }
+
+    func materialize() -> String {
+        if let materialized {
+            return materialized
+        }
+
+        if parent == nil {
+            materialized = segment
+            return segment
+        }
+
+        if depth == 2, let parent {
+            let value = parent.segment + segment
+            materialized = value
+            return value
+        }
+
+        var parts = Array(repeating: "", count: depth)
+        var index = depth - 1
+        var node: KeyPathNode? = self
+        while let current = node {
+            parts[index] = current.segment
+            index -= 1
+            node = current.parent
+        }
+
+        var out = String()
+        out.reserveCapacity(totalLength)
+        for part in parts {
+            out.append(part)
+        }
+
+        materialized = out
+        return out
+    }
+
+    private static func replaceDots(in value: String) -> String {
+        value.contains(".") ? value.replacingOccurrences(of: ".", with: "%2E") : value
+    }
+}

--- a/Tests/QsObjCTests/ObjCEncodePerformanceGuardrailTests.swift
+++ b/Tests/QsObjCTests/ObjCEncodePerformanceGuardrailTests.swift
@@ -1,0 +1,50 @@
+#if canImport(ObjectiveC) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    import Foundation
+    import QsTestSupport
+    import Testing
+
+    struct ObjCEncodePerformanceGuardrailTests {
+        @Test("perf guardrail (opt-in): ObjC bridge deep encode snapshot")
+        func perfGuardrail_objcDeepEncode() throws {
+            guard perfGuardrailsEnabled(extraFlag: "QS_ENABLE_OBJC_PERF_GUARDRAILS") else { return }
+
+            let root = repoRootURL()
+            _ = try runCommand(
+                "/usr/bin/env",
+                args: ["swift", "build", "-c", "release", "--package-path", "Bench", "-q"],
+                cwd: root,
+                errorDomain: "ObjCEncodePerformanceGuardrailTests",
+                tempPrefix: "qsobjc-perf"
+            )
+
+            let benchOutput = try runCommand(
+                root.appendingPathComponent("Bench/.build/release/QsSwiftBench").path,
+                args: ["perf"],
+                cwd: root,
+                errorDomain: "ObjCEncodePerformanceGuardrailTests",
+                tempPrefix: "qsobjc-perf"
+            )
+            let measured = try parseBenchOutput(benchOutput)
+
+            let baseline = try loadBaseline(runtime: "objc", root: root)
+            let tolerance = perfTolerancePct() / 100.0
+
+            for depth in deepEncodePerfCases {
+                guard let baselineMs = baseline[depth] else {
+                    Issue.record("Missing ObjC perf baseline for depth=\(depth)")
+                    continue
+                }
+                guard let measuredMs = measured[BenchCaseKey(runtime: "objc", depth: depth)] else {
+                    Issue.record("Missing ObjC perf measurement for depth=\(depth)")
+                    continue
+                }
+
+                let allowedMs = baselineMs * (1.0 + tolerance)
+                #expect(
+                    measuredMs <= allowedMs,
+                    "ObjC perf guardrail failed at depth=\(depth): measuredMs=\(measuredMs), baselineMs=\(baselineMs), tolerance=\(tolerance), allowedMs=\(allowedMs)"
+                )
+            }
+        }
+    }
+#endif

--- a/Tests/QsSwiftTests/EncodePerformanceGuardrailTests.swift
+++ b/Tests/QsSwiftTests/EncodePerformanceGuardrailTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import QsTestSupport
+
+#if canImport(Testing)
+    import Testing
+#else
+    #error("The swift-testing package is required to build tests on Swift 5.x")
+#endif
+
+struct EncodePerformanceGuardrailTests {
+    @Test(
+        "perf guardrail (opt-in): Swift deep encode snapshot",
+        .timeLimit(.minutes(10)),
+        .enabled(
+            if: perfGuardrailsEnabled(extraFlag: "QS_ENABLE_SWIFT_PERF_GUARDRAILS"),
+            "Perf guardrails not enabled — skipping")
+    )
+    func perfGuardrail_swiftDeepEncode() throws {
+        let root = repoRootURL()
+        _ = try runCommand(
+            "/usr/bin/env",
+            args: ["swift", "build", "-c", "release", "--package-path", "Bench", "-q"],
+            cwd: root,
+            errorDomain: "EncodePerformanceGuardrailTests",
+            tempPrefix: "qsswift-perf"
+        )
+
+        let benchOutput = try runCommand(
+            root.appendingPathComponent("Bench/.build/release/QsSwiftBench").path,
+            args: ["perf"],
+            cwd: root,
+            errorDomain: "EncodePerformanceGuardrailTests",
+            tempPrefix: "qsswift-perf"
+        )
+        let measured = try parseBenchOutput(benchOutput)
+
+        let baseline = try loadBaseline(runtime: "swift", root: root)
+        let tolerance = perfTolerancePct() / 100.0
+
+        for depth in deepEncodePerfCases {
+            guard let baselineMs = baseline[depth] else {
+                Issue.record("Missing Swift perf baseline for depth=\(depth)")
+                continue
+            }
+            guard let measuredMs = measured[BenchCaseKey(runtime: "swift", depth: depth)] else {
+                Issue.record("Missing Swift perf measurement for depth=\(depth)")
+                continue
+            }
+
+            let allowedMs = baselineMs * (1.0 + tolerance)
+            #expect(
+                measuredMs <= allowedMs,
+                "Swift perf guardrail failed at depth=\(depth): measuredMs=\(measuredMs), allowedMs=\(allowedMs), baselineMs=\(baselineMs)"
+            )
+        }
+    }
+}

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -4538,6 +4538,42 @@ struct EncodeTests {
                 Issue.record("Unexpected type for comma round-trip branch: \(String(describing: result))")
             }
         }
+
+        @Test("Encoder.encode ignores commaRoundTrip when list format is not comma")
+        func encoder_nonCommaFormat_doesNotAppendRoundTripMarker() throws {
+            let sideChannel = NSMapTable<AnyObject, AnyObject>.strongToStrongObjects()
+            let result = try Encoder.encode(
+                data: ["only"],
+                undefined: false,
+                sideChannel: sideChannel,
+                prefix: "flags",
+                listFormat: .indices,
+                commaRoundTrip: true,
+                allowEmptyLists: false,
+                strictNullHandling: false,
+                skipNulls: false,
+                encodeDotInKeys: false,
+                encoder: nil,
+                serializeDate: nil,
+                sort: nil,
+                filter: nil,
+                allowDots: false,
+                format: .rfc3986,
+                formatter: nil,
+                encodeValuesOnly: false,
+                charset: .utf8,
+                addQueryPrefix: false,
+                depth: 0
+            )
+
+            if let string = result as? String {
+                #expect(string == "flags[0]=only")
+            } else if let parts = result as? [Any], let first = parts.first as? String {
+                #expect(first == "flags[0]=only")
+            } else {
+                Issue.record("Unexpected type for non-comma round-trip branch: \(String(describing: result))")
+            }
+        }
     #endif
 }
 

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -1510,6 +1510,19 @@ struct EncodeTests {
         )
     }
 
+    @Test("encode - IterableFilter keeps array indices type-strict")
+    func encode_iterableFilterArrayIndicesAreTypeStrict() async throws {
+        let result = try Qs.encode(
+            ["a": [1, 2, 3]],
+            options: EncodeOptions(
+                encode: false,
+                filter: IterableFilter(["a", "0", 2])
+            )
+        )
+
+        #expect(result == "a[2]=3")
+    }
+
     @Test("encode - supports custom representations when filter = FunctionFilter")
     func testFunctionFilterCustomRepresentations() async throws {
         var calls = 0
@@ -3055,6 +3068,24 @@ struct EncodeTests {
         #expect(out == "child[aPrim]=1&child[bPrim]=2&child[zContainer][k]=v")
     }
 
+    @Test(
+        "encode: OrderedDictionary<String,Any> nested depth partitions primitives before containers with encoder=nil (stable)"
+    )
+    func sort_orderedDict_string_keys_nestedPartition_encoderNilStable() throws {
+        let child: OrderedDictionary<String, Any> = [
+            "zContainer": ["k": "v"],
+            "bPrim": "2",
+            "aPrim": "1",
+            "yContainer": ["m": "n"],
+        ]
+        let root: OrderedDictionary<String, Any> = [
+            "child": child
+        ]
+
+        let out = try Qs.encode(root, options: .init(encode: false))
+        #expect(out == "child[bPrim]=2&child[aPrim]=1&child[zContainer][k]=v&child[yContainer][m]=n")
+    }
+
     @Test("encode: .comma + empty list returns no pairs (Undefined sentinel path)")
     func comma_empty_returns_no_pairs() throws {
         let opts = EncodeOptions(listFormat: .comma)
@@ -4000,7 +4031,7 @@ struct EncodeTests {
             addQueryPrefix: false,
             depth: 512
         )
-        #expect((nilResult as? [Any])?.map { String(describing: $0) } == ["a="])
+        #expect(nilResult as? String == "a=")
 
         let nullResult = try Encoder.encode(
             data: NSNull(),
@@ -4025,7 +4056,7 @@ struct EncodeTests {
             addQueryPrefix: false,
             depth: 512
         )
-        #expect((nullResult as? [Any])?.map { String(describing: $0) } == ["a="])
+        #expect(nullResult as? String == "a=")
     }
 
     @Test("Encoder.encode deep fallback NSNull path uses custom encoder")
@@ -4060,7 +4091,7 @@ struct EncodeTests {
             addQueryPrefix: false,
             depth: 512
         )
-        #expect((result as? [Any])?.map { String(describing: $0) } == ["k_a=k_"])
+        #expect(result as? String == "k_a=k_")
     }
 
     @Test("Encoder.encode deep fallback tracks NSArray roots for cycle identity")
@@ -4262,7 +4293,7 @@ struct EncodeTests {
             addQueryPrefix: false,
             depth: 512
         )
-        let dateString = (dateResult as? [Any])?.first as? String
+        let dateString = dateResult as? String
         #expect(dateString == "a=1970-01-01T00:00:00.000Z")
 
         let custom: ValueEncoder = { value, _, _ in
@@ -4291,7 +4322,7 @@ struct EncodeTests {
             addQueryPrefix: false,
             depth: 512
         )
-        #expect((customResult as? [Any])?.map { String(describing: $0) } == ["[a]=[7]"])
+        #expect(customResult as? String == "[a]=[7]")
     }
 
     @Test("Encoder.encode nested NSDictionary branch partitions primitive and container keys")

--- a/Tests/QsSwiftTests/EncoderInternalsTests.swift
+++ b/Tests/QsSwiftTests/EncoderInternalsTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import OrderedCollections
+
+@testable import QsSwift
+
+#if canImport(Testing)
+    import Testing
+#else
+    #error("The swift-testing package is required to build tests on Swift 5.x")
+#endif
+
+struct EncoderInternalsTests {
+    @Test("KeyPathNode caches dot/materialized paths and keeps append semantics")
+    func keyPathNode_cachesMaterializedAndDotEncoded() {
+        let root = KeyPathNode.fromMaterialized("user.name")
+        #expect(root.append("") === root)
+
+        let nested = root.append("[first.last]").append("[0]")
+        #expect(nested.materialize() == "user.name[first.last][0]")
+
+        let dotEncoded1 = nested.asDotEncoded()
+        let dotEncoded2 = nested.asDotEncoded()
+        #expect(dotEncoded1 === dotEncoded2)
+        #expect(dotEncoded1.materialize() == "user%2Ename[first%2Elast][0]")
+    }
+
+    @Test("KeyPathNode identity dot-encoding does not self-retain")
+    func keyPathNode_identityDotEncoding_noSelfRetain() {
+        weak var weakNode: KeyPathNode?
+
+        do {
+            let node = KeyPathNode.fromMaterialized("root").append("[k]").append("[str]")
+            #expect(node.asDotEncoded() === node)
+            #expect(node.asDotEncoded() === node)
+            weakNode = node
+        }
+
+        #expect(weakNode == nil)
+    }
+
+    @Test("Encoder iterative traversal parity for mixed map/list/scalar payloads")
+    func encoder_iterativeTraversalParity_mixedPayload() throws {
+        var nestedObject = OrderedDictionary<String, Any>()
+        nestedObject["arr"] = [1, NSNull(), OrderedDictionary<String, Any>(uniqueKeysWithValues: [("x", "y")])]
+        nestedObject["str"] = "v"
+
+        var payload = OrderedDictionary<String, Any>()
+        payload["k"] = nestedObject
+        payload["n"] = 3
+
+        let any = try Encoder.encode(
+            data: payload,
+            undefined: false,
+            sideChannel: NSMapTable<AnyObject, AnyObject>.weakToWeakObjects(),
+            prefix: "root",
+            listFormat: .indices,
+            commaRoundTrip: false,
+            allowEmptyLists: false,
+            strictNullHandling: false,
+            skipNulls: false,
+            encodeDotInKeys: false,
+            encoder: nil,
+            serializeDate: nil,
+            sort: nil,
+            filter: nil,
+            allowDots: false,
+            format: .rfc3986,
+            formatter: nil,
+            encodeValuesOnly: false,
+            charset: .utf8,
+            addQueryPrefix: false,
+            depth: 0
+        )
+
+        let out =
+            (any as? [Any])?.map { String(describing: $0) }.joined(separator: "&")
+            ?? String(describing: any)
+
+        #expect(out == "root[k][str]=v&root[k][arr][0]=1&root[k][arr][1]=&root[k][arr][2][x]=y&root[n]=3")
+    }
+
+    @Test("Encoder linear-chain fast path falls back when allowDots is enabled")
+    func encoder_linearChainFastPath_fallback_allowDots() throws {
+        let payload: [String: Any] = ["a": ["leaf": "x"]]
+
+        let any = try Encoder.encode(
+            data: payload,
+            undefined: false,
+            sideChannel: NSMapTable<AnyObject, AnyObject>.weakToWeakObjects(),
+            prefix: "root",
+            listFormat: .indices,
+            commaRoundTrip: false,
+            allowEmptyLists: false,
+            strictNullHandling: false,
+            skipNulls: false,
+            encodeDotInKeys: false,
+            encoder: nil,
+            serializeDate: nil,
+            sort: nil,
+            filter: nil,
+            allowDots: true,
+            format: .rfc3986,
+            formatter: nil,
+            encodeValuesOnly: false,
+            charset: .utf8,
+            addQueryPrefix: false,
+            depth: 0
+        )
+
+        let out =
+            (any as? [Any])?.map { String(describing: $0) }.joined(separator: "&")
+            ?? String(describing: any)
+
+        #expect(out == "root.a.leaf=x")
+    }
+}

--- a/Tests/TestSupport/PerfGuardrailsHelpers.swift
+++ b/Tests/TestSupport/PerfGuardrailsHelpers.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+public struct PerfSummary: Decodable {
+    public struct CaseRecord: Decodable {
+        public let runtime: String
+        public let depth: Int
+        public let ms_per_op_median: Double
+    }
+
+    public let cases: [CaseRecord]
+}
+
+public struct BenchCaseKey: Hashable {
+    public let runtime: String
+    public let depth: Int
+
+    public init(runtime: String, depth: Int) {
+        self.runtime = runtime
+        self.depth = depth
+    }
+}
+
+public let deepEncodePerfCases = [2000, 5000, 12000]
+
+/// Resolves repo root by trimming `file -> TestSupport -> Tests -> repo root` from `#filePath`.
+/// This depends on this file remaining under `Tests/TestSupport`; if moved, update this function.
+public func repoRootURL() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+public func runCommand(
+    _ executable: String,
+    args: [String],
+    cwd: URL,
+    errorDomain: String = "PerfGuardrailTests",
+    tempPrefix: String = "qs-perf"
+) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = args
+    process.currentDirectoryURL = cwd
+
+    let fileManager = FileManager.default
+    let tempDir = fileManager.temporaryDirectory
+        .appendingPathComponent("\(tempPrefix)-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: tempDir) }
+
+    let stdoutURL = tempDir.appendingPathComponent("stdout.log")
+    let stderrURL = tempDir.appendingPathComponent("stderr.log")
+    fileManager.createFile(atPath: stdoutURL.path, contents: nil)
+    fileManager.createFile(atPath: stderrURL.path, contents: nil)
+
+    let stdout = try FileHandle(forWritingTo: stdoutURL)
+    let stderr = try FileHandle(forWritingTo: stderrURL)
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+    try stdout.close()
+    try stderr.close()
+
+    let outData = try Data(contentsOf: stdoutURL)
+    let errData = try Data(contentsOf: stderrURL)
+    let out = String(decoding: outData, as: UTF8.self)
+    let err = String(decoding: errData, as: UTF8.self)
+
+    if process.terminationStatus != 0 {
+        throw NSError(
+            domain: errorDomain,
+            code: Int(process.terminationStatus),
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Command failed: \(executable) \(args.joined(separator: " "))\n\(err)"
+            ]
+        )
+    }
+
+    return out
+}
+
+public func loadBaseline(runtime: String, root: URL = repoRootURL()) throws -> [Int: Double] {
+    let baselineURL = root.appendingPathComponent(
+        "Bench/baselines/encode_deep_snapshot_baseline.json"
+    )
+    let data = try Data(contentsOf: baselineURL)
+    let summary = try JSONDecoder().decode(PerfSummary.self, from: data)
+
+    return summary.cases.reduce(into: [Int: Double]()) { acc, entry in
+        guard entry.runtime == runtime else { return }
+        acc[entry.depth] = entry.ms_per_op_median
+    }
+}
+
+public func parseBenchOutput(_ output: String) throws -> [BenchCaseKey: Double] {
+    let regex = try NSRegularExpression(
+        pattern: #"^\s*(swift|objc)\s+depth=\s*(\d+):\s*([0-9.]+)\s*ms/op"#,
+        options: []
+    )
+
+    var result: [BenchCaseKey: Double] = [:]
+    for line in output.split(whereSeparator: \.isNewline) {
+        let text = String(line)
+        let range = NSRange(location: 0, length: text.utf16.count)
+        guard
+            let match = regex.firstMatch(in: text, options: [], range: range),
+            match.numberOfRanges == 4,
+            let runtimeRange = Range(match.range(at: 1), in: text),
+            let depthRange = Range(match.range(at: 2), in: text),
+            let msRange = Range(match.range(at: 3), in: text),
+            let depth = Int(text[depthRange]),
+            let ms = Double(text[msRange])
+        else {
+            continue
+        }
+
+        result[BenchCaseKey(runtime: String(text[runtimeRange]), depth: depth)] = ms
+    }
+
+    return result
+}
+
+public func perfGuardrailsEnabled(extraFlag: String) -> Bool {
+    let env = ProcessInfo.processInfo.environment
+    return env["QS_ENABLE_PERF_GUARDRAILS"] == "1" || env[extraFlag] == "1"
+}
+
+public func perfTolerancePct() -> Double {
+    let raw = ProcessInfo.processInfo.environment["QS_PERF_REGRESSION_TOLERANCE_PCT"] ?? ""
+    return Double(raw) ?? 20.0
+}

--- a/Tests/TestSupport/PerfGuardrailsHelpers.swift
+++ b/Tests/TestSupport/PerfGuardrailsHelpers.swift
@@ -126,7 +126,14 @@ public func parseBenchOutput(_ output: String) throws -> [BenchCaseKey: Double] 
 
 public func perfGuardrailsEnabled(extraFlag: String) -> Bool {
     let env = ProcessInfo.processInfo.environment
-    return env["QS_ENABLE_PERF_GUARDRAILS"] == "1" || env[extraFlag] == "1"
+    let enabledByFlag = env["QS_ENABLE_PERF_GUARDRAILS"] == "1" || env[extraFlag] == "1"
+    guard enabledByFlag else { return false }
+
+    #if DEBUG
+        return env["QS_PERF_ALLOW_DEBUG"] == "1"
+    #else
+        return true
+    #endif
 }
 
 public func perfTolerancePct() -> Double {

--- a/Tests/TestSupport/PerfGuardrailsHelpers.swift
+++ b/Tests/TestSupport/PerfGuardrailsHelpers.swift
@@ -4,7 +4,13 @@ public struct PerfSummary: Decodable {
     public struct CaseRecord: Decodable {
         public let runtime: String
         public let depth: Int
-        public let ms_per_op_median: Double
+        public let msPerOpMedian: Double
+
+        private enum CodingKeys: String, CodingKey {
+            case runtime
+            case depth
+            case msPerOpMedian = "ms_per_op_median"
+        }
     }
 
     public let cases: [CaseRecord]
@@ -94,7 +100,7 @@ public func loadBaseline(runtime: String, root: URL = repoRootURL()) throws -> [
 
     return summary.cases.reduce(into: [Int: Double]()) { acc, entry in
         guard entry.runtime == runtime else { return }
-        acc[entry.depth] = entry.ms_per_op_median
+        acc[entry.depth] = entry.msPerOpMedian
     }
 }
 

--- a/Tests/TestSupport/PerfGuardrailsHelpers.swift
+++ b/Tests/TestSupport/PerfGuardrailsHelpers.swift
@@ -56,13 +56,15 @@ public func runCommand(
 
     let stdout = try FileHandle(forWritingTo: stdoutURL)
     let stderr = try FileHandle(forWritingTo: stderrURL)
+    defer {
+        try? stdout.close()
+        try? stderr.close()
+    }
     process.standardOutput = stdout
     process.standardError = stderr
 
     try process.run()
     process.waitUntilExit()
-    try stdout.close()
-    try stderr.close()
 
     let outData = try Data(contentsOf: stdoutURL)
     let errData = try Data(contentsOf: stderrURL)


### PR DESCRIPTION
## Summary

This PR completes the deep-encoder performance refactor for `QsSwift`/`QsObjC` and closes the remaining parity gaps versus other ports for the target workload (`encode: false`, deep nesting). It keeps public APIs unchanged and preserves output semantics while significantly reducing allocator and string-path overhead in the iterative encoder.

## What changed

- Reworked iterative traversal internals to reduce per-depth overhead.
- Added lazy result accumulation (`EncodedValuesBuffer`) to avoid eager `[Any]` allocation.
- Added key iteration state (`EncodeKeyState`) with singleton-container fast path.
- Reduced key/path churn with per-encode segment caches for bracket/dot key segments.
- Added a guarded deep linear-chain fast path for compatible `encode: false` deep cases, with immediate fallback to generic iterative traversal for unsupported option sets.
- Preserved behavior for filter/sort/ordering semantics, including iterable filter index type strictness and OrderedDictionary nested ordering parity.
- Added/updated internal regression tests for fast-path fallback and invariants.
- Updated benchmark baseline snapshot and changelog entries.

## Compatibility

- No public API signature changes in `QsSwift` or `QsObjC`.
- Behavior preserved for:
  - encode output shape/order expectations
  - cycle detection/error semantics
  - filter/sort semantics
  - ObjC bridge behavior

## Performance (median ms/op)

Workload: deep encode (`encode: false`), median-of-7 snapshot.

### QsSwift main vs this PR

| Runtime | 2000 | 5000 | 12000 |
|---|---:|---:|---:|
| QsSwift main (Swift) | 10.017 | 15.107 | 27.386 |
| QsSwift head (Swift) | 0.334 | 0.759 | 1.818 |
| QsSwift main (ObjC bridge) | 9.169 | 18.304 | 39.470 |
| QsSwift head (ObjC bridge) | 2.194 | 5.529 | 13.190 |

Delta vs main:
- Swift: `-96.67% / -94.98% / -93.36%`
- ObjC bridge: `-76.07% / -69.79% / -66.58%`

### Cross-port snapshot (same workload)

| Port | 2000 | 5000 | 12000 |
|---|---:|---:|---:|
| QsSwift head (Swift) | 0.334 | 0.759 | 1.818 |
| Kotlin | 0.372 | 0.783 | 1.863 |
| .NET/C# | 0.930 | 1.440 | 4.588 |
| Dart | 1.363 | 7.767 | 38.806 |
| Python | 14.831 | 38.091 | 99.512 |

## Validation

- `swift build -q`
- `SWIFT_DETERMINISTIC_HASHING=1 swift test -q`
- `Bench/.build/release/QsSwiftBench perf`
- `Bench/scripts/perf_compare.sh --runs 7 ...`

## Notes

- Updated `Bench/baselines/encode_deep_snapshot_baseline.json`
- Updated `CHANGELOG.md`
- Internal-only refactor; no migration required for consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New perf-snapshot and perf-compare workflows and a script to capture and aggregate performance snapshots into timestamped JSON summaries.

* **Documentation**
  * README and CHANGELOG updated for project rename and a streamlined snapshot/compare performance quick start and guardrail guidance.

* **Tests**
  * Added opt-in Swift/ObjC perf guardrail tests and shared test utilities for performance validation.

* **Refactor**
  * Major internal rework of encoding and ObjC-bridging paths and added a deep-encode performance baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->