### PR TITLE
:construction_worker: add tests for Swift 6.0 and 5.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - runner: macos-14
+            xcode: '15.4'
+            swift: '5.10'
+            experimental: true
+          - runner: macos-15
+            xcode: '16.2'
+            swift: '6.0'
+            experimental: false
           - runner: macos-15
             xcode: '16.4'
             swift: '6.1'
@@ -98,9 +106,9 @@ jobs:
       - name: Compute Package.resolved hash
         run: echo "PACKAGE_RESOLVED_HASH=$(git hash-object Package.resolved 2>/dev/null || echo none)" >> "$GITHUB_ENV"
 
-      - name: Experimental macOS 26 notice
+      - name: Experimental matrix lane notice
         if: ${{ matrix.experimental }}
-        run: echo "::warning::Using macos-26 runner (public preview). This job is marked experimental and allowed to fail."
+        run: echo "::warning::Using experimental CI lane on ${{ matrix.runner }} with Xcode ${{ env.XCODE_VERSION }} / Swift ${{ env.SWIFT_VERSION }}. This job is allowed to fail."
 
       - name: Cache SwiftPM artifacts
         uses: actions/cache@v5
@@ -114,10 +122,19 @@ jobs:
             spm-${{ runner.os }}-swift-${{ env.SWIFT_VERSION }}-
 
       - name: Run tests with coverage
+        if: ${{ matrix.swift != '5.10' }}
         env:
           SKIP_EXPENSIVE_TESTS: 1
           SWIFT_DETERMINISTIC_HASHING: 1
         run: bash scripts/coverage.sh
+
+      - name: Build tests only (Swift 5.10 compatibility smoke check)
+        if: ${{ matrix.swift == '5.10' }}
+        env:
+          SWIFT_DETERMINISTIC_HASHING: 1
+        run: |
+          set -euxo pipefail
+          swift build -c debug --build-tests
 
       - name: Run deep Swift encode regression with Address Sanitizer
         if: ${{ !matrix.experimental }}
@@ -140,6 +157,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage to Codecov
+        if: ${{ matrix.swift != '5.10' }}
         uses: codecov/codecov-action@v5
         with:
           files: coverage/info.lcov
@@ -317,6 +335,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - swift: '6.0'
+            experimental: false
           - swift: '6.1'
             experimental: false
           - swift: '6.2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,7 @@ jobs:
         run: echo "::warning::Using experimental CI lane on ${{ matrix.runner }} with Xcode ${{ env.XCODE_VERSION }} / Swift ${{ env.SWIFT_VERSION }}. This job is allowed to fail."
 
       - name: Cache SwiftPM artifacts
+        if: ${{ matrix.swift != '5.10' }}
         uses: actions/cache@v5
         with:
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.4-wip
+
+- [CHORE] broaden toolchain compatibility: lower `Package.swift` to `swift-tools-version: 6.0`, update `swift-collections` to `1.4.0` and `swift-docc-plugin` to `1.4.6`, and align `Package@swift-5.10.swift` with `QsTestSupport` plus 5.10-specific test target exclusions for perf guardrail files.
+- [CI] expand compatibility coverage across macOS and Linux with Swift `5.10`/`6.0`/`6.1`/`6.2`; add a real Xcode `16.2` / Swift `6.0` lane, keep Swift `5.10` as an experimental build-only smoke check, and skip coverage upload on that lane.
+- [FIX] restore Swift `6.0` compiler compatibility by removing a trailing comma in `Encoder` that newer toolchains accepted but Swift `6.0` rejected.
+
 ## 1.3.3
 
 - [PERF] rewrite the decode hot path for flat query strings: add a byte-oriented fast path with structured-key scanning, allocation-light delimiter/token collection, cheaper scalar/comma-list decoding, and a fast flat finalize path; the ObjC bridge inherits the same shared-core decode speedups.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a78b7854f30bd981d945644ab40cce14073f5fb91c7e5ee5aeb5d707bf06c97",
+  "originHash" : "7abbdcafba65441c902d4747efff865f2e9f50a9e6e42e5451aeeca459674b48",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
+        "version" : "1.4.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,12 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 var deps: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6"),
 ]
 var targetDeps: [Target.Dependency] = [
     .product(name: "Algorithms", package: "swift-algorithms"),

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -6,7 +6,7 @@ import PackageDescription
 var deps: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.1"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6"),
     .package(url: "https://github.com/apple/swift-testing.git", from: "0.9.0"),
 ]
 var targetDeps: [Target.Dependency] = [
@@ -47,13 +47,23 @@ let package = Package(
                 .define("QS_OBJC_BRIDGE", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS]))
             ]
         ),
+        .target(
+            name: "QsTestSupport",
+            path: "Tests/TestSupport"
+        ),
         .testTarget(
             name: "QsSwiftTests",
             dependencies: [
                 "QsSwift",
+                "QsTestSupport",
                 .product(name: "Testing", package: "swift-testing"),
             ],
             path: "Tests/QsSwiftTests",
+            exclude: [
+                "DecodePerfHelpersTests.swift",
+                "DecodePerformanceGuardrailTests.swift",
+                "EncodePerformanceGuardrailTests.swift",
+            ],
             swiftSettings: [
                 .unsafeFlags(["-strict-concurrency=complete"], .when(configuration: .debug)),
                 .unsafeFlags(["-enable-actor-data-race-checks"], .when(configuration: .debug)),
@@ -64,9 +74,14 @@ let package = Package(
             dependencies: [
                 "QsSwift",
                 "QsObjC",
+                "QsTestSupport",
                 .product(name: "Testing", package: "swift-testing"),
             ],
-            path: "Tests/QsObjCTests"
+            path: "Tests/QsObjCTests",
+            exclude: [
+                "ObjCDecodePerformanceGuardrailTests.swift",
+                "ObjCEncodePerformanceGuardrailTests.swift",
+            ]
         ),
         .executableTarget(
             name: "QsSwiftComparison",

--- a/Sources/QsSwift/Internal/Encoder.swift
+++ b/Sources/QsSwift/Internal/Encoder.swift
@@ -88,7 +88,7 @@ internal enum Encoder {
                 undefined: undefined,
                 path: KeyPathNode.fromMaterialized(rootPrefix),
                 config: rootConfig,
-                depth: depth,
+                depth: depth
             )
         ]
 


### PR DESCRIPTION
This pull request broadens toolchain and platform compatibility, updates dependencies, and improves CI coverage and configuration. It introduces support for Swift 5.10 and 6.0, updates dependencies to newer versions, aligns test support for Swift 5.10, and refines CI jobs to better handle experimental lanes and coverage reporting. Additionally, it fixes a Swift 6.0 compatibility issue in the encoder code.

**Toolchain and Dependency Updates:**

- Lowered the minimum tools version in `Package.swift` to `swift-tools-version: 6.0` and updated `swift-collections` to `1.4.0` and `swift-docc-plugin` to `1.4.6` for broader compatibility.
- Updated `Package@swift-5.10.swift` to use `swift-docc-plugin` version `1.4.6`, added a `QsTestSupport` target, and excluded performance guardrail test files from test targets for Swift 5.10 compatibility. [[1]](diffhunk://#diff-551afeb5b9b648fa46f24cf774247e837e0aad15269059674c092644b4bf4bc7L9-R9) [[2]](diffhunk://#diff-551afeb5b9b648fa46f24cf774247e837e0aad15269059674c092644b4bf4bc7R50-R66) [[3]](diffhunk://#diff-551afeb5b9b648fa46f24cf774247e837e0aad15269059674c092644b4bf4bc7R77-R84)

**CI Improvements and Coverage Expansion:**

- Added new CI matrix lanes for macOS 14 (Swift 5.10, Xcode 15.4, marked experimental) and macOS 15 (Swift 6.0, Xcode 16.2), and included a Swift 6.0 job in the Linux matrix. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R69-R76) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R338-R339)
- Refined experimental lane notices and ensured coverage upload and test execution are skipped or adjusted for Swift 5.10 lanes, which now run a build-only smoke check. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L101-R111) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R125-R138) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R160)

**Bug Fixes:**

- Fixed a Swift 6.0 compiler compatibility issue by removing a trailing comma in the `Encoder` initializer argument list in `Encoder.swift`.

**Documentation:**

- Added a `CHANGELOG.md` entry summarizing these changes for version `1.3.4-wip`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Swift 6.0 compatibility.

* **Chores**
  * Expanded Swift toolchain support to include 5.10, 6.0, 6.1, 6.2.
  * Lowered minimum Swift tools version to 6.0.
  * Updated dependencies: swift-collections (→ 1.4.0) and swift-docc-plugin (→ 1.4.6).
  * Added a changelog entry for 1.3.4-wip.

* **CI**
  * Extended macOS/Linux workflow matrix and added conditional steps for Swift 5.10 vs other versions.

* **Tests**
  * Added a test support target and refined test target exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->