### PR TITLE
🦺 add exact container handling to prevent stack overflow in deep graphs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,7 @@ When implementing a new option or behavior:
 - In this toolchain, do not assume leading-dot tag filters (for example, `.smoke`) are supported by `swift test --filter`; prefer regex filters.
 - Add new fixtures beside similar ones; for end-to-end cases, mutate `EndToEndTestCases.swift` only with `OrderedDictionary`.
 - Prefer explicit assertion helpers over vague equality when validating ordering or null semantics.
+- Order-sensitive regression tests that are explicitly gated on `SWIFT_DETERMINISTIC_HASHING=1` may intentionally assert raw `Dictionary` iteration order; do not weaken them to sorted-key or membership-only checks unless the test is meant to be order-agnostic.
 - For ObjC bridge tests (`QsObjCTests`) use swift-testing; for host-level ObjC E2E tests use `ObjCE2ETests` (XCTest). Ensure key-ordering assertions avoid relying on `NSDictionary` enumeration order unless you explicitly sort first.
 
 ## 7. Bench & Comparison

--- a/Bench/Package.resolved
+++ b/Bench/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4bb215aa645108eba91ebae2f9d4ef5b593c6895d34d2c27710f7b829a5cd0f1",
+  "originHash" : "7aa8c4ec9d1713ecffe49b14db3526d744b54392ad97ca5fff68591a7dcf6d69",
   "pins" : [
     {
       "identity" : "swift-algorithms",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -11,132 +11,69 @@ extension Utils {
         allowSparseLists: Bool = false
     ) -> [String: Any?] {
         @inline(__always)
-        func compactValue(_ value: Any?, allowSparse: Bool) -> Any? {
+        func compactEntries(
+            _ entries: [(String, Any?)],
+            allowSparse: Bool
+        ) -> [String: Any?] {
+            var out: [String: Any?] = [:]
+            out.reserveCapacity(entries.count)
+            for (key, rawValue) in entries {
+                if let compacted = compactValue(rawValue, allowSparse: allowSparse) {
+                    out[key] = compacted
+                }
+            }
+            return out
+        }
+
+        @inline(__always)
+        func compactElements(
+            count: Int,
+            allowSparse: Bool,
+            _ visit: (@escaping (Any?) -> Void) -> Void
+        ) -> [Any] {
+            var out: [Any] = []
+            out.reserveCapacity(count)
+            visit { rawElement in
+                let element = Utils.eraseOptionalLike(rawElement)
+                if element is Undefined {
+                    if allowSparse { out.append(NSNull()) }
+                    return
+                }
+                guard let element else {
+                    out.append(NSNull())
+                    return
+                }
+                if let compacted = compactValue(element, allowSparse: allowSparse) {
+                    out.append(compacted)
+                }
+            }
+            return out
+        }
+
+        @inline(__always)
+        func compactValue(_ rawValue: Any?, allowSparse: Bool) -> Any? {
+            let value = Utils.eraseOptionalLike(rawValue)
+
             // Drop Undefined entirely
             if value is Undefined { return nil }
+            guard let value else { return nil }
 
-            if let object = value, Swift.type(of: object) is AnyClass {
-                if let dict = object as? NSDictionary {
-                    var out: [String: Any?] = [:]
-                    let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                    out.reserveCapacity(entries.count)
-                    for (key, rawValue) in entries {
-                        if let cv = compactValue(rawValue, allowSparse: allowSparse) {
-                            out[key] = cv
-                        }
-                    }
-                    return out
-                }
-
-                if let array = object as? NSArray {
-                    var out: [Any] = []
-                    out.reserveCapacity(array.count)
-                    for element in array {
-                        if let cv = compactValue(element, allowSparse: allowSparse) {
-                            out.append(cv)
-                        } else if allowSparse {
-                            out.append(NSNull())
-                        }
-                    }
-                    return out
-                }
+            if let compacted = Utils.withExactStringifiedEntries(
+                value,
+                { entries in
+                    compactEntries(entries, allowSparse: allowSparse)
+                })
+            {
+                return compacted
             }
 
-            // Dictionary branch
-            if let dict = value as? [String: Any?] {
-                var out: [String: Any?] = [:]
-                out.reserveCapacity(dict.count)
-                for (key, val) in dict {
-                    if let cv = compactValue(val, allowSparse: allowSparse) {
-                        out[key] = cv
-                    }
-                    // else: value was Undefined → remove the key
-                }
-                return out
-            }
-
-            if let dict = value as? [AnyHashable: Any?] {
-                var out: [String: Any?] = [:]
-                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                out.reserveCapacity(entries.count)
-                for (key, val) in entries {
-                    if let cv = compactValue(val, allowSparse: allowSparse) {
-                        out[key] = cv
-                    }
-                }
-                return out
-            }
-
-            if let dict = value as? [AnyHashable: Any] {
-                var out: [String: Any?] = [:]
-                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                out.reserveCapacity(entries.count)
-                for (key, val) in entries {
-                    if let cv = compactValue(val, allowSparse: allowSparse) {
-                        out[key] = cv
-                    }
-                }
-                return out
-            }
-
-            // Array branches – tolerate both [Any] and [Any?] shapes.
-            if let arrOpt = value as? [Any?] {
-                var out: [Any] = []
-                out.reserveCapacity(arrOpt.count)
-                for element in arrOpt {
-                    guard let unwrapped = element else {
-                        out.append(NSNull())
-                        continue
-                    }
-                    if unwrapped is Undefined {
-                        if allowSparse { out.append(NSNull()) }
-                        continue
-                    }
-                    if let subDict = unwrapped as? [String: Any?] {
-                        if let cv = compactValue(subDict, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArr = unwrapped as? [Any] {
-                        if let cv = compactValue(subArr, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArrOpt2 = unwrapped as? [Any?] {
-                        if let cv = compactValue(subArrOpt2, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else {
-                        out.append(unwrapped)
-                    }
-                }
-                return out
-            }
-
-            if let arr = value as? [Any] {
-                var out: [Any] = []
-                out.reserveCapacity(arr.count)
-                for element in arr {
-                    if element is Undefined {
-                        if allowSparse { out.append(NSNull()) }
-                        // else: drop it
-                        continue
-                    }
-                    if let subDict = element as? [String: Any?] {
-                        if let cv = compactValue(subDict, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArr = element as? [Any] {
-                        if let cv = compactValue(subArr, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else if let subArrOpt = element as? [Any?] {
-                        if let cv = compactValue(subArrOpt, allowSparse: allowSparse) {
-                            out.append(cv)
-                        }
-                    } else {
-                        out.append(element)
-                    }
-                }
-                return out
+            if let compacted = Utils.withExactArrayElements(
+                value,
+                { count, visit in
+                    compactElements(count: count, allowSparse: allowSparse, visit)
+                })
+            {
+                return compacted
             }
 
             // Primitive (String/Number/Bool/Date/URL/NSNull/etc)
@@ -161,63 +98,60 @@ extension Utils {
         _ root: [String: Any?],
         allowSparseLists: Bool
     ) -> [String: Any] {
-        func normalizeArray(_ arr: [Any?]) -> [Any] {
-            var out: [Any] = []
-            out.reserveCapacity(arr.count)
+        func normalizeEntries(_ entries: [(String, Any?)]) -> [String: Any] {
+            var bridged: [String: Any?] = [:]
+            bridged.reserveCapacity(entries.count)
+            for (key, child) in entries {
+                bridged[key] = child
+            }
+            return compactToAny(bridged, allowSparseLists: allowSparseLists)
+        }
 
-            for el in arr {
-                if el is Undefined {
+        func normalizeArray(
+            count: Int,
+            _ visit: (@escaping (Any?) -> Void) -> Void
+        ) -> [Any] {
+            var out: [Any] = []
+            out.reserveCapacity(count)
+
+            visit { rawElement in
+                let element = Utils.eraseOptionalLike(rawElement)
+                if element is Undefined {
                     if allowSparseLists { out.append(NSNull()) }
-                    continue
+                    return
                 }
 
-                guard let normalized = normalizeValue(el) else { continue }
+                guard let normalized = normalizeValue(element) else { return }
                 out.append(normalized)
             }
             return out
         }
 
-        func normalizeValue(_ value: Any?) -> Any? {
+        func normalizeValue(_ rawValue: Any?) -> Any? {
+            let value = Utils.eraseOptionalLike(rawValue)
+
             switch value {
             case is Undefined:
                 return nil
-            case let dict as [String: Any?]:
-                return compactToAny(dict, allowSparseLists: allowSparseLists)
-            case let dict as [AnyHashable: Any?]:
-                var bridged: [String: Any?] = [:]
-                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                bridged.reserveCapacity(entries.count)
-                for (key, child) in entries {
-                    bridged[key] = child
+            case let value?:
+                if let normalized = Utils.withExactStringifiedEntries(
+                    value,
+                    { entries in
+                        normalizeEntries(entries)
+                    })
+                {
+                    return normalized
                 }
-                return compactToAny(bridged, allowSparseLists: allowSparseLists)
-            case let dict as [AnyHashable: Any]:
-                var bridged: [String: Any?] = [:]
-                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                bridged.reserveCapacity(entries.count)
-                for (key, child) in entries {
-                    bridged[key] = child
+
+                if let normalized = Utils.withExactArrayElements(
+                    value,
+                    { count, visit in
+                        normalizeArray(count: count, visit)
+                    })
+                {
+                    return normalized
                 }
-                return compactToAny(bridged, allowSparseLists: allowSparseLists)
-            case let arrayOpt as [Any?]:
-                return normalizeArray(arrayOpt)
-            case let array as [Any]:
-                return normalizeArray(array.map(Optional.some))
-            case let object? where Swift.type(of: object) is AnyClass:
-                if let dict = object as? NSDictionary {
-                    var bridged: [String: Any?] = [:]
-                    let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
-                    bridged.reserveCapacity(entries.count)
-                    for (key, child) in entries {
-                        bridged[key] = child
-                    }
-                    return compactToAny(bridged, allowSparseLists: allowSparseLists)
-                }
-                if let array = object as? NSArray {
-                    return normalizeArray(array.map(Optional.some))
-                }
-                return object
-            case .some(let value):
+
                 return value
             case .none:
                 return NSNull()

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -31,11 +31,8 @@ extension Utils {
             }
         }
         final class ArrayBox {
-            var arr: [Any]
-            init(_ capacity: Int) {
-                self.arr = []
-                self.arr.reserveCapacity(capacity)
-            }
+            var arr: [Any?]
+            init(_ count: Int) { self.arr = Array(repeating: nil, count: count) }
         }
 
         typealias Assign = (Any?) -> Void
@@ -78,45 +75,28 @@ extension Utils {
             count: Int,
             foundationID: ObjectIdentifier?,
             assign: @escaping Assign,
-            visit: (@escaping (Any?) -> Void) -> Void
+            visit: (@escaping (_ index: Int, _ child: Any?) -> Void) -> Void
         ) {
             let box = ArrayBox(count)
             stack.append(.commitArray(box, foundationID, assign))
 
-            var elements: [Any?] = []
-            elements.reserveCapacity(count)
-            visit { elements.append($0) }
-
-            for rawElement in elements.reversed() {
+            visit { index, rawElement in
                 let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
                     if allowSparseLists {
-                        stack.append(
-                            .build(
-                                node: NSNull(),
-                                assign: { value in
-                                    guard let value else { return }
-                                    box.arr.append(value)
-                                }))
+                        box.arr[index] = NSNull()
                     }
-                    continue
+                    return
                 }
                 guard let element else {
-                    stack.append(
-                        .build(
-                            node: NSNull(),
-                            assign: { value in
-                                guard let value else { return }
-                                box.arr.append(value)
-                            }))
-                    continue
+                    box.arr[index] = NSNull()
+                    return
                 }
                 stack.append(
                     .build(
                         node: element,
                         assign: { value in
-                            guard let value else { return }
-                            box.arr.append(value)
+                            box.arr[index] = value
                         }))
             }
         }
@@ -172,7 +152,8 @@ extension Utils {
                 if let foundationID {
                     activeFoundationContainers.remove(foundationID)
                 }
-                assign(box.arr)
+                let array = allowSparseLists ? box.arr.map { $0 ?? NSNull() } : box.arr.compactMap { $0 }
+                assign(array)
             }
         }
 
@@ -195,11 +176,8 @@ extension Utils {
             }
         }
         final class ArrayBox {
-            var arr: [Any]
-            init(_ capacity: Int) {
-                self.arr = []
-                self.arr.reserveCapacity(capacity)
-            }
+            var arr: [Any?]
+            init(_ count: Int) { self.arr = Array(repeating: nil, count: count) }
         }
 
         typealias Assign = (Any?) -> Void
@@ -237,35 +215,28 @@ extension Utils {
             count: Int,
             foundationID: ObjectIdentifier?,
             assign: @escaping Assign,
-            visit: (@escaping (Any?) -> Void) -> Void
+            visit: (@escaping (_ index: Int, _ child: Any?) -> Void) -> Void
         ) {
             let box = ArrayBox(count)
             stack.append(.commitArray(box, foundationID, assign))
 
-            var elements: [Any?] = []
-            elements.reserveCapacity(count)
-            visit { elements.append($0) }
-
-            for rawElement in elements.reversed() {
+            visit { index, rawElement in
                 let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
                     if allowSparseLists {
-                        stack.append(
-                            .build(
-                                node: NSNull(),
-                                assign: { value in
-                                    guard let value else { return }
-                                    box.arr.append(value)
-                                }))
+                        box.arr[index] = NSNull()
                     }
-                    continue
+                    return
+                }
+                guard let element else {
+                    box.arr[index] = NSNull()
+                    return
                 }
                 stack.append(
                     .build(
                         node: element,
                         assign: { value in
-                            guard let value else { return }
-                            box.arr.append(value)
+                            box.arr[index] = value
                         }))
             }
         }
@@ -321,7 +292,8 @@ extension Utils {
                 if let foundationID {
                     activeFoundationContainers.remove(foundationID)
                 }
-                assign(box.arr)
+                let array = allowSparseLists ? box.arr.map { $0 ?? NSNull() } : box.arr.compactMap { $0 }
+                assign(array)
             }
         }
 

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 extension Utils {
+    @inline(__always)
+    private static func foundationContainerID(_ value: Any) -> ObjectIdentifier? {
+        guard Swift.type(of: value) is AnyClass else { return nil }
+        if let dict = value as? NSDictionary {
+            return ObjectIdentifier(dict)
+        }
+        if let array = value as? NSArray {
+            return ObjectIdentifier(array)
+        }
+        return nil
+    }
+
     /// Compact a nested structure by removing all `Undefined` values.
     /// - Note: `NSNull()` is preserved (represents an explicit `null`).
     /// - If `allowSparseLists` is `false` (default), array holes are *removed* (indexes shift).
@@ -10,6 +22,8 @@ extension Utils {
         _ root: inout [String: Any?],
         allowSparseLists: Bool = false
     ) -> [String: Any?] {
+        var activeFoundationContainers: Set<ObjectIdentifier> = []
+
         @inline(__always)
         func compactEntries(
             _ entries: [(String, Any?)],
@@ -34,7 +48,7 @@ extension Utils {
             var out: [Any] = []
             out.reserveCapacity(count)
             visit { rawElement in
-                let element = Utils.eraseOptionalLike(rawElement)
+                let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
                     if allowSparse { out.append(NSNull()) }
                     return
@@ -57,6 +71,18 @@ extension Utils {
             // Drop Undefined entirely
             if value is Undefined { return nil }
             guard let value else { return nil }
+
+            let foundationID = Utils.foundationContainerID(value)
+            if let foundationID {
+                guard activeFoundationContainers.insert(foundationID).inserted else {
+                    return NSNull()
+                }
+            }
+            defer {
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                }
+            }
 
             if let compacted = Utils.withExactStringifiedEntries(
                 value,
@@ -98,13 +124,16 @@ extension Utils {
         _ root: [String: Any?],
         allowSparseLists: Bool
     ) -> [String: Any] {
+        var activeFoundationContainers: Set<ObjectIdentifier> = []
+
         func normalizeEntries(_ entries: [(String, Any?)]) -> [String: Any] {
-            var bridged: [String: Any?] = [:]
-            bridged.reserveCapacity(entries.count)
+            var out: [String: Any] = [:]
+            out.reserveCapacity(entries.count)
             for (key, child) in entries {
-                bridged[key] = child
+                guard let normalized = normalizeValue(child) else { continue }
+                out[key] = normalized
             }
-            return compactToAny(bridged, allowSparseLists: allowSparseLists)
+            return out
         }
 
         func normalizeArray(
@@ -115,7 +144,7 @@ extension Utils {
             out.reserveCapacity(count)
 
             visit { rawElement in
-                let element = Utils.eraseOptionalLike(rawElement)
+                let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
                     if allowSparseLists { out.append(NSNull()) }
                     return
@@ -134,6 +163,18 @@ extension Utils {
             case is Undefined:
                 return nil
             case let value?:
+                let foundationID = Utils.foundationContainerID(value)
+                if let foundationID {
+                    guard activeFoundationContainers.insert(foundationID).inserted else {
+                        return NSNull()
+                    }
+                }
+                defer {
+                    if let foundationID {
+                        activeFoundationContainers.remove(foundationID)
+                    }
+                }
+
                 if let normalized = Utils.withExactStringifiedEntries(
                     value,
                     { entries in

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -58,12 +58,17 @@ extension Utils {
             let box = DictBox(entries.count)
             stack.append(.commitDict(box, foundationID, assign))
             for (key, child) in entries.reversed() {
+                let value = Utils.eraseOptionalLike(child)
+                if value is Undefined { continue }
+                if value == nil {
+                    box.dict.updateValue(nil, forKey: key)
+                    continue
+                }
                 stack.append(
                     .build(
-                        node: child,
+                        node: value,
                         assign: { value in
-                            guard let value else { return }
-                            box.dict[key] = value
+                            box.dict.updateValue(value, forKey: key)
                         }))
             }
         }

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -18,10 +18,9 @@ extension Utils {
             if let object = value, Swift.type(of: object) is AnyClass {
                 if let dict = object as? NSDictionary {
                     var out: [String: Any?] = [:]
-                    out.reserveCapacity(dict.count)
-                    for (rawKey, rawValue) in dict {
-                        if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
-                        let key = String(describing: rawKey)
+                    let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                    out.reserveCapacity(entries.count)
+                    for (key, rawValue) in entries {
                         if let cv = compactValue(rawValue, allowSparse: allowSparse) {
                             out[key] = cv
                         }
@@ -58,10 +57,9 @@ extension Utils {
 
             if let dict = value as? [AnyHashable: Any?] {
                 var out: [String: Any?] = [:]
-                out.reserveCapacity(dict.count)
-                for (rawKey, val) in dict {
-                    if Utils.isOverflowKey(rawKey) { continue }
-                    let key = String(describing: rawKey)
+                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                out.reserveCapacity(entries.count)
+                for (key, val) in entries {
                     if let cv = compactValue(val, allowSparse: allowSparse) {
                         out[key] = cv
                     }
@@ -71,10 +69,9 @@ extension Utils {
 
             if let dict = value as? [AnyHashable: Any] {
                 var out: [String: Any?] = [:]
-                out.reserveCapacity(dict.count)
-                for (rawKey, val) in dict {
-                    if Utils.isOverflowKey(rawKey) { continue }
-                    let key = String(describing: rawKey)
+                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                out.reserveCapacity(entries.count)
+                for (key, val) in entries {
                     if let cv = compactValue(val, allowSparse: allowSparse) {
                         out[key] = cv
                     }
@@ -188,18 +185,18 @@ extension Utils {
                 return compactToAny(dict, allowSparseLists: allowSparseLists)
             case let dict as [AnyHashable: Any?]:
                 var bridged: [String: Any?] = [:]
-                bridged.reserveCapacity(dict.count)
-                for (key, child) in dict {
-                    if Utils.isOverflowKey(key) { continue }
-                    bridged[String(describing: key)] = child
+                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                bridged.reserveCapacity(entries.count)
+                for (key, child) in entries {
+                    bridged[key] = child
                 }
                 return compactToAny(bridged, allowSparseLists: allowSparseLists)
             case let dict as [AnyHashable: Any]:
                 var bridged: [String: Any?] = [:]
-                bridged.reserveCapacity(dict.count)
-                for (key, child) in dict {
-                    if Utils.isOverflowKey(key) { continue }
-                    bridged[String(describing: key)] = child
+                let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                bridged.reserveCapacity(entries.count)
+                for (key, child) in entries {
+                    bridged[key] = child
                 }
                 return compactToAny(bridged, allowSparseLists: allowSparseLists)
             case let arrayOpt as [Any?]:
@@ -209,10 +206,10 @@ extension Utils {
             case let object? where Swift.type(of: object) is AnyClass:
                 if let dict = object as? NSDictionary {
                     var bridged: [String: Any?] = [:]
-                    bridged.reserveCapacity(dict.count)
-                    for (rawKey, child) in dict {
-                        if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
-                        bridged[String(describing: rawKey)] = child
+                    let entries = Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict)
+                    bridged.reserveCapacity(entries.count)
+                    for (key, child) in entries {
+                        bridged[key] = child
                     }
                     return compactToAny(bridged, allowSparseLists: allowSparseLists)
                 }

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -169,20 +169,13 @@ extension Utils {
             out.reserveCapacity(arr.count)
 
             for el in arr {
-                switch el {
-                case is Undefined:
+                if el is Undefined {
                     if allowSparseLists { out.append(NSNull()) }
-                // else: drop it
-                case let dict as [String: Any?]:
-                    out.append(compactToAny(dict, allowSparseLists: allowSparseLists))
-                case let arrayOpt as [Any?]:
-                    out.append(normalizeArray(arrayOpt))
-                case .some(let value):
-                    out.append(value)
-                case .none:
-                    // explicit nil → NSNull so we can keep `[Any]`
-                    out.append(NSNull())
+                    continue
                 }
+
+                guard let normalized = normalizeValue(el) else { continue }
+                out.append(normalized)
             }
             return out
         }

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -15,7 +15,8 @@ extension Utils {
 
     /// Compact a nested structure by removing all `Undefined` values.
     /// - Note: `NSNull()` is preserved (represents an explicit `null`).
-    /// - If `allowSparseLists` is `false` (default), array holes are *removed* (indexes shift).
+    /// - If `allowSparseLists` is `false` (default), `Undefined` array holes are removed
+    ///   (indexes shift), while explicit `nil` remains as `NSNull()`.
     /// - If `allowSparseLists` is `true`, holes are kept as `NSNull()` (Swift arrays can't be truly sparse).
     @usableFromInline
     static func compact(
@@ -96,15 +97,13 @@ extension Utils {
                     continue
                 }
                 guard let element else {
-                    if allowSparseLists {
-                        stack.append(
-                            .build(
-                                node: NSNull(),
-                                assign: { value in
-                                    guard let value else { return }
-                                    box.arr.append(value)
-                                }))
-                    }
+                    stack.append(
+                        .build(
+                            node: NSNull(),
+                            assign: { value in
+                                guard let value else { return }
+                                box.arr.append(value)
+                            }))
                     continue
                 }
                 stack.append(

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -15,6 +15,34 @@ extension Utils {
             // Drop Undefined entirely
             if value is Undefined { return nil }
 
+            if let object = value, Swift.type(of: object) is AnyClass {
+                if let dict = object as? NSDictionary {
+                    var out: [String: Any?] = [:]
+                    out.reserveCapacity(dict.count)
+                    for (rawKey, rawValue) in dict {
+                        if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+                        let key = String(describing: rawKey)
+                        if let cv = compactValue(rawValue, allowSparse: allowSparse) {
+                            out[key] = cv
+                        }
+                    }
+                    return out
+                }
+
+                if let array = object as? NSArray {
+                    var out: [Any] = []
+                    out.reserveCapacity(array.count)
+                    for element in array {
+                        if let cv = compactValue(element, allowSparse: allowSparse) {
+                            out.append(cv)
+                        } else if allowSparse {
+                            out.append(NSNull())
+                        }
+                    }
+                    return out
+                }
+            }
+
             // Dictionary branch
             if let dict = value as? [String: Any?] {
                 var out: [String: Any?] = [:]
@@ -24,6 +52,32 @@ extension Utils {
                         out[key] = cv
                     }
                     // else: value was Undefined → remove the key
+                }
+                return out
+            }
+
+            if let dict = value as? [AnyHashable: Any?] {
+                var out: [String: Any?] = [:]
+                out.reserveCapacity(dict.count)
+                for (rawKey, val) in dict {
+                    if Utils.isOverflowKey(rawKey) { continue }
+                    let key = String(describing: rawKey)
+                    if let cv = compactValue(val, allowSparse: allowSparse) {
+                        out[key] = cv
+                    }
+                }
+                return out
+            }
+
+            if let dict = value as? [AnyHashable: Any] {
+                var out: [String: Any?] = [:]
+                out.reserveCapacity(dict.count)
+                for (rawKey, val) in dict {
+                    if Utils.isOverflowKey(rawKey) { continue }
+                    let key = String(describing: rawKey)
+                    if let cv = compactValue(val, allowSparse: allowSparse) {
+                        out[key] = cv
+                    }
                 }
                 return out
             }
@@ -133,23 +187,59 @@ extension Utils {
             return out
         }
 
+        func normalizeValue(_ value: Any?) -> Any? {
+            switch value {
+            case is Undefined:
+                return nil
+            case let dict as [String: Any?]:
+                return compactToAny(dict, allowSparseLists: allowSparseLists)
+            case let dict as [AnyHashable: Any?]:
+                var bridged: [String: Any?] = [:]
+                bridged.reserveCapacity(dict.count)
+                for (key, child) in dict {
+                    if Utils.isOverflowKey(key) { continue }
+                    bridged[String(describing: key)] = child
+                }
+                return compactToAny(bridged, allowSparseLists: allowSparseLists)
+            case let dict as [AnyHashable: Any]:
+                var bridged: [String: Any?] = [:]
+                bridged.reserveCapacity(dict.count)
+                for (key, child) in dict {
+                    if Utils.isOverflowKey(key) { continue }
+                    bridged[String(describing: key)] = child
+                }
+                return compactToAny(bridged, allowSparseLists: allowSparseLists)
+            case let arrayOpt as [Any?]:
+                return normalizeArray(arrayOpt)
+            case let array as [Any]:
+                return normalizeArray(array.map(Optional.some))
+            case let object? where Swift.type(of: object) is AnyClass:
+                if let dict = object as? NSDictionary {
+                    var bridged: [String: Any?] = [:]
+                    bridged.reserveCapacity(dict.count)
+                    for (rawKey, child) in dict {
+                        if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+                        bridged[String(describing: rawKey)] = child
+                    }
+                    return compactToAny(bridged, allowSparseLists: allowSparseLists)
+                }
+                if let array = object as? NSArray {
+                    return normalizeArray(array.map(Optional.some))
+                }
+                return object
+            case .some(let value):
+                return value
+            case .none:
+                return NSNull()
+            }
+        }
+
         var out: [String: Any] = [:]
         out.reserveCapacity(root.count)
 
         for (key, value) in root {
-            switch value {
-            case is Undefined:
-                // drop
-                continue
-            case let dict as [String: Any?]:
-                out[key] = compactToAny(dict, allowSparseLists: allowSparseLists)
-            case let arrayOpt as [Any?]:
-                out[key] = normalizeArray(arrayOpt)
-            case .some(let value):
-                out[key] = value
-            case .none:
-                out[key] = NSNull()
-            }
+            guard let normalized = normalizeValue(value) else { continue }
+            out[key] = normalized
         }
         return out
     }

--- a/Sources/QsSwift/Internal/Utils+Compact.swift
+++ b/Sources/QsSwift/Internal/Utils+Compact.swift
@@ -22,98 +22,157 @@ extension Utils {
         _ root: inout [String: Any?],
         allowSparseLists: Bool = false
     ) -> [String: Any?] {
+        final class DictBox {
+            var dict: [String: Any?]
+            init(_ capacity: Int) {
+                self.dict = [:]
+                self.dict.reserveCapacity(capacity)
+            }
+        }
+        final class ArrayBox {
+            var arr: [Any]
+            init(_ capacity: Int) {
+                self.arr = []
+                self.arr.reserveCapacity(capacity)
+            }
+        }
+
+        typealias Assign = (Any?) -> Void
+        enum Task {
+            case build(node: Any?, assign: Assign)
+            case commitDict(DictBox, ObjectIdentifier?, Assign)
+            case commitArray(ArrayBox, ObjectIdentifier?, Assign)
+        }
+
         var activeFoundationContainers: Set<ObjectIdentifier> = []
+        var result: Any?
+        var stack: [Task] = [.build(node: root, assign: { result = $0 })]
 
         @inline(__always)
-        func compactEntries(
+        func scheduleEntries(
             _ entries: [(String, Any?)],
-            allowSparse: Bool
-        ) -> [String: Any?] {
-            var out: [String: Any?] = [:]
-            out.reserveCapacity(entries.count)
-            for (key, rawValue) in entries {
-                if let compacted = compactValue(rawValue, allowSparse: allowSparse) {
-                    out[key] = compacted
-                }
+            foundationID: ObjectIdentifier?,
+            assign: @escaping Assign
+        ) {
+            let box = DictBox(entries.count)
+            stack.append(.commitDict(box, foundationID, assign))
+            for (key, child) in entries.reversed() {
+                stack.append(
+                    .build(
+                        node: child,
+                        assign: { value in
+                            guard let value else { return }
+                            box.dict[key] = value
+                        }))
             }
-            return out
         }
 
         @inline(__always)
-        func compactElements(
+        func scheduleArray(
             count: Int,
-            allowSparse: Bool,
-            _ visit: (@escaping (Any?) -> Void) -> Void
-        ) -> [Any] {
-            var out: [Any] = []
-            out.reserveCapacity(count)
-            visit { rawElement in
+            foundationID: ObjectIdentifier?,
+            assign: @escaping Assign,
+            visit: (@escaping (Any?) -> Void) -> Void
+        ) {
+            let box = ArrayBox(count)
+            stack.append(.commitArray(box, foundationID, assign))
+
+            var elements: [Any?] = []
+            elements.reserveCapacity(count)
+            visit { elements.append($0) }
+
+            for rawElement in elements.reversed() {
                 let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
-                    if allowSparse { out.append(NSNull()) }
-                    return
+                    if allowSparseLists {
+                        stack.append(
+                            .build(
+                                node: NSNull(),
+                                assign: { value in
+                                    guard let value else { return }
+                                    box.arr.append(value)
+                                }))
+                    }
+                    continue
                 }
                 guard let element else {
-                    out.append(NSNull())
-                    return
+                    if allowSparseLists {
+                        stack.append(
+                            .build(
+                                node: NSNull(),
+                                assign: { value in
+                                    guard let value else { return }
+                                    box.arr.append(value)
+                                }))
+                    }
+                    continue
                 }
-                if let compacted = compactValue(element, allowSparse: allowSparse) {
-                    out.append(compacted)
-                }
+                stack.append(
+                    .build(
+                        node: element,
+                        assign: { value in
+                            guard let value else { return }
+                            box.arr.append(value)
+                        }))
             }
-            return out
         }
 
-        @inline(__always)
-        func compactValue(_ rawValue: Any?, allowSparse: Bool) -> Any? {
-            let value = Utils.eraseOptionalLike(rawValue)
-
-            // Drop Undefined entirely
-            if value is Undefined { return nil }
-            guard let value else { return nil }
-
-            let foundationID = Utils.foundationContainerID(value)
-            if let foundationID {
-                guard activeFoundationContainers.insert(foundationID).inserted else {
-                    return NSNull()
+        while let task = stack.popLast() {
+            switch task {
+            case .build(let rawNode, let assign):
+                let node = Utils.eraseOptionalLike(rawNode)
+                if node is Undefined {
+                    assign(nil)
+                    continue
                 }
-            }
-            defer {
+                guard let node else {
+                    assign(nil)
+                    continue
+                }
+
+                let foundationID = Utils.foundationContainerID(node)
+                if let foundationID {
+                    guard activeFoundationContainers.insert(foundationID).inserted else {
+                        assign(NSNull())
+                        continue
+                    }
+                }
+
+                if Utils.withExactStringifiedEntries(
+                    node,
+                    { entries in
+                        scheduleEntries(entries, foundationID: foundationID, assign: assign)
+                    }) != nil
+                {
+                    continue
+                }
+
+                if Utils.withExactArrayElements(
+                    node,
+                    { count, visit in
+                        scheduleArray(count: count, foundationID: foundationID, assign: assign, visit: visit)
+                    }) != nil
+                {
+                    continue
+                }
+
+                assign(node)
+
+            case .commitDict(let box, let foundationID, let assign):
                 if let foundationID {
                     activeFoundationContainers.remove(foundationID)
                 }
-            }
+                assign(box.dict)
 
-            if let compacted = Utils.withExactStringifiedEntries(
-                value,
-                { entries in
-                    compactEntries(entries, allowSparse: allowSparse)
-                })
-            {
-                return compacted
-            }
-
-            if let compacted = Utils.withExactArrayElements(
-                value,
-                { count, visit in
-                    compactElements(count: count, allowSparse: allowSparse, visit)
-                })
-            {
-                return compacted
-            }
-
-            // Primitive (String/Number/Bool/Date/URL/NSNull/etc)
-            return value
-        }
-
-        var newRoot: [String: Any?] = [:]
-        newRoot.reserveCapacity(root.count)
-        for (key, value) in root {
-            if let cv = compactValue(value, allowSparse: allowSparseLists) {
-                newRoot[key] = cv
+            case .commitArray(let box, let foundationID, let assign):
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                }
+                assign(box.arr)
             }
         }
-        root = newRoot
+
+        root = result as? [String: Any?] ?? [:]
         return root
     }
 
@@ -124,88 +183,144 @@ extension Utils {
         _ root: [String: Any?],
         allowSparseLists: Bool
     ) -> [String: Any] {
-        var activeFoundationContainers: Set<ObjectIdentifier> = []
-
-        func normalizeEntries(_ entries: [(String, Any?)]) -> [String: Any] {
-            var out: [String: Any] = [:]
-            out.reserveCapacity(entries.count)
-            for (key, child) in entries {
-                guard let normalized = normalizeValue(child) else { continue }
-                out[key] = normalized
+        final class DictBox {
+            var dict: [String: Any]
+            init(_ capacity: Int) {
+                self.dict = [:]
+                self.dict.reserveCapacity(capacity)
             }
-            return out
+        }
+        final class ArrayBox {
+            var arr: [Any]
+            init(_ capacity: Int) {
+                self.arr = []
+                self.arr.reserveCapacity(capacity)
+            }
         }
 
-        func normalizeArray(
-            count: Int,
-            _ visit: (@escaping (Any?) -> Void) -> Void
-        ) -> [Any] {
-            var out: [Any] = []
-            out.reserveCapacity(count)
+        typealias Assign = (Any?) -> Void
+        enum Task {
+            case build(node: Any?, assign: Assign)
+            case commitDict(DictBox, ObjectIdentifier?, Assign)
+            case commitArray(ArrayBox, ObjectIdentifier?, Assign)
+        }
 
-            visit { rawElement in
+        var activeFoundationContainers: Set<ObjectIdentifier> = []
+        var result: Any?
+        var stack: [Task] = [.build(node: root, assign: { result = $0 })]
+
+        @inline(__always)
+        func scheduleEntries(
+            _ entries: [(String, Any?)],
+            foundationID: ObjectIdentifier?,
+            assign: @escaping Assign
+        ) {
+            let box = DictBox(entries.count)
+            stack.append(.commitDict(box, foundationID, assign))
+            for (key, child) in entries.reversed() {
+                stack.append(
+                    .build(
+                        node: child,
+                        assign: { value in
+                            guard let value else { return }
+                            box.dict[key] = value
+                        }))
+            }
+        }
+
+        @inline(__always)
+        func scheduleArray(
+            count: Int,
+            foundationID: ObjectIdentifier?,
+            assign: @escaping Assign,
+            visit: (@escaping (Any?) -> Void) -> Void
+        ) {
+            let box = ArrayBox(count)
+            stack.append(.commitArray(box, foundationID, assign))
+
+            var elements: [Any?] = []
+            elements.reserveCapacity(count)
+            visit { elements.append($0) }
+
+            for rawElement in elements.reversed() {
                 let element = Utils.eraseOptionalElement(rawElement)
                 if element is Undefined {
-                    if allowSparseLists { out.append(NSNull()) }
-                    return
+                    if allowSparseLists {
+                        stack.append(
+                            .build(
+                                node: NSNull(),
+                                assign: { value in
+                                    guard let value else { return }
+                                    box.arr.append(value)
+                                }))
+                    }
+                    continue
                 }
-
-                guard let normalized = normalizeValue(element) else { return }
-                out.append(normalized)
+                stack.append(
+                    .build(
+                        node: element,
+                        assign: { value in
+                            guard let value else { return }
+                            box.arr.append(value)
+                        }))
             }
-            return out
         }
 
-        func normalizeValue(_ rawValue: Any?) -> Any? {
-            let value = Utils.eraseOptionalLike(rawValue)
+        while let task = stack.popLast() {
+            switch task {
+            case .build(let rawNode, let assign):
+                let node = Utils.eraseOptionalLike(rawNode)
+                if node is Undefined {
+                    assign(nil)
+                    continue
+                }
+                guard let node else {
+                    assign(NSNull())
+                    continue
+                }
 
-            switch value {
-            case is Undefined:
-                return nil
-            case let value?:
-                let foundationID = Utils.foundationContainerID(value)
+                let foundationID = Utils.foundationContainerID(node)
                 if let foundationID {
                     guard activeFoundationContainers.insert(foundationID).inserted else {
-                        return NSNull()
-                    }
-                }
-                defer {
-                    if let foundationID {
-                        activeFoundationContainers.remove(foundationID)
+                        assign(NSNull())
+                        continue
                     }
                 }
 
-                if let normalized = Utils.withExactStringifiedEntries(
-                    value,
+                if Utils.withExactStringifiedEntries(
+                    node,
                     { entries in
-                        normalizeEntries(entries)
-                    })
+                        scheduleEntries(entries, foundationID: foundationID, assign: assign)
+                    }) != nil
                 {
-                    return normalized
+                    continue
                 }
 
-                if let normalized = Utils.withExactArrayElements(
-                    value,
+                if Utils.withExactArrayElements(
+                    node,
                     { count, visit in
-                        normalizeArray(count: count, visit)
-                    })
+                        scheduleArray(count: count, foundationID: foundationID, assign: assign, visit: visit)
+                    }) != nil
                 {
-                    return normalized
+                    continue
                 }
 
-                return value
-            case .none:
-                return NSNull()
+                assign(node)
+
+            case .commitDict(let box, let foundationID, let assign):
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                }
+                assign(box.dict)
+
+            case .commitArray(let box, let foundationID, let assign):
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                }
+                assign(box.arr)
             }
         }
 
-        var out: [String: Any] = [:]
-        out.reserveCapacity(root.count)
-
-        for (key, value) in root {
-            guard let normalized = normalizeValue(value) else { continue }
-            out[key] = normalized
-        }
-        return out
+        return result as? [String: Any] ?? [:]
     }
 }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -682,42 +682,52 @@ internal enum Utils {
         @inline(__always)
     #endif
     internal static func containsUndefined(_ root: Any?) -> Bool {
-        var stack: [Any?] = [root]
+        var stack: [Any?] = [eraseOptionalLike(root)]
         var visitedFoundationContainers: Set<ObjectIdentifier> = []
+
+        @inline(__always)
+        func push(_ child: Any?) {
+            stack.append(eraseOptionalLike(child))
+        }
+
         while let node = stack.popLast() {
+            let node = eraseOptionalLike(node)
             if node is Undefined { return true }
             guard let node else { continue }
 
             switch exactContainer(node) {
             case .stringOptional(let dict):
-                stack.append(contentsOf: dict.values)
+                stack.reserveCapacity(stack.count + dict.count)
+                for child in dict.values { push(child) }
             case .stringAny(let dict):
                 stack.reserveCapacity(stack.count + dict.count)
-                for child in dict.values { stack.append(child) }
+                for child in dict.values { push(child) }
             case .anyHashableOptional(let dict):
-                stack.append(contentsOf: dict.values)
+                stack.reserveCapacity(stack.count + dict.count)
+                for child in dict.values { push(child) }
             case .anyHashableAny(let dict):
                 stack.reserveCapacity(stack.count + dict.count)
-                for child in dict.values { stack.append(child) }
+                for child in dict.values { push(child) }
             case .arrayOptional(let array):
-                stack.append(contentsOf: array)
+                stack.reserveCapacity(stack.count + array.count)
+                for child in array { push(child) }
             case .arrayAny(let array):
                 stack.reserveCapacity(stack.count + array.count)
-                for child in array { stack.append(child) }
+                for child in array { push(child) }
             case .foundationDictionary(let dict):
                 guard visitedFoundationContainers.insert(ObjectIdentifier(dict)).inserted else { continue }
                 stack.reserveCapacity(stack.count + dict.count)
-                for (_, child) in dict { stack.append(child) }
+                for (_, child) in dict { push(child) }
             case .foundationArray(let array):
                 guard visitedFoundationContainers.insert(ObjectIdentifier(array)).inserted else { continue }
                 stack.reserveCapacity(stack.count + array.count)
-                for child in array { stack.append(child) }
+                for child in array { push(child) }
             case .genericDictionary(let dict):
                 stack.reserveCapacity(stack.count + dict._qsCount)
-                dict._qsForEachEntry { _, child in stack.append(child) }
+                dict._qsForEachEntry { _, child in push(child) }
             case .genericArray(let array):
                 stack.reserveCapacity(stack.count + array._qsCount)
-                array._qsForEachElement { _, child in stack.append(child) }
+                array._qsForEachElement { _, child in push(child) }
             case nil:
                 break
             }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import OrderedCollections
 
@@ -138,6 +139,54 @@ internal enum Utils {
         return isGenericContainerType
     }
 
+    // Avoid downcasting between `[String: Any]` and `[String: Any?]` (and the array/hashable
+    // equivalents) while traversing deep graphs. Swift 6.3 can recursively walk the entire
+    // subtree for those conversions, which overflows worker-thread stacks on long chains.
+    private enum ExactContainer {
+        case stringAny([String: Any])
+        case stringOptional([String: Any?])
+        case anyHashableAny([AnyHashable: Any])
+        case anyHashableOptional([AnyHashable: Any?])
+        case arrayAny([Any])
+        case arrayOptional([Any?])
+    }
+
+    @inline(__always)
+    private static func exactContainer(_ value: Any) -> ExactContainer? {
+        let valueType = Swift.type(of: value)
+
+        @inline(__always)
+        func exactCast<T>(_ type: T.Type) -> T? {
+            guard valueType == type else { return nil }
+            guard let typed = value as? T else {
+                assertionFailure("Exact cast failed for runtime type \(valueType)")
+                return nil
+            }
+            return typed
+        }
+
+        if let dict = exactCast([String: Any].self) {
+            return .stringAny(dict)
+        }
+        if let dict = exactCast([String: Any?].self) {
+            return .stringOptional(dict)
+        }
+        if let dict = exactCast([AnyHashable: Any].self) {
+            return .anyHashableAny(dict)
+        }
+        if let dict = exactCast([AnyHashable: Any?].self) {
+            return .anyHashableOptional(dict)
+        }
+        if let array = exactCast([Any].self) {
+            return .arrayAny(array)
+        }
+        if let array = exactCast([Any?].self) {
+            return .arrayOptional(array)
+        }
+
+        return nil
+    }
+
     // MARK: - Is Empty Check
 
     /// Checks if a value is empty. A value is considered empty if it is nil, Undefined, an empty
@@ -193,16 +242,22 @@ internal enum Utils {
                     continue
                 }
 
-                if let dict = node as? [String: Any?] {
+                switch exactContainer(node) {
+                case .stringOptional(let dict):
                     let box = DictBox()
                     stack.append(.commitDict(box, assign))
                     for (key, child) in dict {
                         stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
                     }
                     continue
-                }
-
-                if let dictAHOpt = node as? [AnyHashable: Any?] {
+                case .stringAny(let dict):
+                    let box = DictBox()
+                    stack.append(.commitDict(box, assign))
+                    for (key, child) in dict {
+                        stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
+                    }
+                    continue
+                case .anyHashableOptional(let dictAHOpt):
                     let box = DictBox()
                     stack.append(.commitDict(box, assign))
                     for (keyHash, child) in dictAHOpt {
@@ -211,9 +266,7 @@ internal enum Utils {
                         stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
                     }
                     continue
-                }
-
-                if let dictAH = node as? [AnyHashable: Any] {
+                case .anyHashableAny(let dictAH):
                     let box = DictBox()
                     stack.append(.commitDict(box, assign))
                     for (keyHash, child) in dictAH {
@@ -222,24 +275,22 @@ internal enum Utils {
                         stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
                     }
                     continue
-                }
-
-                if let arr = node as? [Any] {
+                case .arrayAny(let arr):
                     let box = ArrayBox(arr.count)
                     stack.append(.commitArray(box, assign))
                     for (index, child) in arr.enumerated() {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
-                }
-
-                if let arrOpt = node as? [Any?] {
+                case .arrayOptional(let arrOpt):
                     let box = ArrayBox(arrOpt.count)
                     stack.append(.commitArray(box, assign))
                     for (index, child) in arrOpt.enumerated() {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
+                case nil:
+                    break
                 }
 
                 assign(node)
@@ -263,15 +314,26 @@ internal enum Utils {
         var stack: [Any?] = [root]
         while let node = stack.popLast() {
             if node is Undefined { return true }
+            guard let node else { continue }
 
-            if let dict = node as? [String: Any?] {
-                stack.append(contentsOf: dict.values)  // values are Any?
-            } else if let dict = node as? [AnyHashable: Any] {
-                stack.append(contentsOf: dict.values.map { Optional($0) })  // wrap Any → Any?
-            } else if let array = node as? [Any?] {
-                stack.append(contentsOf: array)  // already Any?
-            } else if let array = node as? [Any] {
-                stack.append(contentsOf: array.map { Optional($0) })  // wrap Any → Any?
+            switch exactContainer(node) {
+            case .stringOptional(let dict):
+                stack.append(contentsOf: dict.values)
+            case .stringAny(let dict):
+                stack.reserveCapacity(stack.count + dict.count)
+                for child in dict.values { stack.append(child) }
+            case .anyHashableOptional(let dict):
+                stack.append(contentsOf: dict.values)
+            case .anyHashableAny(let dict):
+                stack.reserveCapacity(stack.count + dict.count)
+                for child in dict.values { stack.append(child) }
+            case .arrayOptional(let array):
+                stack.append(contentsOf: array)
+            case .arrayAny(let array):
+                stack.reserveCapacity(stack.count + array.count)
+                for child in array { stack.append(child) }
+            case nil:
+                break
             }
         }
         return false
@@ -285,22 +347,25 @@ internal enum Utils {
         var depth = 0
         var current = value
         while depth < cap {
-            if let dict = current as? [String: Any?], dict.count == 1, let next = dict.first?.value {
+            guard let currentValue = current else { return depth }
+
+            switch exactContainer(currentValue) {
+            case .stringOptional(let dict):
+                guard dict.count == 1, let entry = dict.first else { return depth }
+                current = entry.value
+            case .stringAny(let dict):
+                guard dict.count == 1, let next = dict.first?.value else { return depth }
                 current = next
-                depth += 1
-                continue
-            }
-            if let dict = current as? [AnyHashable: Any?], dict.count == 1, let next = dict.first?.value {
+            case .anyHashableOptional(let dict):
+                guard dict.count == 1, let entry = dict.first else { return depth }
+                current = entry.value
+            case .anyHashableAny(let dict):
+                guard dict.count == 1, let next = dict.first?.value else { return depth }
                 current = next
-                depth += 1
-                continue
+            case .arrayAny, .arrayOptional, nil:
+                return depth
             }
-            if let dict = current as? [AnyHashable: Any], dict.count == 1, let next = dict.first?.value {
-                current = next
-                depth += 1
-                continue
-            }
-            return depth
+            depth += 1
         }
         return depth
     }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -2,6 +2,76 @@
 import Foundation
 import OrderedCollections
 
+private protocol QsOptionalValue {
+    var _qsWrappedAny: Any? { get }
+}
+
+extension Optional: QsOptionalValue {
+    fileprivate var _qsWrappedAny: Any? {
+        switch self {
+        case .some(let wrapped):
+            return wrapped
+        case .none:
+            return nil
+        }
+    }
+}
+
+protocol QsErasedDictionaryContainer {
+    var _qsCount: Int { get }
+    func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void)
+    func _qsFirstEntry() -> (key: AnyHashable, value: Any?)?
+}
+
+protocol QsErasedArrayContainer {
+    var _qsCount: Int { get }
+    func _qsForEachElement(_ body: (Int, Any?) -> Void)
+}
+
+extension Dictionary: QsErasedDictionaryContainer where Key: Hashable {
+    var _qsCount: Int { count }
+
+    func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
+        for (key, value) in self {
+            body(AnyHashable(key), Utils.eraseOptionalLike(value))
+        }
+    }
+
+    func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
+        for (key, value) in self {
+            return (AnyHashable(key), Utils.eraseOptionalLike(value))
+        }
+        return nil
+    }
+}
+
+extension OrderedDictionary: QsErasedDictionaryContainer where Key: Hashable {
+    var _qsCount: Int { count }
+
+    func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
+        for (key, value) in self {
+            body(AnyHashable(key), Utils.eraseOptionalLike(value))
+        }
+    }
+
+    func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
+        for (key, value) in self {
+            return (AnyHashable(key), Utils.eraseOptionalLike(value))
+        }
+        return nil
+    }
+}
+
+extension Array: QsErasedArrayContainer {
+    var _qsCount: Int { count }
+
+    func _qsForEachElement(_ body: (Int, Any?) -> Void) {
+        for (index, value) in enumerated() {
+            body(index, Utils.eraseOptionalLike(value))
+        }
+    }
+}
+
 /// A collection of utility methods used by the library.
 internal enum Utils {
     private final class GenericContainerTypeNameCache: @unchecked Sendable {
@@ -151,6 +221,16 @@ internal enum Utils {
         case arrayOptional([Any?])
         case foundationDictionary(NSDictionary)
         case foundationArray(NSArray)
+        case genericDictionary(any QsErasedDictionaryContainer)
+        case genericArray(any QsErasedArrayContainer)
+    }
+
+    @inline(__always)
+    static func eraseOptionalLike<T>(_ value: T) -> Any? {
+        if let optional = value as? QsOptionalValue {
+            return optional._qsWrappedAny
+        }
+        return value
     }
 
     @inline(__always)
@@ -190,6 +270,12 @@ internal enum Utils {
         }
         if valueType is AnyClass, let array = value as? NSArray {
             return .foundationArray(array)
+        }
+        if let dict = value as? any QsErasedDictionaryContainer {
+            return .genericDictionary(dict)
+        }
+        if let array = value as? any QsErasedArrayContainer {
+            return .genericArray(array)
         }
 
         return nil
@@ -313,6 +399,22 @@ internal enum Utils {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
+                case .genericDictionary(let dict):
+                    let box = DictBox()
+                    stack.append(.commitDict(box, assign))
+                    dict._qsForEachEntry { keyHash, child in
+                        if Utils.isOverflowKey(keyHash) { return }
+                        let keyString = String(describing: keyHash)
+                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
+                    }
+                    continue
+                case .genericArray(let array):
+                    let box = ArrayBox(array._qsCount)
+                    stack.append(.commitArray(box, assign))
+                    array._qsForEachElement { index, child in
+                        stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
+                    }
+                    continue
                 case nil:
                     break
                 }
@@ -362,6 +464,12 @@ internal enum Utils {
             case .foundationArray(let array):
                 stack.reserveCapacity(stack.count + array.count)
                 for child in array { stack.append(child) }
+            case .genericDictionary(let dict):
+                stack.reserveCapacity(stack.count + dict._qsCount)
+                dict._qsForEachEntry { _, child in stack.append(child) }
+            case .genericArray(let array):
+                stack.reserveCapacity(stack.count + array._qsCount)
+                array._qsForEachElement { _, child in stack.append(child) }
             case nil:
                 break
             }
@@ -395,7 +503,10 @@ internal enum Utils {
             case .foundationDictionary(let dict):
                 guard dict.count == 1, let next = dict.objectEnumerator().nextObject() else { return depth }
                 current = next
-            case .arrayAny, .arrayOptional, .foundationArray, nil:
+            case .genericDictionary(let dict):
+                guard dict._qsCount == 1, let entry = dict._qsFirstEntry() else { return depth }
+                current = entry.value
+            case .arrayAny, .arrayOptional, .foundationArray, .genericArray, nil:
                 return depth
             }
             depth += 1

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -240,35 +240,42 @@ internal enum Utils {
         return eraseOptionalLike(value)
     }
 
+    private struct EntryMergeState {
+        var entries: [(String, Any?)] = []
+        var indexByKey: [String: Int] = [:]
+        var ranksByKey: [String: Int] = [:]
+
+        init(capacity: Int) {
+            entries.reserveCapacity(capacity)
+            indexByKey.reserveCapacity(capacity)
+            ranksByKey.reserveCapacity(capacity)
+        }
+    }
+
     @inline(__always)
     private static func mergeStringifiedEntry(
         _ keyString: String,
         rank: Int,
         value: Any?,
-        entries: inout [(String, Any?)],
-        indexByKey: inout [String: Int],
-        ranksByKey: inout [String: Int]
+        state: inout EntryMergeState
     ) {
-        if let existingIndex = indexByKey[keyString] {
-            guard let existingRank = ranksByKey[keyString], rank >= existingRank else { return }
-            entries[existingIndex] = (keyString, value)
-            ranksByKey[keyString] = rank
+        if let existingIndex = state.indexByKey[keyString] {
+            guard let existingRank = state.ranksByKey[keyString], rank >= existingRank else { return }
+            state.entries[existingIndex] = (keyString, value)
+            state.ranksByKey[keyString] = rank
             return
         }
 
-        indexByKey[keyString] = entries.count
-        ranksByKey[keyString] = rank
-        entries.append((keyString, value))
+        state.indexByKey[keyString] = state.entries.count
+        state.ranksByKey[keyString] = rank
+        state.entries.append((keyString, value))
     }
 
     @inline(__always)
     internal static func stringifiedEntriesPreservingStringKeyPrecedence<Value>(
         _ dict: [AnyHashable: Value]
     ) -> [(String, Any?)] {
-        var entries: [(String, Any?)] = []
-        entries.reserveCapacity(dict.count)
-        var indexByKey: [String: Int] = [:]
-        var ranksByKey: [String: Int] = [:]
+        var state = EntryMergeState(capacity: dict.count)
 
         for (keyHash, child) in dict {
             if Utils.isOverflowKey(keyHash) { continue }
@@ -276,23 +283,18 @@ internal enum Utils {
                 String(describing: keyHash),
                 rank: keyHash.base is String ? 2 : 1,
                 value: eraseOptionalLike(child),
-                entries: &entries,
-                indexByKey: &indexByKey,
-                ranksByKey: &ranksByKey
+                state: &state
             )
         }
 
-        return entries
+        return state.entries
     }
 
     @inline(__always)
     internal static func stringifiedEntriesPreservingStringKeyPrecedence(
         _ entriesByKey: [(AnyHashable, Any?)]
     ) -> [(String, Any?)] {
-        var entries: [(String, Any?)] = []
-        entries.reserveCapacity(entriesByKey.count)
-        var indexByKey: [String: Int] = [:]
-        var ranksByKey: [String: Int] = [:]
+        var state = EntryMergeState(capacity: entriesByKey.count)
 
         for (keyHash, child) in entriesByKey {
             if Utils.isOverflowKey(keyHash) { continue }
@@ -300,23 +302,18 @@ internal enum Utils {
                 String(describing: keyHash),
                 rank: keyHash.base is String ? 2 : 1,
                 value: eraseOptionalLike(child),
-                entries: &entries,
-                indexByKey: &indexByKey,
-                ranksByKey: &ranksByKey
+                state: &state
             )
         }
 
-        return entries
+        return state.entries
     }
 
     @inline(__always)
     internal static func stringifiedEntriesPreservingStringKeyPrecedence(
         _ dict: NSDictionary
     ) -> [(String, Any?)] {
-        var entries: [(String, Any?)] = []
-        entries.reserveCapacity(dict.count)
-        var indexByKey: [String: Int] = [:]
-        var ranksByKey: [String: Int] = [:]
+        var state = EntryMergeState(capacity: dict.count)
 
         for (rawKey, child) in dict {
             if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
@@ -324,13 +321,11 @@ internal enum Utils {
                 String(describing: rawKey),
                 rank: rawKey is String ? 2 : 1,
                 value: eraseOptionalLike(child),
-                entries: &entries,
-                indexByKey: &indexByKey,
-                ranksByKey: &ranksByKey
+                state: &state
             )
         }
 
-        return entries
+        return state.entries
     }
 
     @inline(__always)

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -234,6 +234,99 @@ internal enum Utils {
     }
 
     @inline(__always)
+    private static func mergeStringifiedEntry(
+        _ keyString: String,
+        rank: Int,
+        value: Any?,
+        entries: inout [(String, Any?)],
+        indexByKey: inout [String: Int],
+        ranksByKey: inout [String: Int]
+    ) {
+        if let existingIndex = indexByKey[keyString] {
+            guard let existingRank = ranksByKey[keyString], rank >= existingRank else { return }
+            entries[existingIndex] = (keyString, value)
+            ranksByKey[keyString] = rank
+            return
+        }
+
+        indexByKey[keyString] = entries.count
+        ranksByKey[keyString] = rank
+        entries.append((keyString, value))
+    }
+
+    @inline(__always)
+    internal static func stringifiedEntriesPreservingStringKeyPrecedence<Value>(
+        _ dict: [AnyHashable: Value]
+    ) -> [(String, Any?)] {
+        var entries: [(String, Any?)] = []
+        entries.reserveCapacity(dict.count)
+        var indexByKey: [String: Int] = [:]
+        var ranksByKey: [String: Int] = [:]
+
+        for (keyHash, child) in dict {
+            if Utils.isOverflowKey(keyHash) { continue }
+            mergeStringifiedEntry(
+                String(describing: keyHash),
+                rank: keyHash.base is String ? 2 : 1,
+                value: eraseOptionalLike(child),
+                entries: &entries,
+                indexByKey: &indexByKey,
+                ranksByKey: &ranksByKey
+            )
+        }
+
+        return entries
+    }
+
+    @inline(__always)
+    internal static func stringifiedEntriesPreservingStringKeyPrecedence(
+        _ entriesByKey: [(AnyHashable, Any?)]
+    ) -> [(String, Any?)] {
+        var entries: [(String, Any?)] = []
+        entries.reserveCapacity(entriesByKey.count)
+        var indexByKey: [String: Int] = [:]
+        var ranksByKey: [String: Int] = [:]
+
+        for (keyHash, child) in entriesByKey {
+            if Utils.isOverflowKey(keyHash) { continue }
+            mergeStringifiedEntry(
+                String(describing: keyHash),
+                rank: keyHash.base is String ? 2 : 1,
+                value: child,
+                entries: &entries,
+                indexByKey: &indexByKey,
+                ranksByKey: &ranksByKey
+            )
+        }
+
+        return entries
+    }
+
+    @inline(__always)
+    internal static func stringifiedEntriesPreservingStringKeyPrecedence(
+        _ dict: NSDictionary
+    ) -> [(String, Any?)] {
+        var entries: [(String, Any?)] = []
+        entries.reserveCapacity(dict.count)
+        var indexByKey: [String: Int] = [:]
+        var ranksByKey: [String: Int] = [:]
+
+        for (rawKey, child) in dict {
+            if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+            mergeStringifiedEntry(
+                String(describing: rawKey),
+                rank: rawKey is String ? 2 : 1,
+                value: child,
+                entries: &entries,
+                indexByKey: &indexByKey,
+                ranksByKey: &ranksByKey
+            )
+        }
+
+        return entries
+    }
+
+    @inline(__always)
     private static func exactContainer(_ value: Any) -> ExactContainer? {
         let valueType = Swift.type(of: value)
 
@@ -367,13 +460,10 @@ internal enum Utils {
             _ dict: [AnyHashable: Value],
             assign: @escaping Assign
         ) {
-            var entries: [(String, Any?)] = []
-            entries.reserveCapacity(dict.count)
-            for (keyHash, child) in dict {
-                if Utils.isOverflowKey(keyHash) { continue }
-                entries.append((String(describing: keyHash), Utils.eraseOptionalLike(child)))
-            }
-            scheduleDictionaryEntries(entries, assign: assign)
+            scheduleDictionaryEntries(
+                Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict),
+                assign: assign
+            )
         }
 
         @inline(__always)
@@ -391,13 +481,11 @@ internal enum Utils {
                 return
             }
 
-            var entries: [(String, Any?)] = []
-            entries.reserveCapacity(dict.count)
-            for (key, child) in dict {
-                if let keyHash = key as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
-                entries.append((String(describing: key), child))
-            }
-            scheduleDictionaryEntries(entries, assign: assign, foundationID: foundationID)
+            scheduleDictionaryEntries(
+                Utils.stringifiedEntriesPreservingStringKeyPrecedence(dict),
+                assign: assign,
+                foundationID: foundationID
+            )
         }
 
         @inline(__always)
@@ -464,13 +552,15 @@ internal enum Utils {
                     scheduleFoundationArray(array, assign: assign)
                     continue
                 case .genericDictionary(let dict):
-                    var entries: [(String, Any?)] = []
-                    entries.reserveCapacity(dict._qsCount)
+                    var rawEntries: [(AnyHashable, Any?)] = []
+                    rawEntries.reserveCapacity(dict._qsCount)
                     dict._qsForEachEntry { keyHash, child in
-                        if Utils.isOverflowKey(keyHash) { return }
-                        entries.append((String(describing: keyHash), child))
+                        rawEntries.append((keyHash, child))
                     }
-                    scheduleDictionaryEntries(entries, assign: assign)
+                    scheduleDictionaryEntries(
+                        Utils.stringifiedEntriesPreservingStringKeyPrecedence(rawEntries),
+                        assign: assign
+                    )
                     continue
                 case .genericArray(let array):
                     let box = ArrayBox(array._qsCount)

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -312,7 +312,13 @@ internal enum Utils {
 
     @inline(never)
     internal static func deepBridgeToAnyIterative(_ root: Any?) -> Any {
-        final class DictBox { var dict: [String: Any] = [:] }
+        final class DictBox {
+            var dict: [String: Any]
+            init(_ capacity: Int) {
+                self.dict = [:]
+                self.dict.reserveCapacity(capacity)
+            }
+        }
         final class ArrayBox {
             var arr: [Any]
             init(_ count: Int) { self.arr = Array(repeating: NSNull(), count: count) }
@@ -321,22 +327,98 @@ internal enum Utils {
         typealias Assign = (Any) -> Void
         enum Task {
             case build(node: Any?, assign: Assign)
-            case commitDict(DictBox, Assign)
-            case commitArray(ArrayBox, Assign)
+            case commitDict(DictBox, ObjectIdentifier?, Assign)
+            case commitArray(ArrayBox, ObjectIdentifier?, Assign)
         }
 
         var result: Any = NSNull()
         var stack: [Task] = [.build(node: root, assign: { result = $0 })]
+        var activeFoundationContainers: Set<ObjectIdentifier> = []
+        var completedFoundationContainers: [ObjectIdentifier: Any] = [:]
+
+        @inline(__always)
+        func scheduleDictionaryEntries(
+            _ entries: [(String, Any?)],
+            assign: @escaping Assign,
+            foundationID: ObjectIdentifier? = nil
+        ) {
+            let box = DictBox(entries.count)
+            stack.append(.commitDict(box, foundationID, assign))
+            for (key, child) in entries.reversed() {
+                stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
+            }
+        }
 
         @inline(__always)
         func scheduleStringDictionary<Value>(
             _ dict: [String: Value],
             assign: @escaping Assign
         ) {
-            let box = DictBox()
-            stack.append(.commitDict(box, assign))
+            var entries: [(String, Any?)] = []
+            entries.reserveCapacity(dict.count)
             for (key, child) in dict {
-                stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
+                entries.append((key, Utils.eraseOptionalLike(child)))
+            }
+            scheduleDictionaryEntries(entries, assign: assign)
+        }
+
+        @inline(__always)
+        func scheduleAnyHashableDictionary<Value>(
+            _ dict: [AnyHashable: Value],
+            assign: @escaping Assign
+        ) {
+            var entries: [(String, Any?)] = []
+            entries.reserveCapacity(dict.count)
+            for (keyHash, child) in dict {
+                if Utils.isOverflowKey(keyHash) { continue }
+                entries.append((String(describing: keyHash), Utils.eraseOptionalLike(child)))
+            }
+            scheduleDictionaryEntries(entries, assign: assign)
+        }
+
+        @inline(__always)
+        func scheduleFoundationDictionary(
+            _ dict: NSDictionary,
+            assign: @escaping Assign
+        ) {
+            let foundationID = ObjectIdentifier(dict)
+            if let cached = completedFoundationContainers[foundationID] {
+                assign(cached)
+                return
+            }
+            guard activeFoundationContainers.insert(foundationID).inserted else {
+                assign(NSNull())
+                return
+            }
+
+            var entries: [(String, Any?)] = []
+            entries.reserveCapacity(dict.count)
+            for (key, child) in dict {
+                if let keyHash = key as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+                entries.append((String(describing: key), child))
+            }
+            scheduleDictionaryEntries(entries, assign: assign, foundationID: foundationID)
+        }
+
+        @inline(__always)
+        func scheduleFoundationArray(
+            _ array: NSArray,
+            assign: @escaping Assign
+        ) {
+            let foundationID = ObjectIdentifier(array)
+            if let cached = completedFoundationContainers[foundationID] {
+                assign(cached)
+                return
+            }
+            guard activeFoundationContainers.insert(foundationID).inserted else {
+                assign(NSNull())
+                return
+            }
+
+            let box = ArrayBox(array.count)
+            stack.append(.commitArray(box, foundationID, assign))
+            for (index, child) in array.enumerated() {
+                stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
             }
         }
 
@@ -356,65 +438,43 @@ internal enum Utils {
                     scheduleStringDictionary(dict, assign: assign)
                     continue
                 case .anyHashableOptional(let dictAHOpt):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
-                    for (keyHash, child) in dictAHOpt {
-                        if Utils.isOverflowKey(keyHash) { continue }
-                        let keyString = String(describing: keyHash)
-                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
-                    }
+                    scheduleAnyHashableDictionary(dictAHOpt, assign: assign)
                     continue
                 case .anyHashableAny(let dictAH):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
-                    for (keyHash, child) in dictAH {
-                        if Utils.isOverflowKey(keyHash) { continue }
-                        let keyString = String(describing: keyHash)
-                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
-                    }
+                    scheduleAnyHashableDictionary(dictAH, assign: assign)
                     continue
                 case .arrayAny(let arr):
                     let box = ArrayBox(arr.count)
-                    stack.append(.commitArray(box, assign))
+                    stack.append(.commitArray(box, nil, assign))
                     for (index, child) in arr.enumerated() {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
                 case .arrayOptional(let arrOpt):
                     let box = ArrayBox(arrOpt.count)
-                    stack.append(.commitArray(box, assign))
+                    stack.append(.commitArray(box, nil, assign))
                     for (index, child) in arrOpt.enumerated() {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
                 case .foundationDictionary(let dict):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
-                    for (key, child) in dict {
-                        if let keyHash = key as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
-                        let keyString = String(describing: key)
-                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
-                    }
+                    scheduleFoundationDictionary(dict, assign: assign)
                     continue
                 case .foundationArray(let array):
-                    let box = ArrayBox(array.count)
-                    stack.append(.commitArray(box, assign))
-                    for (index, child) in array.enumerated() {
-                        stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
-                    }
+                    scheduleFoundationArray(array, assign: assign)
                     continue
                 case .genericDictionary(let dict):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
+                    var entries: [(String, Any?)] = []
+                    entries.reserveCapacity(dict._qsCount)
                     dict._qsForEachEntry { keyHash, child in
                         if Utils.isOverflowKey(keyHash) { return }
-                        let keyString = String(describing: keyHash)
-                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
+                        entries.append((String(describing: keyHash), child))
                     }
+                    scheduleDictionaryEntries(entries, assign: assign)
                     continue
                 case .genericArray(let array):
                     let box = ArrayBox(array._qsCount)
-                    stack.append(.commitArray(box, assign))
+                    stack.append(.commitArray(box, nil, assign))
                     array._qsForEachElement { index, child in
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
@@ -425,10 +485,18 @@ internal enum Utils {
 
                 assign(node)
 
-            case .commitDict(let box, let assign):
+            case .commitDict(let box, let foundationID, let assign):
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                    completedFoundationContainers[foundationID] = box.dict
+                }
                 assign(box.dict)
 
-            case .commitArray(let box, let assign):
+            case .commitArray(let box, let foundationID, let assign):
+                if let foundationID {
+                    activeFoundationContainers.remove(foundationID)
+                    completedFoundationContainers[foundationID] = box.arr
+                }
                 assign(box.arr)
             }
         }
@@ -442,6 +510,7 @@ internal enum Utils {
     #endif
     internal static func containsUndefined(_ root: Any?) -> Bool {
         var stack: [Any?] = [root]
+        var visitedFoundationContainers: Set<ObjectIdentifier> = []
         while let node = stack.popLast() {
             if node is Undefined { return true }
             guard let node else { continue }
@@ -463,9 +532,11 @@ internal enum Utils {
                 stack.reserveCapacity(stack.count + array.count)
                 for child in array { stack.append(child) }
             case .foundationDictionary(let dict):
+                guard visitedFoundationContainers.insert(ObjectIdentifier(dict)).inserted else { continue }
                 stack.reserveCapacity(stack.count + dict.count)
                 for (_, child) in dict { stack.append(child) }
             case .foundationArray(let array):
+                guard visitedFoundationContainers.insert(ObjectIdentifier(array)).inserted else { continue }
                 stack.reserveCapacity(stack.count + array.count)
                 for child in array { stack.append(child) }
             case .genericDictionary(let dict):

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -227,10 +227,11 @@ internal enum Utils {
 
     @inline(__always)
     static func eraseOptionalLike<T>(_ value: T) -> Any? {
-        if let optional = value as? QsOptionalValue {
-            return optional._qsWrappedAny
+        var current: Any? = value
+        while let wrapped = current, let optional = wrapped as? QsOptionalValue {
+            current = optional._qsWrappedAny
         }
-        return value
+        return current
     }
 
     @inline(__always)
@@ -292,7 +293,7 @@ internal enum Utils {
             mergeStringifiedEntry(
                 String(describing: keyHash),
                 rank: keyHash.base is String ? 2 : 1,
-                value: child,
+                value: eraseOptionalLike(child),
                 entries: &entries,
                 indexByKey: &indexByKey,
                 ranksByKey: &ranksByKey
@@ -316,7 +317,7 @@ internal enum Utils {
             mergeStringifiedEntry(
                 String(describing: rawKey),
                 rank: rawKey is String ? 2 : 1,
-                value: child,
+                value: eraseOptionalLike(child),
                 entries: &entries,
                 indexByKey: &indexByKey,
                 ranksByKey: &ranksByKey
@@ -438,7 +439,7 @@ internal enum Utils {
             let box = DictBox(entries.count)
             stack.append(.commitDict(box, foundationID, assign))
             for (key, child) in entries.reversed() {
-                stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
+                stack.append(.build(node: Utils.eraseOptionalLike(child), assign: { value in box.dict[key] = value }))
             }
         }
 
@@ -506,7 +507,7 @@ internal enum Utils {
             let box = ArrayBox(array.count)
             stack.append(.commitArray(box, foundationID, assign))
             for (index, child) in array.enumerated() {
-                stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
+                stack.append(.build(node: Utils.eraseOptionalLike(child), assign: { value in box.arr[index] = value }))
             }
         }
 
@@ -535,14 +536,16 @@ internal enum Utils {
                     let box = ArrayBox(arr.count)
                     stack.append(.commitArray(box, nil, assign))
                     for (index, child) in arr.enumerated() {
-                        stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
+                        stack.append(
+                            .build(node: Utils.eraseOptionalLike(child), assign: { value in box.arr[index] = value }))
                     }
                     continue
                 case .arrayOptional(let arrOpt):
                     let box = ArrayBox(arrOpt.count)
                     stack.append(.commitArray(box, nil, assign))
                     for (index, child) in arrOpt.enumerated() {
-                        stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
+                        stack.append(
+                            .build(node: Utils.eraseOptionalLike(child), assign: { value in box.arr[index] = value }))
                     }
                     continue
                 case .foundationDictionary(let dict):

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -375,6 +375,80 @@ internal enum Utils {
         return nil
     }
 
+    @inline(__always)
+    internal static func withExactStringifiedEntries<R>(
+        _ value: Any,
+        _ body: ([(String, Any?)]) -> R
+    ) -> R? {
+        switch exactContainer(value) {
+        case .stringOptional(let dict):
+            var entries: [(String, Any?)] = []
+            entries.reserveCapacity(dict.count)
+            for (key, child) in dict {
+                entries.append((key, eraseOptionalLike(child)))
+            }
+            return body(entries)
+        case .stringAny(let dict):
+            var entries: [(String, Any?)] = []
+            entries.reserveCapacity(dict.count)
+            for (key, child) in dict {
+                entries.append((key, eraseOptionalLike(child)))
+            }
+            return body(entries)
+        case .anyHashableOptional(let dict):
+            return body(stringifiedEntriesPreservingStringKeyPrecedence(dict))
+        case .anyHashableAny(let dict):
+            return body(stringifiedEntriesPreservingStringKeyPrecedence(dict))
+        case .foundationDictionary(let dict):
+            return body(stringifiedEntriesPreservingStringKeyPrecedence(dict))
+        case .genericDictionary(let dict):
+            var rawEntries: [(AnyHashable, Any?)] = []
+            rawEntries.reserveCapacity(dict._qsCount)
+            dict._qsForEachEntry { keyHash, child in
+                rawEntries.append((keyHash, child))
+            }
+            return body(stringifiedEntriesPreservingStringKeyPrecedence(rawEntries))
+        case .arrayAny, .arrayOptional, .foundationArray, .genericArray, nil:
+            return nil
+        }
+    }
+
+    @inline(__always)
+    internal static func withExactArrayElements<R>(
+        _ value: Any,
+        _ body: (_ count: Int, _ visit: (@escaping (Any?) -> Void) -> Void) -> R
+    ) -> R? {
+        switch exactContainer(value) {
+        case .arrayAny(let array):
+            return body(array.count) { visit in
+                for element in array {
+                    visit(eraseOptionalLike(element))
+                }
+            }
+        case .arrayOptional(let array):
+            return body(array.count) { visit in
+                for element in array {
+                    visit(eraseOptionalLike(element))
+                }
+            }
+        case .foundationArray(let array):
+            return body(array.count) { visit in
+                for element in array {
+                    visit(eraseOptionalLike(element))
+                }
+            }
+        case .genericArray(let array):
+            return body(array._qsCount) { visit in
+                array._qsForEachElement { _, child in
+                    visit(child)
+                }
+            }
+        case .stringAny, .stringOptional, .anyHashableAny, .anyHashableOptional,
+            .foundationDictionary, .genericDictionary, nil:
+            return nil
+        }
+    }
+
     // MARK: - Is Empty Check
 
     /// Checks if a value is empty. A value is considered empty if it is nil, Undefined, an empty

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -492,31 +492,31 @@ internal enum Utils {
     @inline(__always)
     internal static func withExactArrayElements<R>(
         _ value: Any,
-        _ body: (_ count: Int, _ visit: (@escaping (Any?) -> Void) -> Void) -> R
+        _ body: (_ count: Int, _ visit: (@escaping (_ index: Int, _ child: Any?) -> Void) -> Void) -> R
     ) -> R? {
         switch exactContainer(value) {
         case .arrayAny(let array):
             return body(array.count) { visit in
-                for element in array {
-                    visit(eraseOptionalLike(element))
+                for (index, element) in array.enumerated() {
+                    visit(index, eraseOptionalLike(element))
                 }
             }
         case .arrayOptional(let array):
             return body(array.count) { visit in
-                for element in array {
-                    visit(eraseOptionalLike(element))
+                for (index, element) in array.enumerated() {
+                    visit(index, eraseOptionalLike(element))
                 }
             }
         case .foundationArray(let array):
             return body(array.count) { visit in
-                for element in array {
-                    visit(eraseOptionalLike(element))
+                for (index, element) in array.enumerated() {
+                    visit(index, eraseOptionalLike(element))
                 }
             }
         case .genericArray(let array):
             return body(array._qsCount) { visit in
-                array._qsForEachElement { _, child in
-                    visit(child)
+                array._qsForEachElement { index, child in
+                    visit(index, child)
                 }
             }
         case .stringAny, .stringOptional, .anyHashableAny, .anyHashableOptional,

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -149,6 +149,8 @@ internal enum Utils {
         case anyHashableOptional([AnyHashable: Any?])
         case arrayAny([Any])
         case arrayOptional([Any?])
+        case foundationDictionary(NSDictionary)
+        case foundationArray(NSArray)
     }
 
     @inline(__always)
@@ -182,6 +184,12 @@ internal enum Utils {
         }
         if let array = exactCast([Any?].self) {
             return .arrayOptional(array)
+        }
+        if valueType is AnyClass, let dict = value as? NSDictionary {
+            return .foundationDictionary(dict)
+        }
+        if valueType is AnyClass, let array = value as? NSArray {
+            return .foundationArray(array)
         }
 
         return nil
@@ -289,6 +297,22 @@ internal enum Utils {
                         stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
                     }
                     continue
+                case .foundationDictionary(let dict):
+                    let box = DictBox()
+                    stack.append(.commitDict(box, assign))
+                    for (key, child) in dict {
+                        if let keyHash = key as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+                        let keyString = String(describing: key)
+                        stack.append(.build(node: child, assign: { value in box.dict[keyString] = value }))
+                    }
+                    continue
+                case .foundationArray(let array):
+                    let box = ArrayBox(array.count)
+                    stack.append(.commitArray(box, assign))
+                    for (index, child) in array.enumerated() {
+                        stack.append(.build(node: child, assign: { value in box.arr[index] = value }))
+                    }
+                    continue
                 case nil:
                     break
                 }
@@ -332,6 +356,12 @@ internal enum Utils {
             case .arrayAny(let array):
                 stack.reserveCapacity(stack.count + array.count)
                 for child in array { stack.append(child) }
+            case .foundationDictionary(let dict):
+                stack.reserveCapacity(stack.count + dict.count)
+                for (_, child) in dict { stack.append(child) }
+            case .foundationArray(let array):
+                stack.reserveCapacity(stack.count + array.count)
+                for child in array { stack.append(child) }
             case nil:
                 break
             }
@@ -362,7 +392,10 @@ internal enum Utils {
             case .anyHashableAny(let dict):
                 guard dict.count == 1, let next = dict.first?.value else { return depth }
                 current = next
-            case .arrayAny, .arrayOptional, nil:
+            case .foundationDictionary(let dict):
+                guard dict.count == 1, let next = dict.objectEnumerator().nextObject() else { return depth }
+                current = next
+            case .arrayAny, .arrayOptional, .foundationArray, nil:
                 return depth
             }
             depth += 1

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -328,6 +328,18 @@ internal enum Utils {
         var result: Any = NSNull()
         var stack: [Task] = [.build(node: root, assign: { result = $0 })]
 
+        @inline(__always)
+        func scheduleStringDictionary<Value>(
+            _ dict: [String: Value],
+            assign: @escaping Assign
+        ) {
+            let box = DictBox()
+            stack.append(.commitDict(box, assign))
+            for (key, child) in dict {
+                stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
+            }
+        }
+
         while let task = stack.popLast() {
             switch task {
             case .build(let node, let assign):
@@ -338,18 +350,10 @@ internal enum Utils {
 
                 switch exactContainer(node) {
                 case .stringOptional(let dict):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
-                    for (key, child) in dict {
-                        stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
-                    }
+                    scheduleStringDictionary(dict, assign: assign)
                     continue
                 case .stringAny(let dict):
-                    let box = DictBox()
-                    stack.append(.commitDict(box, assign))
-                    for (key, child) in dict {
-                        stack.append(.build(node: child, assign: { value in box.dict[key] = value }))
-                    }
+                    scheduleStringDictionary(dict, assign: assign)
                     continue
                 case .anyHashableOptional(let dictAHOpt):
                     let box = DictBox()

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -17,27 +17,27 @@ extension Optional: QsOptionalValue {
     }
 }
 
-protocol QsErasedDictionaryContainer {
+private protocol QsErasedDictionaryContainer {
     var _qsCount: Int { get }
     func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void)
     func _qsFirstEntry() -> (key: AnyHashable, value: Any?)?
 }
 
-protocol QsErasedArrayContainer {
+private protocol QsErasedArrayContainer {
     var _qsCount: Int { get }
     func _qsForEachElement(_ body: (Int, Any?) -> Void)
 }
 
 extension Dictionary: QsErasedDictionaryContainer where Key: Hashable {
-    var _qsCount: Int { count }
+    fileprivate var _qsCount: Int { count }
 
-    func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
+    fileprivate func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
         for (key, value) in self {
             body(AnyHashable(key), Utils.eraseOptionalLike(value))
         }
     }
 
-    func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
+    fileprivate func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
         for (key, value) in self {
             return (AnyHashable(key), Utils.eraseOptionalLike(value))
         }
@@ -46,15 +46,15 @@ extension Dictionary: QsErasedDictionaryContainer where Key: Hashable {
 }
 
 extension OrderedDictionary: QsErasedDictionaryContainer where Key: Hashable {
-    var _qsCount: Int { count }
+    fileprivate var _qsCount: Int { count }
 
-    func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
+    fileprivate func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void) {
         for (key, value) in self {
             body(AnyHashable(key), Utils.eraseOptionalLike(value))
         }
     }
 
-    func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
+    fileprivate func _qsFirstEntry() -> (key: AnyHashable, value: Any?)? {
         for (key, value) in self {
             return (AnyHashable(key), Utils.eraseOptionalLike(value))
         }
@@ -63,9 +63,9 @@ extension OrderedDictionary: QsErasedDictionaryContainer where Key: Hashable {
 }
 
 extension Array: QsErasedArrayContainer {
-    var _qsCount: Int { count }
+    fileprivate var _qsCount: Int { count }
 
-    func _qsForEachElement(_ body: (Int, Any?) -> Void) {
+    fileprivate func _qsForEachElement(_ body: (Int, Any?) -> Void) {
         for (index, value) in enumerated() {
             body(index, Utils.eraseOptionalLike(value))
         }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -252,6 +252,10 @@ internal enum Utils {
         }
     }
 
+    private struct SingleLogicalEntry {
+        let value: Any?
+    }
+
     @inline(__always)
     private static func mergeStringifiedEntry(
         _ keyString: String,
@@ -326,6 +330,77 @@ internal enum Utils {
         }
 
         return state.entries
+    }
+
+    @inline(__always)
+    private static func singleValueIfSingleLogicalEntry<Value>(
+        _ dict: [String: Value]
+    ) -> SingleLogicalEntry? {
+        guard dict.count == 1, let entry = dict.first else { return nil }
+        return SingleLogicalEntry(value: eraseOptionalLike(entry.value))
+    }
+
+    @inline(__always)
+    private static func singleValueIfSingleLogicalEntry<Value>(
+        _ dict: [AnyHashable: Value]
+    ) -> SingleLogicalEntry? {
+        var state = EntryMergeState(capacity: min(dict.count, 2))
+
+        for (keyHash, child) in dict {
+            if Utils.isOverflowKey(keyHash) { continue }
+            mergeStringifiedEntry(
+                String(describing: keyHash),
+                rank: keyHash.base is String ? 2 : 1,
+                value: eraseOptionalLike(child),
+                state: &state
+            )
+            if state.entries.count > 1 { return nil }
+        }
+
+        guard state.entries.count == 1 else { return nil }
+        return SingleLogicalEntry(value: state.entries[0].1)
+    }
+
+    @inline(__always)
+    private static func singleValueIfSingleLogicalEntry(
+        _ dict: NSDictionary
+    ) -> SingleLogicalEntry? {
+        var state = EntryMergeState(capacity: min(dict.count, 2))
+
+        for (rawKey, child) in dict {
+            if let keyHash = rawKey as? AnyHashable, Utils.isOverflowKey(keyHash) { continue }
+            mergeStringifiedEntry(
+                String(describing: rawKey),
+                rank: rawKey is String ? 2 : 1,
+                value: eraseOptionalLike(child),
+                state: &state
+            )
+            if state.entries.count > 1 { return nil }
+        }
+
+        guard state.entries.count == 1 else { return nil }
+        return SingleLogicalEntry(value: state.entries[0].1)
+    }
+
+    @inline(__always)
+    private static func singleValueIfSingleLogicalEntry(
+        _ dict: any QsErasedDictionaryContainer
+    ) -> SingleLogicalEntry? {
+        var state = EntryMergeState(capacity: min(dict._qsCount, 2))
+
+        dict._qsForEachEntry { keyHash, child in
+            guard state.entries.count <= 1 else { return }
+            if Utils.isOverflowKey(keyHash) { return }
+            mergeStringifiedEntry(
+                String(describing: keyHash),
+                rank: keyHash.base is String ? 2 : 1,
+                value: eraseOptionalLike(child),
+                state: &state
+            )
+        }
+
+        guard state.entries.count == 1 else { return nil }
+        return SingleLogicalEntry(value: state.entries[0].1)
     }
 
     @inline(__always)
@@ -589,7 +664,7 @@ internal enum Utils {
         while let task = stack.popLast() {
             switch task {
             case .build(let node, let assign):
-                guard let node else {
+                guard let node = Utils.eraseOptionalLike(node) else {
                     assign(NSNull())
                     continue
                 }
@@ -742,23 +817,23 @@ internal enum Utils {
 
             switch exactContainer(currentValue) {
             case .stringOptional(let dict):
-                guard dict.count == 1, let entry = dict.first else { return depth }
-                current = eraseOptionalLike(entry.value)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .stringAny(let dict):
-                guard dict.count == 1, let next = dict.first?.value else { return depth }
-                current = eraseOptionalLike(next)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .anyHashableOptional(let dict):
-                guard dict.count == 1, let entry = dict.first else { return depth }
-                current = eraseOptionalLike(entry.value)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .anyHashableAny(let dict):
-                guard dict.count == 1, let next = dict.first?.value else { return depth }
-                current = eraseOptionalLike(next)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .foundationDictionary(let dict):
-                guard dict.count == 1, let next = dict.objectEnumerator().nextObject() else { return depth }
-                current = eraseOptionalLike(next)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .genericDictionary(let dict):
-                guard dict._qsCount == 1, let entry = dict._qsFirstEntry() else { return depth }
-                current = eraseOptionalLike(entry.value)
+                guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }
+                current = eraseOptionalLike(next.value)
             case .arrayAny, .arrayOptional, .foundationArray, .genericArray, nil:
                 return depth
             }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -235,6 +235,12 @@ internal enum Utils {
     }
 
     @inline(__always)
+    static func eraseOptionalElement(_ value: Any?) -> Any? {
+        guard let value else { return nil }
+        return eraseOptionalLike(value)
+    }
+
+    @inline(__always)
     private static func mergeStringifiedEntry(
         _ keyString: String,
         rank: Int,

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -741,29 +741,29 @@ internal enum Utils {
     @inline(__always)
     internal static func estimateSingleKeyChainDepth(_ value: Any?, cap: Int = 20_000) -> Int {
         var depth = 0
-        var current = value
+        var current = eraseOptionalLike(value)
         while depth < cap {
-            guard let currentValue = current else { return depth }
+            guard let currentValue = eraseOptionalLike(current) else { return depth }
 
             switch exactContainer(currentValue) {
             case .stringOptional(let dict):
                 guard dict.count == 1, let entry = dict.first else { return depth }
-                current = entry.value
+                current = eraseOptionalLike(entry.value)
             case .stringAny(let dict):
                 guard dict.count == 1, let next = dict.first?.value else { return depth }
-                current = next
+                current = eraseOptionalLike(next)
             case .anyHashableOptional(let dict):
                 guard dict.count == 1, let entry = dict.first else { return depth }
-                current = entry.value
+                current = eraseOptionalLike(entry.value)
             case .anyHashableAny(let dict):
                 guard dict.count == 1, let next = dict.first?.value else { return depth }
-                current = next
+                current = eraseOptionalLike(next)
             case .foundationDictionary(let dict):
                 guard dict.count == 1, let next = dict.objectEnumerator().nextObject() else { return depth }
-                current = next
+                current = eraseOptionalLike(next)
             case .genericDictionary(let dict):
                 guard dict._qsCount == 1, let entry = dict._qsFirstEntry() else { return depth }
-                current = entry.value
+                current = eraseOptionalLike(entry.value)
             case .arrayAny, .arrayOptional, .foundationArray, .genericArray, nil:
                 return depth
             }

--- a/Sources/QsSwift/Internal/Utils.swift
+++ b/Sources/QsSwift/Internal/Utils.swift
@@ -2,6 +2,8 @@
 import Foundation
 import OrderedCollections
 
+// Cheap protocol-based optional erasure used throughout decode hot paths.
+// This lets us unwrap Optional values hidden behind `Any` without paying for Mirror.
 private protocol QsOptionalValue {
     var _qsWrappedAny: Any? { get }
 }
@@ -17,6 +19,9 @@ extension Optional: QsOptionalValue {
     }
 }
 
+// Type-erased traversal hooks for generic Array/Dictionary/OrderedDictionary values.
+// These preserve support for typed Swift containers like `[Int: String]` without falling
+// back to the broad runtime casts that became unsafe on Swift 6.3 for deep graphs.
 private protocol QsErasedDictionaryContainer {
     var _qsCount: Int { get }
     func _qsForEachEntry(_ body: (AnyHashable, Any?) -> Void)
@@ -240,6 +245,9 @@ internal enum Utils {
         return eraseOptionalLike(value)
     }
 
+    // Tracks stringified dictionary entries while resolving collisions such as `1` vs `"1"`.
+    // We keep the first stable insertion slot for a logical key, but allow a higher-ranked
+    // string key to replace the value later.
     private struct EntryMergeState {
         var entries: [(String, Any?)] = []
         var indexByKey: [String: Int] = [:]
@@ -263,6 +271,8 @@ internal enum Utils {
         value: Any?,
         state: inout EntryMergeState
     ) {
+        // Higher rank means "more string-like". This preserves the public collision policy
+        // where real string keys win over non-string keys with the same textual form.
         if let existingIndex = state.indexByKey[keyString] {
             guard let existingRank = state.ranksByKey[keyString], rank >= existingRank else { return }
             state.entries[existingIndex] = (keyString, value)
@@ -409,6 +419,9 @@ internal enum Utils {
 
         @inline(__always)
         func exactCast<T>(_ type: T.Type) -> T? {
+            // `value as? T` alone is too permissive here: it can trigger recursive bridging
+            // between container shapes such as `[String: Any]` and `[String: Any?]`.
+            // Matching the runtime type first keeps traversal classification exact.
             guard valueType == type else { return nil }
             guard let typed = value as? T else {
                 assertionFailure("Exact cast failed for runtime type \(valueType)")
@@ -456,6 +469,9 @@ internal enum Utils {
         _ value: Any,
         _ body: ([(String, Any?)]) -> R
     ) -> R? {
+        // Normalize every dictionary-like input into a single `[(String, Any?)]` view so the
+        // traversal/compaction code can apply one collision policy for Swift, generic, and
+        // Foundation-backed maps.
         switch exactContainer(value) {
         case .stringOptional(let dict):
             var entries: [(String, Any?)] = []
@@ -588,6 +604,8 @@ internal enum Utils {
         ) {
             let box = DictBox(entries.count)
             stack.append(.commitDict(box, foundationID, assign))
+            // The traversal stack is LIFO, so we enqueue children in reverse to preserve the
+            // original logical insertion order in the final dictionary.
             for (key, child) in entries.reversed() {
                 stack.append(.build(node: Utils.eraseOptionalLike(child), assign: { value in box.dict[key] = value }))
             }
@@ -623,6 +641,9 @@ internal enum Utils {
             assign: @escaping Assign
         ) {
             let foundationID = ObjectIdentifier(dict)
+            // Foundation containers can be self-referential. While a node is actively being built,
+            // a recursive reference collapses to `NSNull()`. Once completed, sibling references
+            // can reuse the cached bridged value instead of rebuilding the subtree.
             if let cached = completedFoundationContainers[foundationID] {
                 assign(cached)
                 return
@@ -765,6 +786,8 @@ internal enum Utils {
             if node is Undefined { return true }
             guard let node else { continue }
 
+            // Swift value containers cannot form true retain cycles on their own, but Foundation
+            // collections can, so only the Foundation branches need identity-based cycle guards.
             switch exactContainer(node) {
             case .stringOptional(let dict):
                 stack.reserveCapacity(stack.count + dict.count)
@@ -815,6 +838,8 @@ internal enum Utils {
         while depth < cap {
             guard let currentValue = eraseOptionalLike(current) else { return depth }
 
+            // Follow only the logically single child after overflow-bookkeeping keys and
+            // string/non-string key collisions have been normalized away.
             switch exactContainer(currentValue) {
             case .stringOptional(let dict):
                 guard let next = singleValueIfSingleLogicalEntry(dict) else { return depth }

--- a/Sources/QsSwift/Qs+Decode.swift
+++ b/Sources/QsSwift/Qs+Decode.swift
@@ -16,7 +16,7 @@ extension Qs {
     /// long single-key chains (e.g. `["p": ["p": ...]]`) which risks a `EXC_BAD_ACCESS`
     /// in a background thread. Handing the *final release* to the main thread avoids
     /// that destructor recursion in practice.
-    private static let MAIN_DROP_THRESHOLD = 2500
+    internal static let MAIN_DROP_THRESHOLD = 1_200
 
     // MARK: - Public API (Sync)
 

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1929,7 +1929,7 @@ struct DoesNotCrashTests {
     ///       `testDecode_DeepMaps_NoTimeout_Main` is designed for that purpose.
     @Test("decode - deep maps do not time out")
     func testDecode_DeepMaps_NoTimeout_Safe() async throws {
-        let depth = 2500  // conservative to avoid ARC’s recursive deinit on worker threads
+        let depth = 1_200  // Swift 6.3 reduced worker-thread stack headroom for deep dictionary teardown
         var s = "foo"
         for _ in 0..<depth { s += "[p]" }
         s += "=bar"

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1434,6 +1434,33 @@ struct DecodeTests {
         #expect(nested?["drop"] == nil)
     }
 
+    @Test("decode - bridges typed Swift containers in map input")
+    func testDecode_MapInputBridgesTypedSwiftContainers() throws {
+        let input: [String: Any] = [
+            "dict": [1: "x"] as [Int: String],
+            "array": [nil, "y"] as [String?],
+        ]
+
+        let decoded = try Qs.decode(input)
+        let nestedDict = decoded["dict"] as? [String: Any]
+        let nestedArray = decoded["array"] as? [Any]
+        #expect(nestedDict?["1"] as? String == "x")
+        #expect(nestedArray?.count == 2)
+        #expect(nestedArray?.first is NSNull)
+        #expect(nestedArray?[1] as? String == "y")
+    }
+
+    @Test("decode - compacts typed Swift dictionaries in map input")
+    func testDecode_MapInputCompactsTypedSwiftDictionaries() throws {
+        let input: [String: Any] = [
+            "a": ["drop": Undefined.instance] as [String: Undefined]
+        ]
+
+        let decoded = try Qs.decode(input)
+        let nested = decoded["a"] as? [String: Any]
+        #expect(nested?.isEmpty == true)
+    }
+
     @Test("decode - preserves direct map inputs with nil placeholders")
     func testDecode_MapVariants() throws {
         let optionalMap = try Qs._decodeSyncCore(["a": nil, "b": "two"] as [String: Any?])
@@ -1951,7 +1978,7 @@ struct DoesNotCrashTests {
     ///       `testDecode_DeepMaps_NoTimeout_Main` is designed for that purpose.
     @Test("decode - deep maps do not time out")
     func testDecode_DeepMaps_NoTimeout_Safe() async throws {
-        let depth = 1_200  // Swift 6.3 reduced worker-thread stack headroom for deep dictionary teardown
+        let depth = Qs.MAIN_DROP_THRESHOLD
         var s = "foo"
         for _ in 0..<depth { s += "[p]" }
         s += "=bar"
@@ -1970,7 +1997,7 @@ struct DoesNotCrashTests {
 
     @Test("decode - deep merge conflict does not overflow stack")
     func testDecode_DeepMergeConflict_NoStackOverflow() throws {
-        let depth = 1_200
+        let depth = Qs.MAIN_DROP_THRESHOLD
         var left = "root"
         var right = "root"
         for _ in 0..<depth {

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1205,30 +1205,30 @@ struct DecodeTests {
         // a[1][b][2][c]=1 -> ["a": [ { "b": [ { "c": "1" } ] } ]]
         do {
             let r = try Qs.decode("a[1][b][2][c]=1", options: DecodeOptions(listLimit: 20))
-            let a = r["a"] as? [Any]
-            let level1 = a?.first as? [String: Any]
-            let bArr = level1?["b"] as? [Any]
-            let firstMap = bArr?.first as? [String: Any]
+            let a = arrayElements(r["a"])
+            let level1 = a.flatMap { asDictString($0[0]) }
+            let bArr = arrayElements(level1?["b"])
+            let firstMap = bArr.flatMap { asDictString($0[0]) }
             #expect((firstMap?["c"] as? String) == "1")
         }
 
         // a[1][2][3][c]=1 -> ["a": [[[ { "c": "1" } ]]]]
         do {
             let r = try Qs.decode("a[1][2][3][c]=1", options: DecodeOptions(listLimit: 20))
-            let a = r["a"] as? [Any]
-            let l1 = a?.first as? [Any]
-            let l2 = l1?.first as? [Any]
-            let l3 = l2?.first as? [String: Any]
+            let a = arrayElements(r["a"])
+            let l1 = a.flatMap { arrayElements($0[0]) }
+            let l2 = l1.flatMap { arrayElements($0[0]) }
+            let l3 = l2.flatMap { asDictString($0[0]) }
             #expect((l3?["c"] as? String) == "1")
         }
 
         // a[1][2][3][c][1]=1 -> ["a": [[[ { "c": ["1"] } ]]]]
         do {
             let r = try Qs.decode("a[1][2][3][c][1]=1", options: DecodeOptions(listLimit: 20))
-            let a = r["a"] as? [Any]
-            let l1 = a?.first as? [Any]
-            let l2 = l1?.first as? [Any]
-            let l3 = l2?.first as? [String: Any]
+            let a = arrayElements(r["a"])
+            let l1 = a.flatMap { arrayElements($0[0]) }
+            let l2 = l1.flatMap { arrayElements($0[0]) }
+            let l3 = l2.flatMap { asDictString($0[0]) }
             #expect(asStrings(l3?["c"]) == ["1"])
         }
     }
@@ -4297,12 +4297,31 @@ private func unwrapOptional(_ any: Any) -> Any? {
     return m.children.first?.value
 }
 
+private func arrayElements(_ value: Any?) -> [Any]? {
+    guard let value = value.flatMap(unwrapOptional) else { return nil }
+    if let array = value as? [Any] {
+        return array
+    }
+    if let array = value as? [Any?] {
+        return array.map { element in
+            if let element {
+                return unwrapOptional(element) ?? NSNull()
+            }
+            return NSNull()
+        }
+    }
+    if let array = value as? NSArray {
+        return array.map { unwrapOptional($0) ?? NSNull() }
+    }
+    return nil
+}
+
 private func as2DStrings(_ value: Any?) -> [[String]]? {
-    guard let outer = value as? [Any] else { return nil }
+    guard let outer = arrayElements(value) else { return nil }
     var out: [[String]] = []
     out.reserveCapacity(outer.count)
     for innerAny in outer {
-        guard let inner = innerAny as? [Any] else { return nil }
+        guard let inner = arrayElements(innerAny) else { return nil }
         let row = inner.compactMap { unwrapOptional($0) as? String }
         out.append(row)
     }
@@ -4351,7 +4370,7 @@ func parseQuery_interpretsNumericEntities() throws {
 private func isNSNullValue(_ v: Any?) -> Bool { v is NSNull }
 
 private func asStrings(_ v: Any?) -> [String]? {
-    (v as? [Any])?.compactMap { $0 as? String }
+    arrayElements(v)?.compactMap { unwrapOptional($0) as? String }
 }
 
 private func flatStrings(_ v: Any?) -> [String]? {

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1260,7 +1260,9 @@ struct DecodeTests {
                     #expect(l2.count == 1)
 
                     if let l3 = l2.first.flatMap(asDictString) {
-                        #expect(asStrings(l3["c"]) == ["1"])
+                        let c = arrayElements(l3["c"])
+                        #expect(c?.count == 1)
+                        #expect(c?.first as? String == "1")
                     } else {
                         Issue.record("Expected dictionary at a[0][0][0]")
                     }
@@ -1459,7 +1461,9 @@ struct DecodeTests {
         ]
 
         let decoded = try Qs.decode(input)
-        #expect(asStrings(decoded["a"]) == ["x"])
+        let array = arrayElements(decoded["a"])
+        #expect(array?.count == 1)
+        #expect(array?.first as? String == "x")
     }
 
     @Test("decode - bridges nested Foundation dictionaries to Swift string-keyed maps")
@@ -4387,9 +4391,6 @@ private func unwrapOptional(_ any: Any) -> Any? {
 
 private func arrayElements(_ value: Any?) -> [Any]? {
     guard let value = value.flatMap(unwrapOptional) else { return nil }
-    if let array = value as? [Any] {
-        return array
-    }
     if let array = value as? [Any?] {
         return array.map { element in
             if let element {
@@ -4397,6 +4398,9 @@ private func arrayElements(_ value: Any?) -> [Any]? {
             }
             return NSNull()
         }
+    }
+    if let array = value as? [Any] {
+        return array.map { unwrapOptional($0) ?? NSNull() }
     }
     if let array = value as? NSArray {
         return array.map { unwrapOptional($0) ?? NSNull() }

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1206,9 +1206,13 @@ struct DecodeTests {
         do {
             let r = try Qs.decode("a[1][b][2][c]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let level1 = a.flatMap { asDictString($0[0]) }
+            let level1 = a.flatMap { elements in
+                elements.first.flatMap(asDictString)
+            }
             let bArr = arrayElements(level1?["b"])
-            let firstMap = bArr.flatMap { asDictString($0[0]) }
+            let firstMap = bArr.flatMap { elements in
+                elements.first.flatMap(asDictString)
+            }
             #expect((firstMap?["c"] as? String) == "1")
         }
 
@@ -1216,9 +1220,15 @@ struct DecodeTests {
         do {
             let r = try Qs.decode("a[1][2][3][c]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let l1 = a.flatMap { arrayElements($0[0]) }
-            let l2 = l1.flatMap { arrayElements($0[0]) }
-            let l3 = l2.flatMap { asDictString($0[0]) }
+            let l1 = a.flatMap { elements in
+                elements.first.flatMap(arrayElements)
+            }
+            let l2 = l1.flatMap { elements in
+                elements.first.flatMap(arrayElements)
+            }
+            let l3 = l2.flatMap { elements in
+                elements.first.flatMap(asDictString)
+            }
             #expect((l3?["c"] as? String) == "1")
         }
 
@@ -1226,9 +1236,15 @@ struct DecodeTests {
         do {
             let r = try Qs.decode("a[1][2][3][c][1]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let l1 = a.flatMap { arrayElements($0[0]) }
-            let l2 = l1.flatMap { arrayElements($0[0]) }
-            let l3 = l2.flatMap { asDictString($0[0]) }
+            let l1 = a.flatMap { elements in
+                elements.first.flatMap(arrayElements)
+            }
+            let l2 = l1.flatMap { elements in
+                elements.first.flatMap(arrayElements)
+            }
+            let l3 = l2.flatMap { elements in
+                elements.first.flatMap(asDictString)
+            }
             #expect(asStrings(l3?["c"]) == ["1"])
         }
     }

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1550,6 +1550,20 @@ struct DecodeTests {
         #expect(decoded["drop"] == nil)
     }
 
+    @Test("decode - preserves explicit nil entries in typed direct-map dictionaries during compaction")
+    func testDecode_DirectMapTypedDictionaryKeepsNil() throws {
+        let input: [String: Any?] = [
+            "typed": [1: Optional<String>.none] as [Int: String?],
+            "drop": Undefined.instance,
+        ]
+
+        let decoded = try Qs.decode(input)
+        let typed = decoded["typed"] as? [String: Any]
+        #expect(typed?.keys.contains("1") == true)
+        #expect(typed?["1"] is NSNull)
+        #expect(decoded["drop"] == nil)
+    }
+
     @Test("decode - AnyHashable key collisions are deterministic (String wins)")
     func testDecode_AnyHashableKeyCollision_StringWins() throws {
         // Different literal orders, same outcome.

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1535,6 +1535,21 @@ struct DecodeTests {
         #expect(anyMap["b"] as? Int == 2)
     }
 
+    @Test("decode - preserves explicit nil elements in dense direct-map optional arrays during compaction")
+    func testDecode_DirectMapDenseOptionalArrayKeepsNil() throws {
+        let input: [String: Any?] = [
+            "list": [Optional<String>.none, Optional<String>.some("x")] as [String?],
+            "drop": Undefined.instance,
+        ]
+
+        let decoded = try Qs.decode(input)
+        let list = decoded["list"] as? [Any]
+        #expect(list?.count == 2)
+        #expect(list?.first is NSNull)
+        #expect(list?.last as? String == "x")
+        #expect(decoded["drop"] == nil)
+    }
+
     @Test("decode - AnyHashable key collisions are deterministic (String wins)")
     func testDecode_AnyHashableKeyCollision_StringWins() throws {
         // Different literal orders, same outcome.

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1206,46 +1206,70 @@ struct DecodeTests {
         do {
             let r = try Qs.decode("a[1][b][2][c]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let level1 = a.flatMap { elements in
-                elements.first.flatMap(asDictString)
+            #expect(a?.count == 1)
+
+            if let level1 = a?.first.flatMap(asDictString) {
+                let bArr = arrayElements(level1["b"])
+                #expect(bArr?.count == 1)
+
+                if let firstMap = bArr?.first.flatMap(asDictString) {
+                    #expect((firstMap["c"] as? String) == "1")
+                } else {
+                    Issue.record("Expected nested map at a[0].b[0]")
+                }
+            } else {
+                Issue.record("Expected dictionary at a[0]")
             }
-            let bArr = arrayElements(level1?["b"])
-            let firstMap = bArr.flatMap { elements in
-                elements.first.flatMap(asDictString)
-            }
-            #expect((firstMap?["c"] as? String) == "1")
         }
 
         // a[1][2][3][c]=1 -> ["a": [[[ { "c": "1" } ]]]]
         do {
             let r = try Qs.decode("a[1][2][3][c]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let l1 = a.flatMap { elements in
-                elements.first.flatMap(arrayElements)
+            #expect(a?.count == 1)
+
+            if let l1 = a?.first.flatMap(arrayElements) {
+                #expect(l1.count == 1)
+
+                if let l2 = l1.first.flatMap(arrayElements) {
+                    #expect(l2.count == 1)
+
+                    if let l3 = l2.first.flatMap(asDictString) {
+                        #expect((l3["c"] as? String) == "1")
+                    } else {
+                        Issue.record("Expected dictionary at a[0][0][0]")
+                    }
+                } else {
+                    Issue.record("Expected array at a[0][0]")
+                }
+            } else {
+                Issue.record("Expected array at a[0]")
             }
-            let l2 = l1.flatMap { elements in
-                elements.first.flatMap(arrayElements)
-            }
-            let l3 = l2.flatMap { elements in
-                elements.first.flatMap(asDictString)
-            }
-            #expect((l3?["c"] as? String) == "1")
         }
 
         // a[1][2][3][c][1]=1 -> ["a": [[[ { "c": ["1"] } ]]]]
         do {
             let r = try Qs.decode("a[1][2][3][c][1]=1", options: DecodeOptions(listLimit: 20))
             let a = arrayElements(r["a"])
-            let l1 = a.flatMap { elements in
-                elements.first.flatMap(arrayElements)
+            #expect(a?.count == 1)
+
+            if let l1 = a?.first.flatMap(arrayElements) {
+                #expect(l1.count == 1)
+
+                if let l2 = l1.first.flatMap(arrayElements) {
+                    #expect(l2.count == 1)
+
+                    if let l3 = l2.first.flatMap(asDictString) {
+                        #expect(asStrings(l3["c"]) == ["1"])
+                    } else {
+                        Issue.record("Expected dictionary at a[0][0][0]")
+                    }
+                } else {
+                    Issue.record("Expected array at a[0][0]")
+                }
+            } else {
+                Issue.record("Expected array at a[0]")
             }
-            let l2 = l1.flatMap { elements in
-                elements.first.flatMap(arrayElements)
-            }
-            let l3 = l2.flatMap { elements in
-                elements.first.flatMap(asDictString)
-            }
-            #expect(asStrings(l3?["c"]) == ["1"])
         }
     }
 

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1434,6 +1434,29 @@ struct DecodeTests {
         #expect(nested?["drop"] == nil)
     }
 
+    @Test("decode - nested Foundation key collisions prefer String keys")
+    func testDecode_MapInputFoundationCollision_StringWins() throws {
+        let input: [String: Any] = [
+            "a": NSDictionary(dictionary: [1: "int", "1": "string"])
+        ]
+
+        let decoded = try Qs.decode(input)
+        let nested = decoded["a"] as? [String: Any]
+        #expect(nested?["1"] as? String == "string")
+    }
+
+    @Test("decode - nested Foundation key collisions prefer String keys after compaction")
+    func testDecode_MapInputFoundationCollision_StringWinsAfterCompaction() throws {
+        let input: [String: Any] = [
+            "a": NSDictionary(dictionary: [1: "int", "1": "string", "drop": Undefined.instance])
+        ]
+
+        let decoded = try Qs.decode(input)
+        let nested = decoded["a"] as? [String: Any]
+        #expect(nested?["1"] as? String == "string")
+        #expect(nested?["drop"] == nil)
+    }
+
     @Test("decode - bridges typed Swift containers in map input")
     func testDecode_MapInputBridgesTypedSwiftContainers() throws {
         let input: [String: Any] = [

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1564,6 +1564,25 @@ struct DecodeTests {
         #expect(decoded["drop"] == nil)
     }
 
+    @Test("decode - preserves explicit nil entries in dense direct-map optional dictionaries during compaction")
+    func testDecode_DirectMapDenseOptionalDictionaryKeepsNil() throws {
+        let input: [String: Any?] = [
+            "dict": [
+                "keep": Optional<String>.some("x"),
+                "nil": Optional<String>.none,
+            ] as [String: String?],
+            "drop": Undefined.instance,
+        ]
+
+        let decoded = try Qs.decode(input)
+        let dict = decoded["dict"] as? [String: Any]
+        #expect(dict?.keys.contains("keep") == true)
+        #expect(dict?["keep"] as? String == "x")
+        #expect(dict?.keys.contains("nil") == true)
+        #expect(dict?["nil"] is NSNull)
+        #expect(decoded["drop"] == nil)
+    }
+
     @Test("decode - AnyHashable key collisions are deterministic (String wins)")
     func testDecode_AnyHashableKeyCollision_StringWins() throws {
         // Different literal orders, same outcome.

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -1412,6 +1412,28 @@ struct DecodeTests {
         #expect(isNSNullValue(user?["email"]))
     }
 
+    @Test("decode - compacts nested Foundation arrays in map input")
+    func testDecode_MapInputCompactsNestedFoundationArrays() throws {
+        let input: [String: Any] = [
+            "a": NSArray(array: [Undefined.instance, "x"])
+        ]
+
+        let decoded = try Qs.decode(input)
+        #expect(asStrings(decoded["a"]) == ["x"])
+    }
+
+    @Test("decode - bridges nested Foundation dictionaries to Swift string-keyed maps")
+    func testDecode_MapInputBridgesNestedFoundationDictionaries() throws {
+        let input: [String: Any] = [
+            "a": NSDictionary(dictionary: [1: "x", "drop": Undefined.instance])
+        ]
+
+        let decoded = try Qs.decode(input)
+        let nested = decoded["a"] as? [String: Any]
+        #expect(nested?["1"] as? String == "x")
+        #expect(nested?["drop"] == nil)
+    }
+
     @Test("decode - preserves direct map inputs with nil placeholders")
     func testDecode_MapVariants() throws {
         let optionalMap = try Qs._decodeSyncCore(["a": nil, "b": "two"] as [String: Any?])

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1387,7 +1387,7 @@ struct UtilsTests {
         let out = Utils.compactToAny(input, allowSparseLists: true)
         if let array = out["array"] as? [Any] {
             #expect(array.first is NSNull)
-            if let nested = anyArray(array[1]) {
+            if let nested = array.dropFirst().first.flatMap(anyArray) {
                 #expect(nested.first is NSNull)
                 #expect(nested.last as? String == "value")
             } else {

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1705,6 +1705,14 @@ struct UtilsTests {
         #expect(Utils.containsUndefined(payload))
     }
 
+    @Test("Utils.containsUndefined inspects Foundation containers")
+    func utils_containsUndefined_foundationContainers() {
+        let payload = NSDictionary(dictionary: [
+            "array": NSArray(array: [Undefined.instance, "x"])
+        ])
+        #expect(Utils.containsUndefined(payload))
+    }
+
     @Test("Utils.containsUndefined reports true for direct sentinel input")
     func utils_containsUndefined_directSentinel() {
         #expect(Utils.containsUndefined(Undefined.instance))
@@ -1960,6 +1968,19 @@ struct UtilsTests {
         } else {
             Issue.record("Optional array branch not exercised")
         }
+    }
+
+    @Test("Utils.deepBridgeToAnyIterative bridges Foundation containers")
+    func utils_deepBridge_foundationContainers() {
+        let foundation: NSDictionary = [
+            1: "x",
+            "nested": NSArray(array: ["y"])
+        ]
+
+        let bridged = Utils.deepBridgeToAnyIterative(foundation)
+        let dict = bridged as? [String: Any]
+        #expect(dict?["1"] as? String == "x")
+        #expect((dict?["nested"] as? [Any])?.first as? String == "y")
     }
 
     @Test("Utils.needsMainDrop short-circuits when threshold is non-positive")

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -8,6 +8,8 @@ import OrderedCollections
     #error("The swift-testing package is required to build tests on Swift 5.x")
 #endif
 
+private let deterministicHashing = ProcessInfo.processInfo.environment["SWIFT_DETERMINISTIC_HASHING"] == "1"
+
 struct UtilsTests {
     // MARK: - Utils.encode tests
 
@@ -1750,6 +1752,24 @@ struct UtilsTests {
         #expect(Utils.containsUndefined(payload))
     }
 
+    @Test("Utils.containsUndefined tolerates Foundation self-cycles")
+    func utils_containsUndefined_foundationSelfCycles() throws {
+        #if os(Linux)
+            try withKnownIssue(Comment("Linux: corelibs-foundation segfault constructing NSDictionary self-cycle")) {
+                #expect(
+                    Bool(false),
+                    Comment("Skipped: cannot safely build a cyclic Foundation container on Linux"))
+            }
+        #else
+            let cyclic = NSMutableDictionary()
+            cyclic["self"] = cyclic
+            #expect(!Utils.containsUndefined(cyclic))
+
+            cyclic["sentinel"] = Undefined.instance
+            #expect(Utils.containsUndefined(cyclic))
+        #endif
+    }
+
     @Test("Utils.containsUndefined inspects typed Swift containers")
     func utils_containsUndefined_typedSwiftContainers() {
         let payload: [Int: [String: Undefined]] = [
@@ -2033,6 +2053,63 @@ struct UtilsTests {
         let dict = bridged as? [String: Any]
         #expect(dict?["1"] as? String == "x")
         #expect((dict?["nested"] as? [Any])?.first as? String == "y")
+    }
+
+    @Test(
+        "Utils.deepBridgeToAnyIterative preserves OrderedDictionary entry order",
+        .enabled(if: deterministicHashing, "requires SWIFT_DETERMINISTIC_HASHING=1 for stable dictionary iteration")
+    )
+    func utils_deepBridge_preservesOrderedDictionaryOrder() {
+        let entries: [(AnyHashable, Any)] = [
+            (AnyHashable("first"), 1),
+            (AnyHashable(2), "two"),
+            (AnyHashable("third"), 3),
+        ]
+        let ordered = OrderedDictionary<AnyHashable, Any>(uniqueKeysWithValues: entries)
+
+        let bridged = Utils.deepBridgeToAnyIterative(ordered)
+        if let dict = bridged as? [String: Any] {
+            #expect(Array(dict.keys) == ["first", "2", "third"])
+            #expect(dict["2"] as? String == "two")
+        } else {
+            Issue.record("Expected bridged ordered dictionary, got: \(type(of: bridged))")
+        }
+    }
+
+    @Test("Utils.deepBridgeToAnyIterative tolerates Foundation self-cycles")
+    func utils_deepBridge_foundationSelfCycles() throws {
+        #if os(Linux)
+            try withKnownIssue(Comment("Linux: corelibs-foundation segfault constructing NSDictionary self-cycle")) {
+                #expect(
+                    Bool(false),
+                    Comment("Skipped: cannot safely build a cyclic Foundation container on Linux"))
+            }
+        #else
+            let cyclicDict = NSMutableDictionary()
+            cyclicDict["self"] = cyclicDict
+            cyclicDict["leaf"] = "x"
+
+            let bridgedDict = Utils.deepBridgeToAnyIterative(cyclicDict)
+            if let dict = bridgedDict as? [String: Any] {
+                #expect(dict["leaf"] as? String == "x")
+                #expect(dict["self"] is NSNull)
+            } else {
+                Issue.record("Expected bridged cyclic dictionary, got: \(type(of: bridgedDict))")
+            }
+
+            let cyclicArray = NSMutableArray()
+            cyclicArray.add(cyclicArray)
+            cyclicArray.add("y")
+
+            let bridgedArray = Utils.deepBridgeToAnyIterative(cyclicArray)
+            if let array = bridgedArray as? [Any] {
+                #expect(array.count == 2)
+                #expect(array[0] is NSNull)
+                #expect(array[1] as? String == "y")
+            } else {
+                Issue.record("Expected bridged cyclic array, got: \(type(of: bridgedArray))")
+            }
+        #endif
     }
 
     @Test("Utils.deepBridgeToAnyIterative bridges typed Swift containers")

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1268,8 +1268,8 @@ struct UtilsTests {
     // while keeping CI stable.
     @Test("deep maps do not time out (safe depth)")
     func testDecode_DeepMaps_NoTimeout_Safe() throws {
-        /// Conservative depth to avoid ARC’s recursive deinit on worker-thread stacks.
-        let depth = 2500
+        /// Swift 6.3 reduced cooperative worker-thread stack headroom for deep dictionary teardown.
+        let depth = 1_200
         var s = "foo"
         for _ in 0..<depth { s += "[p]" }
         s += "=bar"
@@ -1933,7 +1933,7 @@ struct UtilsTests {
 
         let optionalArray: [Any?] = [nil, "value"]
         let bridgedArray = Utils.deepBridgeToAnyIterative(optionalArray)
-        if let arrOpt = bridgedArray as? [Any?] {
+        if Swift.type(of: bridgedArray) == [Any?].self, let arrOpt = bridgedArray as? [Any?] {
             switch arrOpt.first {
             case .some(.none):
                 #expect(true)

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -2055,6 +2055,49 @@ struct UtilsTests {
         #expect((dict?["nested"] as? [Any])?.first as? String == "y")
     }
 
+    @Test("Utils.deepBridgeToAnyIterative unwraps boxed optionals in raw array containers")
+    func utils_deepBridge_unwrapsBoxedOptionalsInRawArrays() {
+        func expectNormalizedArray(_ bridged: Any, expectedValues: [Any?], label: String) {
+            guard let array = bridged as? [Any] else {
+                Issue.record("Expected bridged array for \(label), got: \(type(of: bridged))")
+                return
+            }
+
+            #expect(array.count == expectedValues.count)
+            for (index, expected) in expectedValues.enumerated() {
+                let actual = array[index]
+                if let expected {
+                    switch expected {
+                    case let string as String:
+                        #expect(actual as? String == string)
+                    case let int as Int:
+                        #expect(actual as? Int == int)
+                    default:
+                        Issue.record("Unhandled expected value for \(label) at index \(index): \(expected)")
+                    }
+                } else {
+                    #expect(actual is NSNull)
+                }
+            }
+        }
+
+        let boxedNil: Any = Optional<String>.none as Any
+        let boxedSome: Any = Optional<String>.some("x") as Any
+        let boxedInt: Any = Optional<Int>.some(42) as Any
+
+        expectNormalizedArray(
+            Utils.deepBridgeToAnyIterative([boxedNil, boxedSome, boxedInt] as [Any]),
+            expectedValues: [nil, "x", 42],
+            label: "[Any]"
+        )
+
+        expectNormalizedArray(
+            Utils.deepBridgeToAnyIterative([boxedNil, boxedSome, nil, boxedInt] as [Any?]),
+            expectedValues: [nil, "x", nil, 42],
+            label: "[Any?]"
+        )
+    }
+
     @Test(
         "Utils.deepBridgeToAnyIterative preserves OrderedDictionary entry order",
         .enabled(if: deterministicHashing, "requires SWIFT_DETERMINISTIC_HASHING=1 for stable dictionary iteration")

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1343,10 +1343,13 @@ struct UtilsTests {
 
         if let typed = compacted["typed"] as? [String: Any?] {
             #expect(typed.keys.contains("1"))
-            switch typed["1"] {
-            case .some(.none):
-                #expect(Bool(true))
-            default:
+            let preservesNilEntry: Bool
+            if case .some(.none) = typed["1"] {
+                preservesNilEntry = true
+            } else {
+                preservesNilEntry = false
+            }
+            if !preservesNilEntry {
                 Issue.record("Expected typed dictionary nil entry to be preserved")
             }
         } else {
@@ -2309,10 +2312,13 @@ struct UtilsTests {
         let optionalArray: [Any?] = [nil, "value"]
         let bridgedArray = Utils.deepBridgeToAnyIterative(optionalArray)
         if Swift.type(of: bridgedArray) == [Any?].self, let arrOpt = bridgedArray as? [Any?] {
-            switch arrOpt.first {
-            case .some(.none):
-                #expect(true)
-            default:
+            let firstElementIsNone: Bool
+            if case .some(.none) = arrOpt.first {
+                firstElementIsNone = true
+            } else {
+                firstElementIsNone = false
+            }
+            if !firstElementIsNone {
                 Issue.record("Expected first element to be .none")
             }
 

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1723,6 +1723,66 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.compact and compactToAny normalize deep Foundation and pure-Swift containers consistently")
+    func utils_compact_deepFoundationMatchesPureSwift() {
+        let undefined = Undefined.instance
+        let swiftNested: [Any] = [
+            [1: [undefined, "x"]] as [Int: [Any]],
+            ["inner": [undefined, ["deep": undefined, "keep": "leaf"] as [String: Any?], nil] as [Any?]]
+                as [String: [Any?]],
+        ]
+        let foundationNested = NSArray(array: [
+            NSDictionary(dictionary: [1: NSArray(array: [undefined, "x"])]),
+            NSDictionary(dictionary: [
+                "inner": NSArray(array: [
+                    undefined,
+                    NSDictionary(dictionary: ["deep": undefined, "keep": "leaf"]),
+                    NSNull(),
+                ])
+            ]),
+        ])
+
+        func expectDeepNormalizedShape(_ value: Any?, label: String) {
+            guard let array = value as? [Any] else {
+                Issue.record("Expected normalized array for \(label), got: \(String(describing: value))")
+                return
+            }
+
+            #expect(array.count == 2)
+
+            let first = array[0] as? [String: Any]
+            let firstInner = first?["1"] as? [Any]
+            #expect(firstInner?.count == 2)
+            #expect(firstInner?.first is NSNull)
+            #expect(firstInner?[1] as? String == "x")
+
+            let second = array[1] as? [String: Any]
+            let secondInner = second?["inner"] as? [Any]
+            #expect(secondInner?.count == 3)
+            #expect(secondInner?.first is NSNull)
+            let deepDict = secondInner?[1] as? [String: Any]
+            #expect(deepDict?["deep"] == nil)
+            #expect(deepDict?["keep"] as? String == "leaf")
+            #expect(secondInner?[2] is NSNull)
+        }
+
+        var compactRoot: [String: Any?] = [
+            "swift": swiftNested,
+            "foundation": foundationNested,
+        ]
+        let compacted = Utils.compact(&compactRoot, allowSparseLists: true)
+        expectDeepNormalizedShape(compacted["swift"] ?? nil, label: "compact swift")
+        expectDeepNormalizedShape(compacted["foundation"] ?? nil, label: "compact foundation")
+
+        let compactedAny = Utils.compactToAny(
+            [
+                "swift": swiftNested,
+                "foundation": foundationNested,
+            ], allowSparseLists: true)
+        expectDeepNormalizedShape(compactedAny["swift"], label: "compactToAny swift")
+        expectDeepNormalizedShape(compactedAny["foundation"], label: "compactToAny foundation")
+    }
+
     @Test("Utils.containsUndefined detects sentinel in nested structures")
     func utils_containsUndefined_detects() {
         let undefined = Undefined.instance

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1752,22 +1752,46 @@ struct UtilsTests {
                 return
             }
 
-            #expect(array.count == 2)
+            guard array.count == 2 else {
+                Issue.record("Expected 2 elements for \(label), got \(array.count)")
+                return
+            }
 
-            let first = anyDict(array[0])
-            let firstInner = anyArray(first?["1"])
-            #expect(firstInner?.count == 2)
-            #expect(firstInner?.first is NSNull)
-            #expect(firstInner?[1] as? String == "x")
+            guard let first = anyDict(array.first) else {
+                Issue.record("Expected first dictionary for \(label)")
+                return
+            }
+            guard let firstInner = anyArray(first["1"]) else {
+                Issue.record("Expected first inner array for \(label)")
+                return
+            }
+            guard firstInner.count == 2 else {
+                Issue.record("Expected first inner array count 2 for \(label), got \(firstInner.count)")
+                return
+            }
+            #expect(firstInner.first is NSNull)
+            #expect(firstInner.dropFirst().first as? String == "x")
 
-            let second = anyDict(array[1])
-            let secondInner = anyArray(second?["inner"])
-            #expect(secondInner?.count == 3)
-            #expect(secondInner?.first is NSNull)
-            let deepDict = anyDict(secondInner?[1])
-            #expect(deepDict?["deep"] == nil)
-            #expect(deepDict?["keep"] as? String == "leaf")
-            #expect(secondInner?[2] is NSNull)
+            guard let second = anyDict(array.dropFirst().first) else {
+                Issue.record("Expected second dictionary for \(label)")
+                return
+            }
+            guard let secondInner = anyArray(second["inner"]) else {
+                Issue.record("Expected second inner array for \(label)")
+                return
+            }
+            guard secondInner.count == 3 else {
+                Issue.record("Expected second inner array count 3 for \(label), got \(secondInner.count)")
+                return
+            }
+            #expect(secondInner.first is NSNull)
+            guard let deepDict = anyDict(secondInner.dropFirst().first) else {
+                Issue.record("Expected deep dictionary for \(label)")
+                return
+            }
+            #expect(deepDict["deep"] == nil)
+            #expect(deepDict["keep"] as? String == "leaf")
+            #expect(secondInner.dropFirst(2).first is NSNull)
         }
 
         var compactRoot: [String: Any?] = [

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1698,24 +1698,28 @@ struct UtilsTests {
 
         let sparse = Utils.compactToAny(input, allowSparseLists: true)
         if let list = sparse["list"] as? [Any] {
-            let foundationDict = list[0] as? [String: Any]
+            #expect(list.count == 3)
+
+            let foundationDict = list.first as? [String: Any]
             #expect(foundationDict?["1"] as? String == "x")
             #expect(foundationDict?["drop"] == nil)
 
-            let hashableDict = list[1] as? [String: Any]
+            let hashableDict = list.dropFirst().first as? [String: Any]
             #expect(hashableDict?["2"] as? String == "y")
 
-            let foundationArray = list[2] as? [Any]
+            let foundationArray = list.dropFirst(2).first as? [Any]
             #expect(foundationArray?.count == 2)
             #expect(foundationArray?.first is NSNull)
-            #expect(foundationArray?[1] as? String == "z")
+            #expect(foundationArray?.dropFirst().first as? String == "z")
         } else {
             Issue.record("Expected normalized list from compactToAny")
         }
 
         let dense = Utils.compactToAny(input, allowSparseLists: false)
         if let list = dense["list"] as? [Any] {
-            let foundationArray = list[2] as? [Any]
+            #expect(list.count == 3)
+
+            let foundationArray = list.dropFirst(2).first as? [Any]
             #expect(foundationArray?.count == 1)
             #expect(foundationArray?.first as? String == "z")
         } else {

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -2031,6 +2031,33 @@ struct UtilsTests {
         #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
     }
 
+    @Test("Utils.estimateSingleKeyChainDepth ignores overflow bookkeeping in AnyHashable dictionaries")
+    func utils_estimateSingleKeyChainDepth_ignoresOverflowMetadata() {
+        let child: [AnyHashable: Any] = [
+            AnyHashable("b"): "end",
+            AnyHashable(Utils.overflowKey): 9,
+        ]
+        let root: [AnyHashable: Any] = [
+            AnyHashable("a"): child,
+            AnyHashable(Utils.overflowKey): 3,
+        ]
+
+        #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
+    }
+
+    @Test("Utils.estimateSingleKeyChainDepth ignores overflow bookkeeping in OrderedDictionary chains")
+    func utils_estimateSingleKeyChainDepth_ignoresOverflowMetadataInOrderedDictionary() {
+        var child = OrderedDictionary<AnyHashable, Any>()
+        child[AnyHashable("b")] = "end"
+        child[AnyHashable(Utils.overflowKey)] = 9
+
+        var root = OrderedDictionary<AnyHashable, Any>()
+        root[AnyHashable("a")] = child
+        root[AnyHashable(Utils.overflowKey)] = 3
+
+        #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
+    }
+
     @Test("Utils.estimateSingleKeyChainDepth unwraps boxed optional dictionary links")
     func utils_estimateSingleKeyChainDepth_boxedOptionalChain() {
         let level2: [String: Any] = ["c": "end"]
@@ -2232,6 +2259,14 @@ struct UtilsTests {
     func utils_deepBridge_nilAndHashable() {
         let bridgedNil = Utils.deepBridgeToAnyIterative(nil)
         #expect(bridgedNil is NSNull)
+
+        let boxedRoot = Optional<[String: Any]>.some(["leaf": "value"]) as Any
+        let bridgedBoxedRoot = Utils.deepBridgeToAnyIterative(boxedRoot)
+        #expect((bridgedBoxedRoot as? [String: Any])?["leaf"] as? String == "value")
+
+        let boxedNilRoot = Optional<[String: Any]>.none as Any
+        let bridgedBoxedNilRoot = Utils.deepBridgeToAnyIterative(boxedNilRoot)
+        #expect(bridgedBoxedNilRoot is NSNull)
 
         let dict: [AnyHashable: Any] = [
             1: ["nested": NSNull()],

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1321,8 +1321,11 @@ struct UtilsTests {
             "optional": [Optional<Any>.none, Optional<Any>.some(undefined), Optional<Any>.some("tail")] as [Any?]
         ]
         let optionalCompacted = Utils.compact(&optionalRoot, allowSparseLists: false)
-        if let optional = optionalCompacted["optional"] {
+        if let optional = optionalCompacted["optional"] as? [Any] {
             #expect(!Utils.containsUndefined(optional))
+            #expect(optional.count == 2)
+            #expect(optional.first is NSNull)
+            #expect(optional.last as? String == "tail")
         } else {
             Issue.record("Expected optional array branch result")
         }

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1934,6 +1934,14 @@ struct UtilsTests {
         #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
     }
 
+    @Test("Utils.estimateSingleKeyChainDepth unwraps boxed optional dictionary links")
+    func utils_estimateSingleKeyChainDepth_boxedOptionalChain() {
+        let level2: [String: Any] = ["c": "end"]
+        let level1: [String: Any] = ["b": Optional<[String: Any]>.some(level2) as Any]
+        let root: [String: Any] = ["a": Optional<[String: Any]>.some(level1) as Any]
+        #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 3)
+    }
+
     @Test("Utils.merge handles heterogeneous containers")
     func utils_merge_coversBranches() {
         let undefined = Undefined.instance
@@ -2306,6 +2314,14 @@ struct UtilsTests {
         let root: [String: Any?] = ["k": nil]
         #expect(!Utils.needsMainDrop(root, threshold: 0))
         #expect(!Utils.needsMainDrop(root, threshold: -3))
+    }
+
+    @Test("Utils.needsMainDrop sees boxed optional single-key chains")
+    func utils_needsMainDrop_boxedOptionalChain() {
+        let level2: [String: Any] = ["c": "end"]
+        let level1: [String: Any] = ["b": Optional<[String: Any]>.some(level2) as Any]
+        let root: [String: Any?] = ["a": Optional<[String: Any]>.some(level1) as Any]
+        #expect(Utils.needsMainDrop(root, threshold: 2))
     }
 
     @Test("Utils.dropOnMainThread tolerates nil payloads")

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -2413,6 +2413,8 @@ struct UtilsTests {
 
         let bridged = Utils.deepBridgeToAnyIterative(ordered)
         if let dict = bridged as? [String: Any] {
+            // This is intentionally implementation-sensitive: it guards against reversing
+            // OrderedDictionary scheduling in deepBridgeToAnyIterative when hashing is deterministic.
             #expect(Array(dict.keys) == ["first", "2", "third"])
             #expect(dict["2"] as? String == "two")
         } else {

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1387,7 +1387,7 @@ struct UtilsTests {
         let out = Utils.compactToAny(input, allowSparseLists: true)
         if let array = out["array"] as? [Any] {
             #expect(array.first is NSNull)
-            if let nested = array.last as? [Any] {
+            if let nested = anyArray(array[1]) {
                 #expect(nested.first is NSNull)
                 #expect(nested.last as? String == "value")
             } else {
@@ -1424,7 +1424,7 @@ struct UtilsTests {
         let compacted = Utils.compact(&root, allowSparseLists: true)
         if let arr = compacted["opt"] as? [Any] {
             #expect(arr.count == 3)
-            let inner = arr.first as? [Any]
+            let inner = anyArray(arr[0])
             #expect(inner?.count == 3)
             #expect(inner?[0] as? String == "inner")
             #expect(inner?[1] is NSNull)
@@ -1448,7 +1448,7 @@ struct UtilsTests {
             #expect(list.count == 3)
             #expect(list[0] as? String == "value")
             #expect(list[1] is NSNull)
-            let dict = list[2] as? [String: Any]
+            let dict = list[2] as? [String: Any?]
             #expect(dict?.isEmpty == true)
         } else {
             Issue.record("Swift [Any] branch not exercised")
@@ -1465,8 +1465,8 @@ struct UtilsTests {
         let compacted = Utils.compact(&root)
         if let list = compacted["list"] as? [Any] {
             #expect(list.count == 2)
-            #expect(list.first as? String == "keep")
-            let nested = list.last as? [String: Any]
+            #expect(list[0] as? String == "keep")
+            let nested = list[1] as? [String: Any?]
             #expect(nested?.isEmpty == true)
         } else {
             Issue.record("Swift [Any] allowSparse=false branch not exercised")
@@ -1479,7 +1479,7 @@ struct UtilsTests {
         var root: [String: Any?] = ["list": [Any](arrayLiteral: nested)]
 
         let compacted = Utils.compact(&root, allowSparseLists: true)
-        if let list = compacted["list"] as? [Any], let inner = list.first as? [Any] {
+        if let list = compacted["list"] as? [Any], let inner = anyArray(list[0]) {
             #expect(inner.count == 2)
             #expect(inner[0] as? String == "inner")
             #expect(inner[1] is NSNull)
@@ -1497,7 +1497,7 @@ struct UtilsTests {
         let compacted = Utils.compact(&root, allowSparseLists: true)
         if let list = compacted["list"] as? [Any] {
             #expect(list.count == 2)
-            let nested = list.first as? [Any]
+            let nested = anyArray(list[0])
             #expect(nested?.contains { ($0 as? String) == "leaf" } == true)
             #expect(nested?.contains { $0 is NSNull } == true)
             #expect(list.last is NSNull)
@@ -1517,8 +1517,8 @@ struct UtilsTests {
         let compacted = Utils.compact(&root)
         if let list = compacted["list"] as? [Any] {
             #expect(list.count == 2)
-            #expect((list.first as? [String: Any])?.isEmpty == true)
-            #expect(list.last as? String == "tail")
+            #expect((list[0] as? [String: Any?])?.isEmpty == true)
+            #expect(list[1] as? String == "tail")
         } else {
             Issue.record("Dense Swift [Any] branch not compacted as expected")
         }
@@ -1547,7 +1547,7 @@ struct UtilsTests {
         var root: [String: Any?] = ["list": [Any?](arrayLiteral: optionalInner, nil)]
 
         let compacted = Utils.compact(&root, allowSparseLists: true)
-        if let list = compacted["list"] as? [Any], let nested = list.first as? [Any] {
+        if let list = compacted["list"] as? [Any], let nested = anyArray(list[0]) {
             #expect(nested.count == 3)
             #expect(nested.first is NSNull)
             #expect(nested[1] as? String == "leaf")
@@ -1583,9 +1583,9 @@ struct UtilsTests {
 
         if let foundation = sparse["foundation"] as? [Any] {
             #expect(foundation.first is NSNull)
-            let emptied = foundation.compactMap { $0 as? [String: Any] }.first
+            let emptied = foundation.compactMap(compactDict).first
             #expect(emptied?.isEmpty == true)
-            let nested = foundation.compactMap { $0 as? [Any] }.first
+            let nested = foundation.compactMap(anyArray).first
             #expect(nested?.first is NSNull)
         } else {
             Issue.record("Foundation-backed array branch not exercised")
@@ -1593,9 +1593,9 @@ struct UtilsTests {
 
         if let optional = sparse["optional"] as? [Any] {
             #expect(optional.first is NSNull)
-            if let nested = optional.dropFirst().first as? [Any] {
+            if let nested = anyArray(optional[1]) {
                 #expect(nested.first is NSNull)
-                let nestedDict = nested.compactMap { $0 as? [String: Any] }.first
+                let nestedDict = nested.compactMap(compactDict).first
                 #expect(nestedDict?.keys.contains("keep") == true)
                 #expect(nested.last as? String == "leaf")
             } else {
@@ -1750,17 +1750,17 @@ struct UtilsTests {
 
             #expect(array.count == 2)
 
-            let first = array[0] as? [String: Any]
-            let firstInner = first?["1"] as? [Any]
+            let first = anyDict(array[0])
+            let firstInner = anyArray(first?["1"])
             #expect(firstInner?.count == 2)
             #expect(firstInner?.first is NSNull)
             #expect(firstInner?[1] as? String == "x")
 
-            let second = array[1] as? [String: Any]
-            let secondInner = second?["inner"] as? [Any]
+            let second = anyDict(array[1])
+            let secondInner = anyArray(second?["inner"])
             #expect(secondInner?.count == 3)
             #expect(secondInner?.first is NSNull)
-            let deepDict = secondInner?[1] as? [String: Any]
+            let deepDict = anyDict(secondInner?[1])
             #expect(deepDict?["deep"] == nil)
             #expect(deepDict?["keep"] as? String == "leaf")
             #expect(secondInner?[2] is NSNull)
@@ -1781,6 +1781,61 @@ struct UtilsTests {
             ], allowSparseLists: true)
         expectDeepNormalizedShape(compactedAny["swift"], label: "compactToAny swift")
         expectDeepNormalizedShape(compactedAny["foundation"], label: "compactToAny foundation")
+    }
+
+    @Test("Utils.compact and compactToAny tolerate Foundation self-cycles")
+    func utils_compact_foundationSelfCycles() throws {
+        #if os(Linux)
+            try withKnownIssue(Comment("Linux: corelibs-foundation segfault constructing NSDictionary self-cycle")) {
+                #expect(
+                    Bool(false),
+                    Comment("Skipped: cannot safely build a cyclic Foundation container on Linux"))
+            }
+        #else
+            let cyclicDict = NSMutableDictionary()
+            cyclicDict["self"] = cyclicDict
+            cyclicDict["leaf"] = "x"
+
+            var compactRoot: [String: Any?] = ["dict": cyclicDict]
+            let compacted = Utils.compact(&compactRoot, allowSparseLists: true)
+            if let dict = compacted["dict"] as? [String: Any?] {
+                #expect(dict["leaf"] as? String == "x")
+                #expect((dict["self"] ?? nil) is NSNull)
+            } else {
+                Issue.record("Expected compacted cyclic dictionary")
+            }
+
+            let compactedAny = Utils.compactToAny(["dict": cyclicDict], allowSparseLists: true)
+            if let dict = compactedAny["dict"] as? [String: Any] {
+                #expect(dict["leaf"] as? String == "x")
+                #expect(dict["self"] is NSNull)
+            } else {
+                Issue.record("Expected compactToAny cyclic dictionary")
+            }
+
+            let cyclicArray = NSMutableArray()
+            cyclicArray.add(cyclicArray)
+            cyclicArray.add("y")
+
+            var compactArrayRoot: [String: Any?] = ["array": cyclicArray]
+            let compactedArray = Utils.compact(&compactArrayRoot, allowSparseLists: true)
+            if let array = compactedArray["array"] as? [Any] {
+                #expect(array.count == 2)
+                #expect(array[0] is NSNull)
+                #expect(array[1] as? String == "y")
+            } else {
+                Issue.record("Expected compacted cyclic array")
+            }
+
+            let compactedAnyArray = Utils.compactToAny(["array": cyclicArray], allowSparseLists: true)
+            if let array = compactedAnyArray["array"] as? [Any] {
+                #expect(array.count == 2)
+                #expect(array[0] is NSNull)
+                #expect(array[1] as? String == "y")
+            } else {
+                Issue.record("Expected compactToAny cyclic array")
+            }
+        #endif
     }
 
     @Test("Utils.containsUndefined detects sentinel in nested structures")
@@ -2290,6 +2345,38 @@ struct UtilsTests {
 }
 
 // MARK: - Helpers
+
+private func compactDict(_ value: Any) -> [String: Any?]? {
+    value as? [String: Any?]
+}
+
+private func anyArray(_ value: Any?) -> [Any]? {
+    if let array = value as? [Any] {
+        return array
+    }
+    if let array = value as? [Any?] {
+        return array.map { $0 ?? NSNull() }
+    }
+    if let array = value as? NSArray {
+        return array.map { $0 }
+    }
+    return nil
+}
+
+private func anyDict(_ value: Any?) -> [String: Any]? {
+    if let dict = value as? [String: Any] {
+        return dict
+    }
+    if let dict = value as? [String: Any?] {
+        var bridged: [String: Any] = [:]
+        bridged.reserveCapacity(dict.count)
+        for (key, child) in dict {
+            bridged[key] = child ?? NSNull()
+        }
+        return bridged
+    }
+    return nil
+}
 
 private final class Holder: CustomStringConvertible {
     var payload: Any?

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1331,6 +1331,29 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.compact preserves nil entries in typed dictionaries while dropping Undefined")
+    func utils_compact_preservesNilInTypedDictionaries() {
+        var root: [String: Any?] = [
+            "typed": [1: Optional<String>.none] as [Int: String?],
+            "drop": Undefined.instance,
+        ]
+
+        let compacted = Utils.compact(&root, allowSparseLists: false)
+        #expect(compacted.keys.contains("drop") == false)
+
+        if let typed = compacted["typed"] as? [String: Any?] {
+            #expect(typed.keys.contains("1"))
+            switch typed["1"] {
+            case .some(.none):
+                #expect(Bool(true))
+            default:
+                Issue.record("Expected typed dictionary nil entry to be preserved")
+            }
+        } else {
+            Issue.record("Expected compacted typed dictionary")
+        }
+    }
+
     @Test("Utils.compact preserves sparse lists when requested")
     func utils_compact_allowSparseKeepsPlaceholders() {
         let undefined = Undefined.instance

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1268,8 +1268,8 @@ struct UtilsTests {
     // while keeping CI stable.
     @Test("deep maps do not time out (safe depth)")
     func testDecode_DeepMaps_NoTimeout_Safe() throws {
-        /// Swift 6.3 reduced cooperative worker-thread stack headroom for deep dictionary teardown.
-        let depth = 1_200
+        /// Keep the worker-thread safety test aligned with production's main-drop heuristic.
+        let depth = Qs.MAIN_DROP_THRESHOLD
         var s = "foo"
         for _ in 0..<depth { s += "[p]" }
         s += "=bar"
@@ -1713,6 +1713,14 @@ struct UtilsTests {
         #expect(Utils.containsUndefined(payload))
     }
 
+    @Test("Utils.containsUndefined inspects typed Swift containers")
+    func utils_containsUndefined_typedSwiftContainers() {
+        let payload: [Int: [String: Undefined]] = [
+            1: ["drop": Undefined.instance]
+        ]
+        #expect(Utils.containsUndefined(payload))
+    }
+
     @Test("Utils.containsUndefined reports true for direct sentinel input")
     func utils_containsUndefined_directSentinel() {
         #expect(Utils.containsUndefined(Undefined.instance))
@@ -1730,6 +1738,13 @@ struct UtilsTests {
     func utils_estimateSingleKeyChainDepth_nonOptionalChain() {
         let child: [AnyHashable: Any] = [AnyHashable(2): "end"]
         let root: [AnyHashable: Any] = [AnyHashable(1): child]
+        #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
+    }
+
+    @Test("Utils.estimateSingleKeyChainDepth traverses typed Swift dictionary chains")
+    func utils_estimateSingleKeyChainDepth_typedSwiftChain() {
+        let child: [Int: String] = [2: "end"]
+        let root: [Int: [Int: String]] = [1: child]
         #expect(Utils.estimateSingleKeyChainDepth(root, cap: 10) == 2)
     }
 
@@ -1974,13 +1989,30 @@ struct UtilsTests {
     func utils_deepBridge_foundationContainers() {
         let foundation: NSDictionary = [
             1: "x",
-            "nested": NSArray(array: ["y"])
+            "nested": NSArray(array: ["y"]),
         ]
 
         let bridged = Utils.deepBridgeToAnyIterative(foundation)
         let dict = bridged as? [String: Any]
         #expect(dict?["1"] as? String == "x")
         #expect((dict?["nested"] as? [Any])?.first as? String == "y")
+    }
+
+    @Test("Utils.deepBridgeToAnyIterative bridges typed Swift containers")
+    func utils_deepBridge_typedSwiftContainers() {
+        let typed: [String: Any] = [
+            "dict": [1: "x"] as [Int: String],
+            "array": [nil, "y"] as [String?],
+        ]
+
+        let bridged = Utils.deepBridgeToAnyIterative(typed)
+        let dict = bridged as? [String: Any]
+        let nestedDict = dict?["dict"] as? [String: Any]
+        let nestedArray = dict?["array"] as? [Any]
+        #expect(nestedDict?["1"] as? String == "x")
+        #expect(nestedArray?.count == 2)
+        #expect(nestedArray?.first is NSNull)
+        #expect(nestedArray?[1] as? String == "y")
     }
 
     @Test("Utils.needsMainDrop short-circuits when threshold is non-positive")

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1783,6 +1783,75 @@ struct UtilsTests {
         expectDeepNormalizedShape(compactedAny["foundation"], label: "compactToAny foundation")
     }
 
+    @Test("Utils.compact and compactToAny handle deep typed and Foundation chains")
+    func utils_compact_deepExactContainerChains() {
+        let depth = Qs.MAIN_DROP_THRESHOLD + 50
+        let undefined = Undefined.instance
+
+        func buildTypedChain(depth: Int, leaf: Any) -> Any {
+            var current: Any = leaf
+            for _ in 0..<depth {
+                current = [1: current] as [Int: Any]
+            }
+            return current
+        }
+
+        func buildFoundationChain(depth: Int, leaf: Any) -> Any {
+            var current: Any = leaf
+            for _ in 0..<depth {
+                current = NSDictionary(dictionary: [1: current])
+            }
+            return current
+        }
+
+        func descendStringifiedChain(_ value: Any?, depth: Int) -> [String: Any]? {
+            var current = value
+            for _ in 0..<depth {
+                current = anyDict(current)?["1"]
+            }
+            return anyDict(current)
+        }
+
+        let typedChain = buildTypedChain(
+            depth: depth,
+            leaf: ["keep": "typed", "drop": undefined] as [String: Any?]
+        )
+        let foundationChain = buildFoundationChain(
+            depth: depth,
+            leaf: NSDictionary(dictionary: ["keep": "foundation", "drop": undefined])
+        )
+
+        var compactRoot: [String: Any?] = [
+            "typed": typedChain,
+            "foundation": foundationChain,
+        ]
+        let compacted = Utils.compact(&compactRoot, allowSparseLists: false)
+
+        let compactedTypedLeaf = descendStringifiedChain(compacted["typed"] ?? nil, depth: depth)
+        #expect(compactedTypedLeaf?["keep"] as? String == "typed")
+        #expect(compactedTypedLeaf?["drop"] == nil)
+
+        let compactedFoundationLeaf = descendStringifiedChain(compacted["foundation"] ?? nil, depth: depth)
+        #expect(compactedFoundationLeaf?["keep"] as? String == "foundation")
+        #expect(compactedFoundationLeaf?["drop"] == nil)
+
+        let compactedAny = Utils.compactToAny(
+            [
+                "typed": typedChain,
+                "foundation": foundationChain,
+            ],
+            allowSparseLists: false
+        )
+
+        let compactedAnyTypedLeaf = descendStringifiedChain(compactedAny["typed"], depth: depth)
+        #expect(compactedAnyTypedLeaf?["keep"] as? String == "typed")
+        #expect(compactedAnyTypedLeaf?["drop"] == nil)
+
+        let compactedAnyFoundationLeaf = descendStringifiedChain(compactedAny["foundation"], depth: depth)
+        #expect(compactedAnyFoundationLeaf?["keep"] as? String == "foundation")
+        #expect(compactedAnyFoundationLeaf?["drop"] == nil)
+    }
+
     @Test("Utils.compact and compactToAny tolerate Foundation self-cycles")
     func utils_compact_foundationSelfCycles() throws {
         #if os(Linux)

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1684,6 +1684,43 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.compactToAny normalizes Foundation and AnyHashable containers inside arrays")
+    func utils_compactToAny_arrayElementsBridgeFoundationAndHashableContainers() {
+        let input: [String: Any?] = [
+            "list": [
+                NSDictionary(dictionary: [1: "x", "drop": Undefined.instance]),
+                [AnyHashable(2): "y"] as [AnyHashable: Any],
+                NSArray(array: [Undefined.instance, "z"]),
+            ]
+        ]
+
+        let sparse = Utils.compactToAny(input, allowSparseLists: true)
+        if let list = sparse["list"] as? [Any] {
+            let foundationDict = list[0] as? [String: Any]
+            #expect(foundationDict?["1"] as? String == "x")
+            #expect(foundationDict?["drop"] == nil)
+
+            let hashableDict = list[1] as? [String: Any]
+            #expect(hashableDict?["2"] as? String == "y")
+
+            let foundationArray = list[2] as? [Any]
+            #expect(foundationArray?.count == 2)
+            #expect(foundationArray?.first is NSNull)
+            #expect(foundationArray?[1] as? String == "z")
+        } else {
+            Issue.record("Expected normalized list from compactToAny")
+        }
+
+        let dense = Utils.compactToAny(input, allowSparseLists: false)
+        if let list = dense["list"] as? [Any] {
+            let foundationArray = list[2] as? [Any]
+            #expect(foundationArray?.count == 1)
+            #expect(foundationArray?.first as? String == "z")
+        } else {
+            Issue.record("Expected dense normalized list from compactToAny")
+        }
+    }
+
     @Test("Utils.containsUndefined detects sentinel in nested structures")
     func utils_containsUndefined_detects() {
         let undefined = Undefined.instance

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1859,10 +1859,24 @@ struct UtilsTests {
         #expect(Utils.containsUndefined(payload))
     }
 
+    @Test("Utils.containsUndefined detects boxed optional sentinels in Swift [Any]")
+    func utils_containsUndefined_boxedOptionalSwiftArrayRoot() {
+        let payload: [Any] = [Optional<Undefined>.some(Undefined.instance) as Any, "value"]
+        #expect(Utils.containsUndefined(payload))
+    }
+
     @Test("Utils.containsUndefined inspects Foundation containers")
     func utils_containsUndefined_foundationContainers() {
         let payload = NSDictionary(dictionary: [
             "array": NSArray(array: [Undefined.instance, "x"])
+        ])
+        #expect(Utils.containsUndefined(payload))
+    }
+
+    @Test("Utils.containsUndefined detects boxed optional sentinels in Foundation containers")
+    func utils_containsUndefined_boxedOptionalFoundationContainers() {
+        let payload = NSDictionary(dictionary: [
+            "array": NSArray(array: [Optional<Undefined>.some(Undefined.instance) as Any, "x"])
         ])
         #expect(Utils.containsUndefined(payload))
     }

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1593,7 +1593,7 @@ struct UtilsTests {
 
         if let optional = sparse["optional"] as? [Any] {
             #expect(optional.first is NSNull)
-            if let nested = anyArray(optional[1]) {
+            if let nested: [Any] = optional.dropFirst().first.flatMap(anyArray) {
                 #expect(nested.first is NSNull)
                 let nestedDict = nested.compactMap(compactDict).first
                 #expect(nestedDict?.keys.contains("keep") == true)


### PR DESCRIPTION
This pull request introduces a major refactor and enhancement to the utility functions for compacting and normalizing nested data structures in `QsSwift`, especially regarding Foundation containers (`NSDictionary`, `NSArray`) and Swift's typed containers. It also adds comprehensive new tests to ensure correct bridging and compaction behaviors, and updates the documentation and a performance threshold constant.

### Core utility refactor and enhancements

* Refactored `Utils.compact` and `Utils.compactToAny` to use a stack-based approach for traversing and compacting nested containers, improving performance and correctness, especially with Foundation types and cyclic references. The new approach handles Foundation containers and Swift containers more robustly, including key-collision resolution and proper bridging to Swift types. [[1]](diffhunk://#diff-f90ef8f95c19273da3fe110d0c21938b73d127a974de0840c56fcb1d2e19d0f2R4-R160) [[2]](diffhunk://#diff-f90ef8f95c19273da3fe110d0c21938b73d127a974de0840c56fcb1d2e19d0f2L113-R300)
* Added logic to ensure that order-sensitive regression tests can intentionally assert raw `Dictionary` iteration order when gated on deterministic hashing, clarifying the testing policy.

### Testing improvements

* Added new tests to `DecodeTests.swift` covering nested Foundation arrays and dictionaries, key collision resolution (preferring string keys), compaction of typed Swift containers, and bridging behaviors between Foundation and Swift types. These tests ensure the new compaction logic works as intended in all edge cases.
* Refactored several existing decode tests to use helper functions for safer and clearer access of nested arrays and dictionaries, improving test reliability and diagnostics.

### Performance and dependency updates

* Lowered the `MAIN_DROP_THRESHOLD` constant from 2500 to 1200, potentially improving stability when dropping large chained containers in background threads.
* Updated the `swift-collections` dependency in `Bench/Package.resolved` from version 1.2.1 to 1.4.0. [[1]](diffhunk://#diff-123354f11951260f9b11be6274e1f1079e5852cf9b594deb4d2e8c82e649f0dfL2-R2) [[2]](diffhunk://#diff-123354f11951260f9b11be6274e1f1079e5852cf9b594deb4d2e8c82e649f0dfL18-R19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Stability**
  * Improved iterative traversal and normalization of Swift/Foundation containers: nested optionals unwrapped consistently, string-key collisions resolved predictably, sparse-array semantics preserved, Foundation container identity tracked to avoid cycles, and earlier main-thread cleanup threshold.

* **Tests**
  * Expanded and hardened tests for bridging/compaction, undefined detection, ordering, cycle resilience, and depth/stress behaviors.

* **Documentation**
  * Added guidance on deterministic-hashing test expectations.

* **CI**
  * Updated workflow toolchain versions and test matrix for newer Swift/Xcode releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->