### PR TITLE
:zap: improve deep encode performance across the Swift core and ObjC bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [PERF] optimize Swift deep `encode=false` linear-chain handling in `Encoder`: accumulate chain segments and materialize the final path once, replace `NSDictionary.allKeys.first` with `keyEnumerator().nextObject()`, and keep cycle detection / scalar semantics unchanged.
 - [TEST] add Swift linear-chain parity coverage for `[String: Any]`, `OrderedDictionary<String, Any>`, and `NSDictionary`, including cycle error propagation, terminal `nil`/`NSNull`/`Date`/`Data` behavior, and multi-key fallback assertions.
-- [PERF][ObjC] add a narrow direct-encode fast path in `QsBridge.encode` for eligible single-key `NSDictionary` chains (`encode=false` safe subset), bypassing full bridge materialization on deep nesting.
+- [PERF][ObjC] add a narrow direct-encode fast path in `QsBridge.encode` for eligible single-key `NSDictionary` chains (strict `encode=false` safe subset for non-`nil` options, plus `options=nil` defaults for deep-chain safety), bypassing full bridge materialization on deep nesting.
 - [PERF][ObjC] add a conservative sorted direct-encode bypass for `NSString`-keyed Foundation graphs when sorting is enabled and custom encoder/date/filter hooks are absent; fallback bridging remains unchanged for all ineligible graphs.
 - [PERF][ObjC] refactor `_bridgeInputForEncode` hot loops to manual `NSDictionary` / `NSArray` iteration (with reserved capacities) and add faster key stringification paths for `NSString` / `NSNumber`.
 - [PERF][ObjC] cache `EncodeOptionsObjC.swift` conversion with full dirty-bit invalidation across all mutable encode options to avoid repeated option materialization on repeated encode calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.3.2-wip
+
+- [PERF] optimize Swift deep `encode=false` linear-chain handling in `Encoder`: accumulate chain segments and materialize the final path once, replace `NSDictionary.allKeys.first` with `keyEnumerator().nextObject()`, and keep cycle detection / scalar semantics unchanged.
+- [TEST] add Swift linear-chain parity coverage for `[String: Any]`, `OrderedDictionary<String, Any>`, and `NSDictionary`, including cycle error propagation, terminal `nil`/`NSNull`/`Date`/`Data` behavior, and multi-key fallback assertions.
+- [PERF][ObjC] add a narrow direct-encode fast path in `QsBridge.encode` for eligible single-key `NSDictionary` chains (`encode=false` safe subset), bypassing full bridge materialization on deep nesting.
+- [PERF][ObjC] add a conservative sorted direct-encode bypass for `NSString`-keyed Foundation graphs when sorting is enabled and custom encoder/date/filter hooks are absent; fallback bridging remains unchanged for all ineligible graphs.
+- [PERF][ObjC] refactor `_bridgeInputForEncode` hot loops to manual `NSDictionary` / `NSArray` iteration (with reserved capacities) and add faster key stringification paths for `NSString` / `NSNumber`.
+- [PERF][ObjC] cache `EncodeOptionsObjC.swift` conversion with full dirty-bit invalidation across all mutable encode options to avoid repeated option materialization on repeated encode calls.
+- [TEST][ObjC] extend bridge coverage for sorted-direct eligibility rules, `UndefinedObjC` / cycle / non-string-key fallback parity, and `EncodeOptionsObjC` cache invalidation scenarios.
+
 ## 1.3.1
 
 - [PERF] refactor `Encoder` to a fully iterative traversal core with linked key-path caching (`KeyPathNode`), immutable per-traversal config (`EncodeConfig`), explicit traversal frames (`EncodeFrame`), and O(1) active-path cycle checks for class-backed containers.

--- a/Sources/QsObjC/Models/EncodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/EncodeOptionsObjC.swift
@@ -11,7 +11,7 @@
     /// Thread-safety: not thread-safe. Configure on one thread, then use.
     @objc(QsEncodeOptions)
     @objcMembers
-    public final class EncodeOptionsObjC: NSObject, @unchecked Sendable {
+    public final class EncodeOptionsObjC: NSObject {
 
         // MARK: - Custom encoders / sorters
 

--- a/Sources/QsObjC/Models/EncodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/EncodeOptionsObjC.swift
@@ -26,62 +26,92 @@
         /// Note: You do not need to normalize spaces here; the core applies the final
         /// space style (`%20` vs `+`) after your block runs.
         public typealias ValueEncoderBlock = (Any?, NSNumber?, NSNumber?) -> NSString
-        public var valueEncoderBlock: ValueEncoderBlock?
+        public var valueEncoderBlock: ValueEncoderBlock? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// If set, converts `NSDate` to an **unencoded** string before the core percent-encodes it.
         public typealias DateSerializerBlock = (NSDate) -> NSString
-        public var dateSerializerBlock: DateSerializerBlock?
+        public var dateSerializerBlock: DateSerializerBlock? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Deterministic key sorter. Must return **-1**, **0**, or **+1** (like `strcmp` or `NSComparisonResult.rawValue`).
         /// If provided, this takes precedence over `sortKeysCaseInsensitively`.
         public typealias SortComparatorBlock = (Any?, Any?) -> Int
-        public var sortComparatorBlock: SortComparatorBlock?
+        public var sortComparatorBlock: SortComparatorBlock? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         // MARK: - Output formatting / behavior
 
         /// If true, prepend `'?'` to the encoded string (useful for building URLs).
-        public var addQueryPrefix: Bool = false
+        public var addQueryPrefix: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Accept dotted key paths (`a.b.c`) as if they were bracket paths (`a[b][c]`).
         /// For compatibility with other ports, this is OR’ed with `encodeDotInKeys` (either flag enables dots).
-        public var allowDots: Bool = false
+        public var allowDots: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// When true, include empty lists as `a[]` instead of omitting the key.
-        public var allowEmptyLists: Bool = false
+        public var allowEmptyLists: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Output character set for percent-encoding. Defaults to UTF-8.
-        public var charset: UInt = String.Encoding.utf8.rawValue
+        public var charset: UInt = String.Encoding.utf8.rawValue {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Include the `utf8=✓` sentinel (qs convention) when appropriate.
-        public var charsetSentinel: Bool = false
+        public var charsetSentinel: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Pair delimiter between `key=value` tokens (e.g. `&` or `;`).
-        public var delimiter: String = "&"
+        public var delimiter: String = "&" {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Master switch: when false, the encoder **does not percent-encode**—useful for tests
         /// that assert exact literal output.
-        public var encode: Bool = true
+        public var encode: Bool = true {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Deprecated spelling kept for parity with Swift/other ports.
         /// When true, dots in **keys** are parsed/treated as path separators.
         /// `allowDots || encodeDotInKeys` is passed to Swift as `allowDots`.
-        public var encodeDotInKeys: Bool = false
+        public var encodeDotInKeys: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// If true, `valueEncoderBlock` is **not** used for keys—only for values.
-        public var encodeValuesOnly: Bool = false
+        public var encodeValuesOnly: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// RFC formatting (3986 vs 1738).
-        public var format: FormatObjC = .rfc3986
+        public var format: FormatObjC = .rfc3986 {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Deprecated (mirrors Swift). Used only when `listFormat == nil`.
         /// `NSNumber(bool)`: `nil` = “unspecified”, `0` = false, `1` = true.
-        public var indices: NSNumber?
+        public var indices: NSNumber? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// List/array style (e.g. `.brackets`, `.indices`, `.comma`). If `nil`, the legacy
         /// `indices` setting above is consulted.
         ///
         /// Swift-facing storage (optional enum). Not visible to Obj-C.
-        @nonobjc public var listFormat: ListFormatObjC?
+        @nonobjc public var listFormat: ListFormatObjC? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         // Obj-C-facing boxed accessor under the same Obj-C name.
         // Obj-C will see: @property (nullable, nonatomic, strong) NSNumber *listFormat;
@@ -92,30 +122,55 @@
         }
 
         /// Drop `null` values instead of serializing them.
-        public var skipNulls: Bool = false
+        public var skipNulls: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// If true, a key without value encodes as `key` (and decodes as `NSNull`) rather than `key=`.
-        public var strictNullHandling: Bool = false
+        public var strictNullHandling: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Only meaningful with `.comma` list format: when a list has a single item, append `[]`
         /// to allow it to round-trip back to an array on decode.
-        public var commaRoundTrip: Bool = false
+        public var commaRoundTrip: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Only meaningful with `.comma` list format: when true, drop `null` entries before joining.
-        public var commaCompactNulls: Bool = false
+        public var commaCompactNulls: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Convenience: provide a predictable case-insensitive A→Z sort (ties broken case-sensitively
         /// so `"A"` sorts before `"a"`). Ignored if `sortComparatorBlock` is set.
-        public var sortKeysCaseInsensitively: Bool = false
+        public var sortKeysCaseInsensitively: Bool = false {
+            didSet { invalidateSwiftOptionsCache() }
+        }
 
         /// Bridges Swift’s filter options. To omit keys from Obj-C, return `UndefinedObjC`.
-        public var filter: FilterObjC?
+        public var filter: FilterObjC? {
+            didSet { invalidateSwiftOptionsCache() }
+        }
+
+        private var cachedSwiftOptions: QsSwift.EncodeOptions?
+        private var isSwiftOptionsCacheDirty = true
+
+        @inline(__always)
+        private func invalidateSwiftOptionsCache() {
+            isSwiftOptionsCacheDirty = true
+            cachedSwiftOptions = nil
+        }
 
         // MARK: - Bridge to Swift core
 
         /// Internal bridge that constructs the Swift `EncodeOptions` used by the core.
         /// We also normalize dot handling so **either** Obj-C flag enables dots.
         var swift: QsSwift.EncodeOptions {
+            if !isSwiftOptionsCacheDirty, let cachedSwiftOptions {
+                return cachedSwiftOptions
+            }
+
             let normalizedCharset: String.Encoding = {
                 let candidate = String.Encoding(rawValue: charset)
                 return (candidate == .utf8 || candidate == .isoLatin1) ? candidate : .utf8
@@ -159,7 +214,7 @@
                 return nil
             }()
 
-            return QsSwift.EncodeOptions(
+            let built = QsSwift.EncodeOptions(
                 encoder: swiftEncoder,
                 dateSerializer: swiftDateSerializer,
 
@@ -189,6 +244,10 @@
                 // Sorting
                 sort: swiftSorter
             )
+
+            cachedSwiftOptions = built
+            isSwiftOptionsCacheDirty = false
+            return built
         }
 
         // MARK: - Swift convenience

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -66,11 +66,13 @@
                 let swiftOptions = options?.swift ?? QsSwift.EncodeOptions()
 
                 if let dictionary = object as? NSDictionary {
-                    if _isNarrowObjCEncodeFastPathConfig(options),
-                        _isSingleKeyNSDictionaryScalarChainEligible(dictionary)
-                    {
-                        let str = try Qs.encode(dictionary, options: swiftOptions)
-                        return str as NSString
+                    if _isSingleKeyNSDictionaryScalarChainEligible(dictionary) {
+                        // `options == nil` maps to default Swift options and is safe for this narrow
+                        // shape, while non-nil remains gated by the strict fast-path config.
+                        if options == nil || _isNarrowObjCEncodeFastPathConfig(options) {
+                            let str = try Qs.encode(dictionary, options: swiftOptions)
+                            return str as NSString
+                        }
                     }
 
                     if _isSortedDirectEncodeConfigEligible(options),

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -65,12 +65,20 @@
             do {
                 let swiftOptions = options?.swift ?? QsSwift.EncodeOptions()
 
-                if let dictionary = object as? NSDictionary,
-                    _isNarrowObjCEncodeFastPathConfig(options),
-                    _isSingleKeyNSDictionaryScalarChainEligible(dictionary)
-                {
-                    let str = try Qs.encode(dictionary, options: swiftOptions)
-                    return str as NSString
+                if let dictionary = object as? NSDictionary {
+                    if _isNarrowObjCEncodeFastPathConfig(options),
+                        _isSingleKeyNSDictionaryScalarChainEligible(dictionary)
+                    {
+                        let str = try Qs.encode(dictionary, options: swiftOptions)
+                        return str as NSString
+                    }
+
+                    if _isSortedDirectEncodeConfigEligible(options),
+                        _isSortedNSStringFoundationGraphEligible(dictionary)
+                    {
+                        let str = try Qs.encode(dictionary, options: swiftOptions)
+                        return str as NSString
+                    }
                 }
 
                 // Convert and normalize in one traversal to avoid redundant full-tree walks.
@@ -209,7 +217,9 @@
                 let inserted = seen.insert(id).inserted
                 var out = OrderedDictionary<String, Any>()
                 out.reserveCapacity(dict.count)
-                dict.forEach { key, value in
+                let keys = dict.keyEnumerator()
+                while let key = keys.nextObject() {
+                    guard let value = dict.object(forKey: key) else { continue }
                     out[stringifyKey(key)] = _bridgeInputForEncode(
                         value,
                         seen: &seen,
@@ -223,8 +233,15 @@
                 let id = ObjectIdentifier(array)
                 if seen.contains(id) { return array }
                 let inserted = seen.insert(id).inserted
-                let mapped = array.map {
-                    _bridgeInputForEncode($0, seen: &seen, bridgeUndefined: bridgeUndefined)
+                var mapped: [Any] = []
+                mapped.reserveCapacity(array.count)
+                for index in 0..<array.count {
+                    mapped.append(
+                        _bridgeInputForEncode(
+                            array.object(at: index),
+                            seen: &seen,
+                            bridgeUndefined: bridgeUndefined
+                        ))
                 }
                 if inserted { seen.remove(id) }
                 return mapped
@@ -238,9 +255,12 @@
                 return out
 
             case let array as [Any]:
-                return array.map {
-                    _bridgeInputForEncode($0, seen: &seen, bridgeUndefined: bridgeUndefined)
+                var out: [Any] = []
+                out.reserveCapacity(array.count)
+                for value in array {
+                    out.append(_bridgeInputForEncode(value, seen: &seen, bridgeUndefined: bridgeUndefined))
                 }
+                return out
 
             default:
                 return input
@@ -326,8 +346,70 @@
         }
 
         @inline(__always)
+        internal static func _isSortedDirectEncodeConfigEligible(_ options: EncodeOptionsObjC?) -> Bool {
+            guard let options else { return false }
+            guard options.sortComparatorBlock != nil || options.sortKeysCaseInsensitively else {
+                return false
+            }
+            guard options.valueEncoderBlock == nil else { return false }
+            guard options.dateSerializerBlock == nil else { return false }
+            guard options.filter == nil else { return false }
+            return true
+        }
+
+        @inline(__always)
+        internal static func _isSortedNSStringFoundationGraphEligible(_ root: NSDictionary) -> Bool {
+            var stack: [Any] = [root]
+            var seen = Set<ObjectIdentifier>()
+
+            while let node = stack.popLast() {
+                if node is UndefinedObjC { return false }
+
+                if let dict = node as? NSDictionary {
+                    let id = ObjectIdentifier(dict)
+                    if seen.contains(id) { return false }
+                    seen.insert(id)
+
+                    let keys = dict.keyEnumerator()
+                    while let key = keys.nextObject() {
+                        guard key is NSString else { return false }
+                        guard let value = dict.object(forKey: key) else { return false }
+                        stack.append(value)
+                    }
+                    continue
+                }
+
+                if let array = node as? NSArray {
+                    let id = ObjectIdentifier(array)
+                    if seen.contains(id) { return false }
+                    seen.insert(id)
+
+                    for index in 0..<array.count {
+                        stack.append(array.object(at: index))
+                    }
+                    continue
+                }
+
+                if _isSortedDirectBypassDisallowedSwiftContainer(node) {
+                    return false
+                }
+            }
+
+            return true
+        }
+
+        @inline(__always)
         private static func _isNarrowFastPathContainer(_ value: Any) -> Bool {
             if value is NSDictionary || value is NSArray { return true }
+            if value is [String: Any] || value is [AnyHashable: Any] || value is [Any] { return true }
+            if value is OrderedDictionary<String, Any> { return true }
+            if value is OrderedDictionary<AnyHashable, Any> { return true }
+            if value is OrderedDictionary<NSString, Any> { return true }
+            return false
+        }
+
+        @inline(__always)
+        private static func _isSortedDirectBypassDisallowedSwiftContainer(_ value: Any) -> Bool {
             if value is [String: Any] || value is [AnyHashable: Any] || value is [Any] { return true }
             if value is OrderedDictionary<String, Any> { return true }
             if value is OrderedDictionary<AnyHashable, Any> { return true }
@@ -340,9 +422,12 @@
         /// Consistently stringify any dictionary key (Obj-C or Swift).
         @inline(__always)
         internal static func stringifyKey(_ key: Any) -> String {
+            if let key = key as? String { return key }
+            if let key = key as? NSString { return key as String }
+            if let key = key as? NSNumber { return key.stringValue }
             // We intentionally use `String(describing:)` so non-string keys (NSNumber, NSObject subclasses)
             // become a readable string and round-trip deterministically in the encoder.
-            String(describing: key)
+            return String(describing: key)
         }
     }
 #endif

--- a/Sources/QsObjC/QsBridge.swift
+++ b/Sources/QsObjC/QsBridge.swift
@@ -63,11 +63,21 @@
             _ object: Any, options: EncodeOptionsObjC? = nil, error outError: NSErrorPointer = nil
         ) -> NSString? {
             do {
+                let swiftOptions = options?.swift ?? QsSwift.EncodeOptions()
+
+                if let dictionary = object as? NSDictionary,
+                    _isNarrowObjCEncodeFastPathConfig(options),
+                    _isSingleKeyNSDictionaryScalarChainEligible(dictionary)
+                {
+                    let str = try Qs.encode(dictionary, options: swiftOptions)
+                    return str as NSString
+                }
+
                 // Convert and normalize in one traversal to avoid redundant full-tree walks.
                 let bridged = bridgeInputForEncode(object, bridgeUndefined: true)
 
                 // Let the core do its thing (and report EncodeError.cyclicObject if a cycle is present).
-                let str = try Qs.encode(bridged, options: options?.swift ?? QsSwift.EncodeOptions())
+                let str = try Qs.encode(bridged, options: swiftOptions)
                 return str as NSString
             } catch {
                 outError?.pointee = error as NSError
@@ -256,6 +266,73 @@
         ) -> Any? {
             guard let value else { return nil }
             return _bridgeInputForEncode(value, seen: &seen, bridgeUndefined: true)
+        }
+
+        // MARK: - Narrow ObjC encode fast path
+
+        @inline(__always)
+        internal static func _isNarrowObjCEncodeFastPathConfig(_ options: EncodeOptionsObjC?) -> Bool {
+            guard let options else { return false }
+            guard options.encode == false else { return false }
+            guard options.valueEncoderBlock == nil else { return false }
+            guard options.dateSerializerBlock == nil else { return false }
+            guard options.sortComparatorBlock == nil else { return false }
+            guard options.sortKeysCaseInsensitively == false else { return false }
+            guard options.filter == nil else { return false }
+            guard options.allowDots == false else { return false }
+            guard options.encodeDotInKeys == false else { return false }
+            guard options.encodeValuesOnly == false else { return false }
+            guard options.allowEmptyLists == false else { return false }
+            guard options.skipNulls == false else { return false }
+            guard options.strictNullHandling == false else { return false }
+            guard options.commaRoundTrip == false else { return false }
+            guard options.commaCompactNulls == false else { return false }
+
+            let effectiveListFormat: ListFormatObjC = {
+                if let listFormat = options.listFormat { return listFormat }
+                if let legacyIndices = options.indices {
+                    return legacyIndices.boolValue ? .indices : .repeatKey
+                }
+                return .indices
+            }()
+
+            return effectiveListFormat == .indices
+        }
+
+        @inline(__always)
+        internal static func _isSingleKeyNSDictionaryScalarChainEligible(_ root: NSDictionary) -> Bool {
+            var seen = Set<ObjectIdentifier>()
+            var cursor = root
+
+            while true {
+                let id = ObjectIdentifier(cursor)
+                if seen.contains(id) { return false }
+                seen.insert(id)
+
+                guard cursor.count == 1 else { return false }
+
+                let keys = cursor.keyEnumerator()
+                guard let key = keys.nextObject() else { return false }
+                guard let next = cursor.object(forKey: key) else { return false }
+                if next is UndefinedObjC { return false }
+
+                if let nextDict = next as? NSDictionary {
+                    cursor = nextDict
+                    continue
+                }
+
+                return !_isNarrowFastPathContainer(next)
+            }
+        }
+
+        @inline(__always)
+        private static func _isNarrowFastPathContainer(_ value: Any) -> Bool {
+            if value is NSDictionary || value is NSArray { return true }
+            if value is [String: Any] || value is [AnyHashable: Any] || value is [Any] { return true }
+            if value is OrderedDictionary<String, Any> { return true }
+            if value is OrderedDictionary<AnyHashable, Any> { return true }
+            if value is OrderedDictionary<NSString, Any> { return true }
+            return false
         }
 
         // MARK: - Small utils

--- a/Sources/QsSwift/Internal/Encoder.swift
+++ b/Sources/QsSwift/Internal/Encoder.swift
@@ -451,11 +451,27 @@ extension QsSwift.Encoder {
         guard config.listFormat == .indices else { return nil }
 
         var current: Any? = data
-        var path = prefix
+        var chainKeys: [String] = []
+        chainKeys.reserveCapacity(16)
+        var suffixReserve = 0
         var seen = Set<ObjectIdentifier>()
+
+        @inline(__always)
+        func materializePath() -> String {
+            var path = String()
+            path.reserveCapacity(prefix.count + suffixReserve)
+            path.append(prefix)
+            for key in chainKeys {
+                path.append("[")
+                path.append(key)
+                path.append("]")
+            }
+            return path
+        }
 
         while true {
             if current == nil {
+                let path = materializePath()
                 return "\(config.formatter.apply(path))="
             }
 
@@ -464,58 +480,97 @@ extension QsSwift.Encoder {
                 continue
             }
 
+            let isClassObject: Bool
             if let object = current, type(of: object) is AnyClass {
+                isClassObject = true
                 if object is NSNull {
+                    let path = materializePath()
                     return "\(config.formatter.apply(path))="
                 }
 
                 if let dict = object as? NSDictionary {
-                    let id = ObjectIdentifier(dict)
-                    if seen.contains(id) {
-                        throw EncodeError.cyclicObject
-                    }
-                    seen.insert(id)
+                    var cursor = dict
+                    while true {
+                        let id = ObjectIdentifier(cursor)
+                        if seen.contains(id) {
+                            throw EncodeError.cyclicObject
+                        }
+                        seen.insert(id)
 
-                    guard dict.count == 1 else { return nil }
-                    guard let key = dict.allKeys.first else { return nil }
-                    path.append("[")
-                    path.append(String(describing: key))
-                    path.append("]")
-                    current = dict[key]
+                        guard cursor.count == 1 else { return nil }
+                        let enumerator = cursor.keyEnumerator()
+                        guard let keyObject = enumerator.nextObject() else { return nil }
+                        let key = String(describing: keyObject)
+                        chainKeys.append(key)
+                        suffixReserve += key.count + 2
+
+                        let next = cursor.object(forKey: keyObject)
+                        if let nextDict = next as? NSDictionary {
+                            cursor = nextDict
+                            continue
+                        }
+
+                        current = next
+                        break
+                    }
+                    continue
+                }
+            } else {
+                isClassObject = false
+            }
+
+            if !isClassObject {
+                if let map = current as? [String: Any] {
+                    var cursor = map
+                    while true {
+                        guard cursor.count == 1, let (key, next) = cursor.first else { return nil }
+                        chainKeys.append(key)
+                        suffixReserve += key.count + 2
+
+                        if let nextMap = next as? [String: Any] {
+                            cursor = nextMap
+                            continue
+                        }
+
+                        current = next
+                        break
+                    }
+                    continue
+                }
+
+                if let ordered = current as? OrderedDictionary<String, Any> {
+                    var cursor = ordered
+                    while true {
+                        guard cursor.count == 1, let key = cursor.keys.first, let next = cursor[key] else {
+                            return nil
+                        }
+                        chainKeys.append(key)
+                        suffixReserve += key.count + 2
+
+                        if let nextOrdered = next as? OrderedDictionary<String, Any> {
+                            cursor = nextOrdered
+                            continue
+                        }
+
+                        current = next
+                        break
+                    }
                     continue
                 }
             }
 
-            switch current {
-            case let map as [String: Any]:
-                guard map.count == 1, let (key, next) = map.first else { return nil }
-                path.append("[")
-                path.append(key)
-                path.append("]")
-                current = next
+            let normalizedScalar: Any? = {
+                guard let some = current else { return nil }
+                return unwrapOptional(some) ?? some
+            }()
 
-            case let ordered as OrderedDictionary<String, Any>:
-                guard ordered.count == 1, let key = ordered.keys.first, let next = ordered[key] else {
-                    return nil
-                }
-                path.append("[")
-                path.append(key)
-                path.append("]")
-                current = next
-
-            default:
-                let normalizedScalar: Any? = {
-                    guard let some = current else { return nil }
-                    return unwrapOptional(some) ?? some
-                }()
-
-                if Utils.isNonNullishPrimitive(normalizedScalar) || normalizedScalar is Data {
-                    return
-                        "\(config.formatter.apply(path))=\(config.formatter.apply(describe(normalizedScalar, charset: config.charset)))"
-                }
-
-                return nil
+            if Utils.isNonNullishPrimitive(normalizedScalar) || normalizedScalar is Data {
+                let path = materializePath()
+                return
+                    "\(config.formatter.apply(path))=\(config.formatter.apply(describe(normalizedScalar, charset: config.charset)))"
             }
+
+            return nil
         }
     }
 

--- a/Tests/QsObjCTests/ObjCBridgeTests.swift
+++ b/Tests/QsObjCTests/ObjCBridgeTests.swift
@@ -209,6 +209,122 @@
             }
         }
 
+        @Test("sorted direct encode config: eligible only with sorter and no custom blocks/filter")
+        func sortedDirectEncodeConfigEligibility() {
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(nil) == false)
+
+            let noSorter = EncodeOptionsObjC()
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(noSorter) == false)
+
+            let caseInsensitive = EncodeOptionsObjC()
+            caseInsensitive.sortKeysCaseInsensitively = true
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(caseInsensitive))
+
+            let comparator = EncodeOptionsObjC()
+            comparator.sortComparatorBlock = { _, _ in 0 }
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(comparator))
+
+            let withValueEncoder = EncodeOptionsObjC()
+            withValueEncoder.sortKeysCaseInsensitively = true
+            withValueEncoder.valueEncoderBlock = { _, _, _ in "x" }
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(withValueEncoder) == false)
+
+            let withDateSerializer = EncodeOptionsObjC()
+            withDateSerializer.sortKeysCaseInsensitively = true
+            withDateSerializer.dateSerializerBlock = { _ in "x" }
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(withDateSerializer) == false)
+
+            let withFilter = EncodeOptionsObjC()
+            withFilter.sortKeysCaseInsensitively = true
+            withFilter.filter = FilterObjC.keys(["a"])
+            #expect(QsBridge._isSortedDirectEncodeConfigEligible(withFilter) == false)
+        }
+
+        @Test("sorted foundation graph: eligibility and rejection rules")
+        func sortedFoundationGraphEligibilityRules() {
+            let eligibleNested: NSDictionary = [
+                "a": [
+                    "b": [
+                        "c": "d",
+                        "e": "f",
+                    ],
+                    "arr": [
+                        ["k": "v"],
+                        "x",
+                    ],
+                ]
+            ]
+            #expect(QsBridge._isSortedNSStringFoundationGraphEligible(eligibleNested))
+
+            let nonNSStringKeyInner = NSMutableDictionary()
+            nonNSStringKeyInner[NSNumber(value: 1)] = "v"
+            let nonNSStringKeyPayload: NSDictionary = ["a": nonNSStringKeyInner]
+            #expect(QsBridge._isSortedNSStringFoundationGraphEligible(nonNSStringKeyPayload) == false)
+
+            let undefinedPayload: NSDictionary = ["a": ["b": UndefinedObjC()]]
+            #expect(QsBridge._isSortedNSStringFoundationGraphEligible(undefinedPayload) == false)
+
+            let swiftOrdered = OrderedDictionary<String, Any>(uniqueKeysWithValues: [("k", "v")])
+            let swiftContainerPayload = NSDictionary(object: swiftOrdered, forKey: "a" as NSString)
+            #expect(QsBridge._isSortedNSStringFoundationGraphEligible(swiftContainerPayload) == false)
+
+            let cycleRoot = NSMutableDictionary()
+            let cycleArray = NSMutableArray()
+            cycleRoot["a"] = cycleArray
+            cycleArray.add(cycleRoot)
+            #expect(QsBridge._isSortedNSStringFoundationGraphEligible(cycleRoot) == false)
+        }
+
+        @Test("encode: sorted nested multi-key NSDictionary parity")
+        func encode_sortedNestedMultiKeyNSDictionary_parity() {
+            let payload: NSDictionary = [
+                "a": [
+                    "b": [
+                        "e": "f",
+                        "c": "d",
+                    ]
+                ]
+            ]
+
+            let options = EncodeOptionsObjC()
+            options.encode = false
+            options.sortKeysCaseInsensitively = true
+
+            let s = QsBridge.encode(payload, options: options, error: nil) as String?
+            #expect(s == "a[b][c]=d&a[b][e]=f")
+        }
+
+        @Test("encode: nested non-string key payload still encodes via fallback")
+        func encode_sortedBypassRejected_nonStringNestedKey_stillEncodes() {
+            let nested = NSMutableDictionary()
+            nested[NSNumber(value: 2)] = "two"
+            nested[NSNumber(value: 1)] = "one"
+            let payload: NSDictionary = ["a": nested]
+
+            let options = EncodeOptionsObjC()
+            options.encode = false
+            options.sortComparatorBlock = { lhs, rhs in
+                let left = Int(String(describing: lhs ?? "")) ?? 0
+                let right = Int(String(describing: rhs ?? "")) ?? 0
+                return left == right ? 0 : (left < right ? -1 : 1)
+            }
+
+            let s = QsBridge.encode(payload, options: options, error: nil) as String?
+            #expect(s == "a[1]=one&a[2]=two")
+        }
+
+        @Test("encode: sorted graph with UndefinedObjC still omitted via fallback")
+        func encode_sortedBypassRejected_undefinedStillOmitted() {
+            let payload: NSDictionary = ["a": ["b": UndefinedObjC()]]
+
+            let options = EncodeOptionsObjC()
+            options.encode = false
+            options.sortKeysCaseInsensitively = true
+
+            let s = QsBridge.encode(payload, options: options, error: nil) as String?
+            #expect(s == "")
+        }
+
         // MARK: - bridgeInputForDecode
 
         @Test("bridgeInputForDecode: NSString → Swift.String")

--- a/Tests/QsObjCTests/ObjCBridgeTests.swift
+++ b/Tests/QsObjCTests/ObjCBridgeTests.swift
@@ -7,6 +7,15 @@
     @testable import QsSwift
 
     struct ObjCBridgeTests {
+        private func makeSingleKeyNSDictionaryChain(depth: Int, leaf: Any) -> NSDictionary {
+            precondition(depth > 0, "depth must be > 0")
+            var current: Any = leaf
+            for _ in 0..<depth {
+                current = NSDictionary(object: current, forKey: "a" as NSString)
+            }
+            return current as! NSDictionary
+        }
+
         @Test("encode → decode round-trip (flat)")
         func roundtripFlat() throws {
             let input: NSDictionary = [
@@ -61,6 +70,143 @@
             #expect(((list?[0] as? String) ?? "") == "1")
             #expect(((list?[1] as? String) ?? "") == "2")
             #expect(((list?[2] as? String) ?? "") == "3")
+        }
+
+        // MARK: - Narrow ObjC encode fast path
+
+        @Test("narrow fast path config: eligible only for encode=false defaults")
+        func narrowFastPath_config_eligibleDefaults() {
+            let options = EncodeOptionsObjC()
+            options.encode = false
+
+            #expect(QsBridge._isNarrowObjCEncodeFastPathConfig(options))
+            #expect(QsBridge._isNarrowObjCEncodeFastPathConfig(nil) == false)
+        }
+
+        @Test("narrow fast path config: blocked by custom options")
+        func narrowFastPath_config_blockedOptions() {
+            let cases: [(String, (EncodeOptionsObjC) -> Void)] = [
+                ("valueEncoderBlock", { $0.valueEncoderBlock = { _, _, _ in "x" } }),
+                (
+                    "dateSerializerBlock",
+                    {
+                        $0.dateSerializerBlock = { _ in "x" }
+                    }
+                ),
+                ("sortComparatorBlock", { $0.sortComparatorBlock = { _, _ in 0 } }),
+                ("sortKeysCaseInsensitively", { $0.sortKeysCaseInsensitively = true }),
+                ("filter", { $0.filter = FilterObjC.keys(["a"]) }),
+                ("allowDots", { $0.allowDots = true }),
+                ("encodeDotInKeys", { $0.encodeDotInKeys = true }),
+                ("encodeValuesOnly", { $0.encodeValuesOnly = true }),
+                ("allowEmptyLists", { $0.allowEmptyLists = true }),
+                ("skipNulls", { $0.skipNulls = true }),
+                ("strictNullHandling", { $0.strictNullHandling = true }),
+                ("commaRoundTrip", { $0.commaRoundTrip = true }),
+                ("commaCompactNulls", { $0.commaCompactNulls = true }),
+                ("listFormat=brackets", { $0.listFormat = .brackets }),
+                (
+                    "legacy indices=false",
+                    {
+                        $0.listFormat = nil
+                        $0.indices = NSNumber(value: false)
+                    }
+                ),
+            ]
+
+            for (name, apply) in cases {
+                let options = EncodeOptionsObjC()
+                options.encode = false
+                apply(options)
+                #expect(
+                    QsBridge._isNarrowObjCEncodeFastPathConfig(options) == false,
+                    "\(name) should disable narrow fast path"
+                )
+            }
+        }
+
+        @Test("narrow fast path chain: eligible for single-key NSDictionary scalar leaf")
+        func narrowFastPath_chain_eligible() {
+            let payload = makeSingleKeyNSDictionaryChain(depth: 12, leaf: "x")
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(payload))
+        }
+
+        @Test("narrow fast path chain: ineligible when any node has multiple keys")
+        func narrowFastPath_chain_ineligibleMultiKeyNode() {
+            let leaf: NSDictionary = ["a": "x", "b": "y"]
+            let payload: NSDictionary = ["a": leaf]
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(payload) == false)
+        }
+
+        @Test("narrow fast path chain: ineligible on cycle")
+        func narrowFastPath_chain_ineligibleCycle() {
+            let root = NSMutableDictionary()
+            root["a"] = root
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(root) == false)
+        }
+
+        @Test("narrow fast path chain: ineligible when UndefinedObjC appears")
+        func narrowFastPath_chain_ineligibleUndefined() {
+            let payload = makeSingleKeyNSDictionaryChain(depth: 4, leaf: UndefinedObjC())
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(payload) == false)
+        }
+
+        @Test("narrow fast path chain: ineligible on terminal container leaf")
+        func narrowFastPath_chain_ineligibleContainerLeaf() {
+            let arrayPayload = makeSingleKeyNSDictionaryChain(depth: 4, leaf: NSArray(array: ["x"]))
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(arrayPayload) == false)
+
+            let dictPayload = makeSingleKeyNSDictionaryChain(depth: 2, leaf: NSDictionary())
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(dictPayload) == false)
+
+            let orderedLeaf = OrderedDictionary<String, Any>(uniqueKeysWithValues: [("k", "v")])
+            let orderedPayload = makeSingleKeyNSDictionaryChain(depth: 3, leaf: orderedLeaf)
+            #expect(QsBridge._isSingleKeyNSDictionaryScalarChainEligible(orderedPayload) == false)
+        }
+
+        @Test("encode: deep single-key NSDictionary chain parity (encode=false)")
+        func encode_narrowFastPathCandidate_deepChainParity() throws {
+            let depth = 8
+            let payload = makeSingleKeyNSDictionaryChain(depth: depth, leaf: "x")
+            let options = EncodeOptionsObjC()
+            options.encode = false
+
+            var err: NSError?
+            let s = QsBridge.encode(payload, options: options, error: &err)
+            #expect(err == nil)
+
+            let expectedKey = "a" + String(repeating: "[a]", count: max(0, depth - 1))
+            #expect(s as String? == "\(expectedKey)=x")
+        }
+
+        @Test("encode: deep chain with UndefinedObjC still omitted (fallback parity)")
+        func encode_narrowFastPathCandidate_undefinedStillOmitted() {
+            let payload = makeSingleKeyNSDictionaryChain(depth: 6, leaf: UndefinedObjC())
+            let options = EncodeOptionsObjC()
+            options.encode = false
+
+            var err: NSError?
+            let s = QsBridge.encode(payload, options: options, error: &err)
+            #expect(err == nil)
+            #expect(s as String? == "")
+        }
+
+        @Test("encode: deep chain cycle still maps to cyclicObject (fallback parity)")
+        func encode_narrowFastPathCandidate_cycleStillErrors() {
+            let root = NSMutableDictionary()
+            root["a"] = root
+
+            let options = EncodeOptionsObjC()
+            options.encode = false
+
+            var err: NSError?
+            let s = QsBridge.encode(root, options: options, error: &err)
+            #expect(s == nil)
+            #expect(err != nil)
+            #expect(err?.domain == EncodeErrorInfoObjC.domain)
+            if let err {
+                #expect(EncodeErrorObjC.kind(from: err) == .cyclicObject)
+            }
         }
 
         // MARK: - bridgeInputForDecode

--- a/Tests/QsObjCTests/ObjCModelCoverageTests.swift
+++ b/Tests/QsObjCTests/ObjCModelCoverageTests.swift
@@ -350,6 +350,58 @@
             #expect(opts.swift.charset == .utf8)
         }
 
+        @Test("EncodeOptionsObjC swift cache invalidates for scalar mutations")
+        func encodeOptionsSwiftCacheInvalidates_scalarMutation() {
+            let opts = EncodeOptionsObjC()
+            #expect(opts.swift.delimiter == "&")
+            #expect(opts.swift.addQueryPrefix == false)
+
+            opts.delimiter = ";"
+            opts.addQueryPrefix = true
+
+            let rebuilt = opts.swift
+            #expect(rebuilt.delimiter == ";")
+            #expect(rebuilt.addQueryPrefix == true)
+        }
+
+        @Test("EncodeOptionsObjC swift cache invalidates for valueEncoderBlock replacement")
+        func encodeOptionsSwiftCacheInvalidates_valueEncoderReplacement() {
+            let opts = EncodeOptionsObjC()
+            opts.valueEncoderBlock = { _, _, _ in "first" }
+            #expect(opts.swift.getEncoder("x") == "first")
+
+            opts.valueEncoderBlock = { _, _, _ in "second" }
+            #expect(opts.swift.getEncoder("x") == "second")
+        }
+
+        @Test("EncodeOptionsObjC swift cache invalidates through listFormatBoxed updates")
+        func encodeOptionsSwiftCacheInvalidates_listFormatBoxedMutation() {
+            let opts = EncodeOptionsObjC()
+            opts.listFormatBoxed = NSNumber(value: ListFormatObjC.repeatKey.rawValue)
+            #expect(opts.swift.getListFormat == .repeatKey)
+
+            opts.listFormatBoxed = NSNumber(value: ListFormatObjC.comma.rawValue)
+            #expect(opts.swift.getListFormat == .comma)
+        }
+
+        @Test("EncodeOptionsObjC swift cache invalidates for sorter toggles")
+        func encodeOptionsSwiftCacheInvalidates_sorterToggles() {
+            let opts = EncodeOptionsObjC()
+            #expect(opts.swift.sort == nil)
+
+            opts.sortKeysCaseInsensitively = true
+            #expect(opts.swift.sort != nil)
+
+            opts.sortKeysCaseInsensitively = false
+            #expect(opts.swift.sort == nil)
+
+            opts.sortComparatorBlock = { _, _ in 0 }
+            #expect(opts.swift.sort != nil)
+
+            opts.sortComparatorBlock = nil
+            #expect(opts.swift.sort == nil)
+        }
+
         @Test("FilterObjC factories wrap Swift filters")
         func filterObjCFactories() {
             let functionFilter = FilterObjC.function(

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -4325,6 +4325,88 @@ struct EncodeTests {
         #expect(customResult as? String == "[a]=[7]")
     }
 
+    @Test("encode linear-chain parity for [String: Any], OrderedDictionary, and NSDictionary")
+    func encode_linearChain_parity_supportedContainers() throws {
+        func expectedChain(depth: Int) -> String {
+            var out = "a"
+            if depth > 1 {
+                for _ in 1..<depth {
+                    out.append("[a]")
+                }
+            }
+            out.append("[leaf]=x")
+            return out
+        }
+
+        let depth = 24
+        let expected = expectedChain(depth: depth)
+        let options = EncodeOptions(encode: false)
+
+        var swiftChain: [String: Any] = ["leaf": "x"]
+        for _ in 0..<depth {
+            swiftChain = ["a": swiftChain]
+        }
+        let swiftOut = try Qs.encode(swiftChain, options: options)
+        #expect(swiftOut == expected)
+
+        var orderedChain = OrderedDictionary<String, Any>(uniqueKeysWithValues: [("leaf", "x")])
+        for _ in 0..<depth {
+            var next = OrderedDictionary<String, Any>()
+            next["a"] = orderedChain
+            orderedChain = next
+        }
+        let orderedOut = try Qs.encode(orderedChain, options: options)
+        #expect(orderedOut == expected)
+
+        var nsChain: NSDictionary = NSDictionary(dictionary: ["leaf": "x"])
+        for _ in 0..<depth {
+            nsChain = NSDictionary(object: nsChain, forKey: "a" as NSString)
+        }
+        let nsOut = try Qs.encode(nsChain, options: options)
+        #expect(nsOut == expected)
+    }
+
+    @Test("encode linear-chain terminal nil and NSNull preserve behavior")
+    func encode_linearChain_terminalNilAndNSNull() throws {
+        let nilLeaf: [String: Any] = ["a": ["leaf": Optional<String>.none as Any]]
+        let nilOut = try Qs.encode(nilLeaf, options: .init(encode: false))
+        #expect(nilOut == "a[leaf]=")
+
+        let nullLeaf: [String: Any] = ["a": ["leaf": NSNull()]]
+        let nullOut = try Qs.encode(nullLeaf, options: .init(encode: false))
+        #expect(nullOut == "a[leaf]=")
+    }
+
+    @Test("encode linear-chain terminal Date and Data preserve behavior")
+    func encode_linearChain_terminalDateAndData() throws {
+        let dateOut = try Qs.encode(
+            ["a": ["leaf": Date(timeIntervalSince1970: 0)]],
+            options: .init(
+                dateSerializer: { _ in "DATE_TOKEN" },
+                encode: false
+            )
+        )
+        #expect(dateOut == "a[leaf]=DATE_TOKEN")
+
+        let dataOut = try Qs.encode(
+            ["a": ["leaf": Data("abc".utf8)]],
+            options: .init(encode: false)
+        )
+        #expect(dataOut == "a[leaf]=abc")
+    }
+
+    #if canImport(Darwin)
+        @Test("encode linear-chain detects NSDictionary cycle")
+        func encode_linearChain_detectsNSDictionaryCycle() throws {
+            let cyclic = NSMutableDictionary()
+            cyclic["self"] = cyclic
+
+            #expect(throws: EncodeError.cyclicObject) {
+                _ = try Qs.encode(cyclic, options: .init(encode: false))
+            }
+        }
+    #endif
+
     @Test("Encoder.encode nested NSDictionary branch partitions primitive and container keys")
     func encoder_nsdictionaryPartition_withEncoder() throws {
         let sideChannel = NSMapTable<AnyObject, AnyObject>.strongToStrongObjects()

--- a/Tests/QsSwiftTests/EncodeTests.swift
+++ b/Tests/QsSwiftTests/EncodeTests.swift
@@ -4395,17 +4395,24 @@ struct EncodeTests {
         #expect(dataOut == "a[leaf]=abc")
     }
 
-    #if canImport(Darwin)
-        @Test("encode linear-chain detects NSDictionary cycle")
-        func encode_linearChain_detectsNSDictionaryCycle() throws {
+    @Test("encode linear-chain detects NSDictionary cycle")
+    func encode_linearChain_detectsNSDictionaryCycle() throws {
+        #if os(Linux)
+            try withKnownIssue(Comment("Linux: corelibs-foundation segfault when constructing NSDictionary self-cycle"))
+            {
+                #expect(
+                    Bool(false),
+                    Comment("Cannot safely construct NSDictionary self-cycle on Linux; tracked as known issue."))
+            }
+        #else
             let cyclic = NSMutableDictionary()
             cyclic["self"] = cyclic
 
             #expect(throws: EncodeError.cyclicObject) {
                 _ = try Qs.encode(cyclic, options: .init(encode: false))
             }
-        }
-    #endif
+        #endif
+    }
 
     @Test("Encoder.encode nested NSDictionary branch partitions primitive and container keys")
     func encoder_nsdictionaryPartition_withEncoder() throws {

--- a/Tests/QsSwiftTests/EncoderInternalsTests.swift
+++ b/Tests/QsSwiftTests/EncoderInternalsTests.swift
@@ -113,4 +113,44 @@ struct EncoderInternalsTests {
 
         #expect(out == "root.a.leaf=x")
     }
+
+    @Test("Encoder linear-chain fast path falls back when a node has multiple keys")
+    func encoder_linearChainFastPath_fallback_multiKeyNode() throws {
+        var nested = OrderedDictionary<String, Any>()
+        nested["leaf"] = "x"
+
+        var payload = OrderedDictionary<String, Any>()
+        payload["a"] = nested
+        payload["b"] = "y"
+
+        let any = try Encoder.encode(
+            data: payload,
+            undefined: false,
+            sideChannel: NSMapTable<AnyObject, AnyObject>.weakToWeakObjects(),
+            prefix: "root",
+            listFormat: .indices,
+            commaRoundTrip: false,
+            allowEmptyLists: false,
+            strictNullHandling: false,
+            skipNulls: false,
+            encodeDotInKeys: false,
+            encoder: nil,
+            serializeDate: nil,
+            sort: nil,
+            filter: nil,
+            allowDots: false,
+            format: .rfc3986,
+            formatter: nil,
+            encodeValuesOnly: false,
+            charset: .utf8,
+            addQueryPrefix: false,
+            depth: 0
+        )
+
+        let out =
+            (any as? [Any])?.map { String(describing: $0) }.joined(separator: "&")
+            ?? String(describing: any)
+
+        #expect(out == "root[a][leaf]=x&root[b]=y")
+    }
 }


### PR DESCRIPTION
## Summary

This PR improves deep `encode=false` performance across the Swift core and ObjC bridge, while preserving public API and behavior.

## What changed

- Optimized Swift deep linear-chain encoding in `Encoder`:
  - Accumulate path segments and materialize path once at leaf.
  - Use `NSDictionary` key enumerator extraction instead of `allKeys.first`.
  - Preserve cycle detection and scalar semantics.
- Added Swift regression coverage for linear-chain parity:
  - `[String: Any]`, `OrderedDictionary<String, Any>`, `NSDictionary`.
  - Cycle behavior, `nil`/`NSNull`, `Date`, `Data`, and fallback parity.
- Added ObjC bridge narrow direct-encode fast path:
  - Eligible single-key `NSDictionary` deep chains under strict safe config.
- Added ObjC bridge conservative sorted direct-encode bypass:
  - Only for `NSString`-keyed Foundation graphs under sorter-enabled, no custom encoder/date/filter hooks.
  - Falls back to existing bridge path for ineligible graphs.
- Refactored ObjC encode bridge hot loops:
  - Manual `NSDictionary` / `NSArray` iteration with reserved capacities.
  - Faster key stringify path for `NSString` and `NSNumber`.
- Added full dirty-bit cache for `EncodeOptionsObjC.swift` conversion:
  - Invalidate on all mutable option setters.
  - Rebuild once on mutation, reuse otherwise.
- Extended ObjC test coverage:
  - Fast-path eligibility/rejection rules.
  - Sorted graph eligibility and fallback parity.
  - `EncodeOptionsObjC` cache invalidation correctness.

## API/behavior impact

- No public API changes.
- No dependency changes.
- No intended behavior changes; all new paths are gated and fallback to prior logic when not eligible.

## Benchmark results

### Main vs PR head (QsSwift Bench, 5-run medians, ms/op)

| Runtime | depth=2000 | depth=5000 | depth=12000 |
|---|---:|---:|---:|
| Swift `main` | 0.470 | 1.018 | 2.339 |
| Swift `PR` | 0.252 | 0.670 | 1.472 |
| Swift delta | -46.38% | -34.18% | -37.07% |
| ObjC `main` | 2.234 | 5.473 | 13.426 |
| ObjC `PR` | 1.190 | 2.428 | 5.778 |
| ObjC delta | -46.73% | -55.64% | -56.96% |

### Cross-port encode=false deep nesting (ms/op)

| Port/runtime | depth=2000 | depth=5000 | depth=12000 |
|---|---:|---:|---:|
| .NET (BenchmarkDotNet mean) | 0.102 | 0.290 | 0.848 |
| Kotlin (5-run median) | 0.212 | 0.276 | 0.786 |
| Dart (5-run aggregated median) | 0.211 | 0.527 | 1.303 |
| Swift (PR) | 0.252 | 0.670 | 1.472 |
| ObjC bridge (PR) | 1.190 | 2.428 | 5.778 |

### Relative to Kotlin (x, lower is better)

| Port/runtime | depth=2000 | depth=5000 | depth=12000 |
|---|---:|---:|---:|
| .NET | 0.48x | 1.05x | 1.08x |
| Dart | 1.00x | 1.91x | 1.66x |
| Swift (PR) | 1.19x | 2.43x | 1.87x |
| ObjC bridge (PR) | 5.61x | 8.80x | 7.35x |

## Validation

- `SWIFT_DETERMINISTIC_HASHING=1 swift test -q` passed.
- Benchmarks rerun for:
  - `main` vs PR head (QsSwift/ObjC bridge),
  - Kotlin,
  - Dart,
  - .NET (`Encode_DeepNesting`).

## Notes

- .NET figures are BenchmarkDotNet means on `.NET 10.0.3`.
- Swift/Kotlin/Dart figures are local perf-harness medians.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved encoding performance with new fast-paths, faster iteration, and cached option conversion to speed deep-nested and common-key encodes.
  * Tightened cache invalidation so changes to encoder options reliably rebuild derived settings.

* **Tests**
  * Broadened test coverage for deep single-key chains, cycle detection, sorted/direct-encode eligibility, terminal value cases (nil/NSNull/Date/Data), and cache-invalidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->