### PR TITLE
:sparkles: add Foundation URL helpers for appending QsSwift-encoded query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0-dev
+
+- [FEAT] add Foundation `URLComponents` and `URL` helpers for appending QsSwift-encoded nested query strings without double-encoding bracket notation.
+
 ## 1.3.6
 
 - [FEAT] add `DecodeOptions.strictMerge` and `QsDecodeOptions.strictMerge`, defaulting to `true`, so object/scalar parse conflicts now match Node `qs` by wrapping into arrays; set `strictMerge: false` to preserve the legacy map-merge behavior.

--- a/README.md
+++ b/README.md
@@ -455,6 +455,64 @@ try Qs.encode(["a": "b c"], options: .init(format: .rfc1738)) // "a=b+c"
 
 ---
 
+## Foundation URL helpers
+
+Use the Foundation helpers when you want to append QsSwift output to `URLComponents` or `URL` without routing already
+encoded bracket notation through Foundation's decoded query APIs.
+
+```swift
+import Foundation
+import QsSwift
+
+var components = URLComponents(string: "https://api.example.com/products")!
+try components.appendQsQueryItems([
+    "filter": [
+        "where": [
+            "name": "John",
+            "age": ["gte": 30],
+        ],
+    ],
+    "tags": ["a", "b"],
+])
+
+components.url?.absoluteString
+// "https://api.example.com/products?filter%5Bwhere%5D%5Bname%5D=John&filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30&tags%5B0%5D=a&tags%5B1%5D=b"
+```
+
+Immutable `URL` usage returns a new URL and preserves the original:
+
+```swift
+let url = URL(string: "https://api.example.com/products?existing=x#details")!
+let next = try url.appendingQsQueryItems([
+    "filter": ["where": ["name": "John"]],
+    "tags": ["a", "b"],
+])
+
+next.absoluteString
+// "https://api.example.com/products?existing=x&filter%5Bwhere%5D%5Bname%5D=John&tags%5B0%5D=a&tags%5B1%5D=b#details"
+```
+
+Repeated keys and custom delimiters are preserved:
+
+```swift
+var semicolon = URLComponents(string: "https://api.example.com/products?existing=x")!
+try semicolon.appendQsQueryItems(
+    ["tag": ["swift", "ios"]],
+    options: .init(listFormat: .repeatKey, delimiter: ";")
+)
+
+semicolon.percentEncodedQuery
+// "existing=x;tag=swift;tag=ios"
+```
+
+The helpers append to `percentEncodedQuery`, not `queryItems`. `queryItems` treats names and values as decoded text and
+can double-encode QsSwift output (`%5B` becoming `%255B`). The URL helpers force URL-safe QsSwift encoding internally,
+even if the supplied options use `encode: false` or `encodeValuesOnly: true`.
+
+Non-goal: this integration does not add Alamofire, Vapor, AsyncHTTPClient, or other framework-specific helpers.
+
+---
+
 ## `nil`, `NSNull`, and `Undefined` (null semantics)
 
 Query strings don’t have a native null concept, so Qs uses a few conventions to mirror “JSON-style” semantics as

--- a/Sources/QsSwift/FoundationURL+Qs.swift
+++ b/Sources/QsSwift/FoundationURL+Qs.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// Errors thrown while appending QsSwift output to Foundation URL types.
+public enum QsURLQueryError: Error, Equatable, Sendable {
+    /// The generated query was not valid for `URLComponents.percentEncodedQuery`.
+    case invalidPercentEncodedQuery
+
+    /// Foundation could not construct a `URL` from the updated URL components.
+    case invalidURL
+}
+
+public extension URLComponents {
+    /// Appends QsSwift-encoded query items to this component's percent-encoded query.
+    ///
+    /// This method appends to `percentEncodedQuery` instead of `queryItems` so qs-style bracket keys stay encoded as
+    /// `%5B` / `%5D` instead of being encoded again as `%255B` / `%255D`.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode and append. Passing `nil` leaves the receiver unchanged.
+    ///   - options: Encoder settings. URL helpers force URL-safe encoding internally while preserving structural
+    ///     options such as delimiter, list format, sorting, null handling, and custom encoders.
+    /// - Throws: `EncodeError` from `Qs.encode`, or `QsURLQueryError.invalidPercentEncodedQuery` when the generated
+    ///   query is not valid percent-encoded query text.
+    mutating func appendQsQueryItems(
+        _ value: Any?,
+        options: EncodeOptions = .init()
+    ) throws {
+        guard let encoded = try Qs._encodedURLQuery(value, options: options) else {
+            return
+        }
+
+        let existingQuery = percentEncodedQuery ?? ""
+        let nextQuery =
+            existingQuery.isEmpty
+            ? encoded.query
+            : existingQuery + encoded.delimiter + encoded.query
+
+        guard Qs._isValidPercentEncodedQuery(nextQuery) else {
+            throw QsURLQueryError.invalidPercentEncodedQuery
+        }
+
+        percentEncodedQuery = nextQuery
+    }
+
+    /// Attempts to append QsSwift-encoded query items, returning `false` on failure.
+    ///
+    /// The receiver is restored to its original percent-encoded query if encoding or validation fails.
+    @discardableResult
+    mutating func appendQsQueryItemsIfPossible(
+        _ value: Any?,
+        options: EncodeOptions = .init()
+    ) -> Bool {
+        let originalQuery = percentEncodedQuery
+
+        do {
+            try appendQsQueryItems(value, options: options)
+            return true
+        } catch {
+            percentEncodedQuery = originalQuery
+            return false
+        }
+    }
+}
+
+public extension URL {
+    /// Returns a new URL with QsSwift-encoded query items appended.
+    ///
+    /// The original URL is not mutated. Existing query text and fragments are preserved.
+    ///
+    /// - Parameters:
+    ///   - value: The value to encode and append. Passing `nil` returns an equivalent URL.
+    ///   - options: Encoder settings.
+    /// - Throws: `EncodeError` from `Qs.encode`, `QsURLQueryError.invalidPercentEncodedQuery`, or
+    ///   `QsURLQueryError.invalidURL` if Foundation cannot rebuild the URL.
+    func appendingQsQueryItems(
+        _ value: Any?,
+        options: EncodeOptions = .init()
+    ) throws -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            throw QsURLQueryError.invalidURL
+        }
+
+        try components.appendQsQueryItems(value, options: options)
+
+        guard let url = components.url else {
+            throw QsURLQueryError.invalidURL
+        }
+
+        return url
+    }
+
+    /// Returns a new URL with QsSwift-encoded query items appended, or `nil` on failure.
+    func appendingQsQueryItemsOrNil(
+        _ value: Any?,
+        options: EncodeOptions = .init()
+    ) -> URL? {
+        try? appendingQsQueryItems(value, options: options)
+    }
+}
+
+extension Qs {
+    @usableFromInline
+    internal static func _encodedURLQuery(
+        _ value: Any?,
+        options: EncodeOptions
+    ) throws -> (query: String, delimiter: String)? {
+        guard value != nil else {
+            return nil
+        }
+
+        let urlOptions = options.copy(
+            addQueryPrefix: false,
+            encode: true,
+            encodeValuesOnly: false
+        )
+        let query = try encode(value, options: urlOptions)
+
+        guard !query.isEmpty else {
+            return nil
+        }
+
+        guard _isValidPercentEncodedQuery(query) else {
+            throw QsURLQueryError.invalidPercentEncodedQuery
+        }
+
+        return (query, urlOptions.delimiter)
+    }
+
+    @usableFromInline
+    internal static func _isValidPercentEncodedQuery(_ query: String) -> Bool {
+        let scalars = query.unicodeScalars
+        var index = scalars.startIndex
+
+        while index != scalars.endIndex {
+            let scalar = scalars[index]
+
+            if scalar.value == 37 {
+                let firstHexIndex = scalars.index(after: index)
+                guard firstHexIndex != scalars.endIndex else {
+                    return false
+                }
+
+                let secondHexIndex = scalars.index(after: firstHexIndex)
+                guard secondHexIndex != scalars.endIndex else {
+                    return false
+                }
+
+                guard isHexDigit(scalars[firstHexIndex]), isHexDigit(scalars[secondHexIndex]) else {
+                    return false
+                }
+
+                index = scalars.index(after: secondHexIndex)
+            } else {
+                guard scalar.value <= 127, CharacterSet.urlQueryAllowed.contains(scalar) else {
+                    return false
+                }
+
+                index = scalars.index(after: index)
+            }
+        }
+
+        return true
+    }
+
+    @inlinable
+    internal static func isHexDigit(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 48...57, 65...70, 97...102:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/QsSwiftTests/FoundationURLTests.swift
+++ b/Tests/QsSwiftTests/FoundationURLTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+@testable import QsSwift
+
+#if canImport(Testing)
+    import Testing
+#else
+    #error("The swift-testing package is required to build tests on Swift 5.x")
+#endif
+
+struct FoundationURLTests {
+    @Test("URLComponents helpers leave nil and empty encoded output unchanged")
+    func urlComponents_nilAndEmptyOutputAreNoOps() throws {
+        var nilComponents = URLComponents(string: "https://example.com/products?existing=x%20y#frag")!
+        let nilBefore = nilComponents.string
+
+        try nilComponents.appendQsQueryItems(nil)
+
+        #expect(nilComponents.string == nilBefore)
+
+        var emptyComponents = URLComponents(string: "https://example.com/products?existing=x%20y#frag")!
+        let emptyBefore = emptyComponents.string
+
+        try emptyComponents.appendQsQueryItems([String: Any]())
+
+        #expect(emptyComponents.string == emptyBefore)
+    }
+
+    @Test("URLComponents helper appends simple, nested, and array values without double encoding")
+    func urlComponents_appendsNestedQueryWithoutDoubleEncoding() throws {
+        var simple = URLComponents(string: "https://api.example.com/products")!
+
+        try simple.appendQsQueryItems(["a": "b"])
+
+        #expect(simple.url?.absoluteString == "https://api.example.com/products?a=b")
+
+        var components = URLComponents(string: "https://api.example.com/products")!
+        let input: [String: Any] = [
+            "filter": [
+                "where": [
+                    "age": ["gte": 30],
+                    "name": "John",
+                ],
+            ],
+            "tags": ["a", "b"],
+        ]
+
+        try components.appendQsQueryItems(
+            input,
+            options: EncodeOptions(sort: Self.lexicalSort)
+        )
+
+        let url = try #require(components.url)
+        #expect(
+            url.absoluteString
+                == "https://api.example.com/products?filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30"
+                    + "&filter%5Bwhere%5D%5Bname%5D=John&tags%5B0%5D=a&tags%5B1%5D=b"
+        )
+        #expect(url.absoluteString.contains("filter%5Bwhere%5D"))
+        #expect(!url.absoluteString.contains("%255B"))
+    }
+
+    @Test("URLComponents helper preserves structured list values")
+    func urlComponents_appendsListOfDictionaries() throws {
+        var components = URLComponents(string: "https://api.example.com/products")!
+
+        try components.appendQsQueryItems(
+            ["items": [["id": 1], ["id": 2]]],
+            options: EncodeOptions(sort: Self.lexicalSort)
+        )
+
+        #expect(
+            components.percentEncodedQuery
+                == "items%5B0%5D%5Bid%5D=1&items%5B1%5D%5Bid%5D=2"
+        )
+    }
+
+    @Test("URLComponents helper preserves duplicate keys, empty values, and name-only values")
+    func urlComponents_preservesDuplicateEmptyAndNameOnlyValues() throws {
+        var duplicates = URLComponents(string: "https://example.com/products")!
+
+        try duplicates.appendQsQueryItems(
+            ["tag": ["a", "b"]],
+            options: EncodeOptions(listFormat: .repeatKey)
+        )
+
+        #expect(duplicates.percentEncodedQuery == "tag=a&tag=b")
+
+        var emptyAndBare = URLComponents(string: "https://example.com/products")!
+
+        try emptyAndBare.appendQsQueryItems(
+            ["bare": NSNull(), "empty": ""],
+            options: EncodeOptions(strictNullHandling: true, sort: Self.lexicalSort)
+        )
+
+        #expect(emptyAndBare.percentEncodedQuery == "bare&empty=")
+        #expect(emptyAndBare.url?.absoluteString == "https://example.com/products?bare&empty=")
+    }
+
+    @Test("URLComponents helper preserves existing query text, fragments, and URL components")
+    func urlComponents_preservesExistingQueryAndURLParts() throws {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.user = "user"
+        components.password = "pass"
+        components.host = "api.example.com"
+        components.port = 8443
+        components.path = "/products"
+        components.percentEncodedQuery = "existing=x%20y&flag"
+        components.fragment = "frag"
+
+        try components.appendQsQueryItems(
+            ["filter": ["name": "John"]],
+            options: EncodeOptions(sort: Self.lexicalSort)
+        )
+
+        #expect(
+            components.url?.absoluteString
+                == "https://user:pass@api.example.com:8443/products"
+                    + "?existing=x%20y&flag&filter%5Bname%5D=John#frag"
+        )
+    }
+
+    @Test("URL helper returns a new URL and preserves the original")
+    func url_appendingReturnsNewURL() throws {
+        let original = URL(string: "https://example.com/products?existing=x#frag")!
+
+        let next = try original.appendingQsQueryItems(["a": ["b": "c"]])
+
+        #expect(original.absoluteString == "https://example.com/products?existing=x#frag")
+        #expect(next.absoluteString == "https://example.com/products?existing=x&a%5Bb%5D=c#frag")
+    }
+
+    @Test("URL helper supports relative URLs")
+    func url_appendingSupportsRelativeURLs() throws {
+        let original = URL(string: "/products?existing=x#frag")!
+
+        let next = try original.appendingQsQueryItems(["a": "b"])
+
+        #expect(next.relativeString == "/products?existing=x&a=b#frag")
+    }
+
+    @Test("URL helpers ignore addQueryPrefix and preserve custom delimiters")
+    func urlHelpers_ignoreQueryPrefixAndPreserveDelimiter() throws {
+        var prefixed = URLComponents(string: "https://example.com/products")!
+
+        try prefixed.appendQsQueryItems(
+            ["a": "b"],
+            options: EncodeOptions(addQueryPrefix: true)
+        )
+
+        #expect(prefixed.percentEncodedQuery == "a=b")
+
+        var semicolon = URLComponents(string: "https://example.com/products?existing=x")!
+
+        try semicolon.appendQsQueryItems(
+            ["a": "b", "c": "d"],
+            options: EncodeOptions(delimiter: ";", sort: Self.lexicalSort)
+        )
+
+        #expect(semicolon.percentEncodedQuery == "existing=x;a=b;c=d")
+        #expect(semicolon.url?.absoluteString == "https://example.com/products?existing=x;a=b;c=d")
+    }
+
+    @Test("URL helpers normalize raw and values-only encoding options")
+    func urlHelpers_normalizeRawEncodingOptions() throws {
+        var rawKeys = URLComponents(string: "https://example.com/products")!
+
+        try rawKeys.appendQsQueryItems(
+            ["a": ["b": "c"]],
+            options: EncodeOptions(encode: false)
+        )
+
+        #expect(rawKeys.percentEncodedQuery == "a%5Bb%5D=c")
+
+        var valuesOnly = URLComponents(string: "https://example.com/products")!
+
+        try valuesOnly.appendQsQueryItems(
+            ["a": ["b": "c d"]],
+            options: EncodeOptions(encodeValuesOnly: true)
+        )
+
+        #expect(valuesOnly.percentEncodedQuery == "a%5Bb%5D=c%20d")
+    }
+
+    @Test("URL helpers report invalid custom encoder output without mutating components")
+    func urlHelpers_invalidCustomEncoderOutput() throws {
+        let invalidEncoder: ValueEncoder = { value, _, _ in
+            String(describing: value ?? "")
+        }
+        let options = EncodeOptions(encoder: invalidEncoder)
+        var components = URLComponents(string: "https://example.com/products?existing=x")!
+
+        #expect(throws: QsURLQueryError.invalidPercentEncodedQuery) {
+            try components.appendQsQueryItems(["a": ["b": "c"]], options: options)
+        }
+        #expect(components.percentEncodedQuery == "existing=x")
+
+        let didAppend = components.appendQsQueryItemsIfPossible(["a": ["b": "c"]], options: options)
+        #expect(!didAppend)
+        #expect(components.percentEncodedQuery == "existing=x")
+
+        let url = URL(string: "https://example.com/products")!
+        #expect(url.appendingQsQueryItemsOrNil(["a": ["b": "c"]], options: options) == nil)
+
+        let unicodeEncoder: ValueEncoder = { _, _, _ in
+            "é"
+        }
+        var unicodeComponents = URLComponents(string: "https://example.com/products?existing=x")!
+
+        #expect(throws: QsURLQueryError.invalidPercentEncodedQuery) {
+            try unicodeComponents.appendQsQueryItems(["a": "b"], options: EncodeOptions(encoder: unicodeEncoder))
+        }
+        #expect(unicodeComponents.percentEncodedQuery == "existing=x")
+    }
+
+    private static func lexicalSort(_ lhs: Any?, _ rhs: Any?) -> Int {
+        let left = String(describing: lhs ?? "")
+        let right = String(describing: rhs ?? "")
+        return left.compare(right).rawValue
+    }
+}


### PR DESCRIPTION
This pull request introduces new Foundation helpers for appending QsSwift-encoded query strings to `URLComponents` and `URL` without double-encoding bracket notation. It also adds comprehensive tests and documentation for these helpers, ensuring correct integration and usage. The update is documented in the changelog and README.

**Foundation URL Integration:**

* Added `URLComponents.appendQsQueryItems` and `URL.appendingQsQueryItems` helpers in `FoundationURL+Qs.swift` to safely append QsSwift-encoded query data to URLs, preserving bracket notation and avoiding double encoding. Includes error handling for invalid percent-encoded queries and malformed URLs.
* Introduced `QsURLQueryError` for robust error reporting when appending query items fails.

**Documentation:**

* Updated `README.md` with usage examples and explanations for the new Foundation URL helpers, including notes on encoding behavior and limitations.
* Added a new entry in `CHANGELOG.md` for version 1.4.0-dev describing the Foundation URL helper feature.

**Testing:**

* Added a comprehensive test suite in `FoundationURLTests.swift` to verify correct behavior of the helpers, including edge cases for encoding, duplicate keys, delimiter preservation, nil/empty handling, and error scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Foundation URL helpers allow appending encoded query strings to `URLComponents` and `URL` objects without bracket notation double-encoding. Includes both mutating and immutable variants with flexible error handling options.

* **Documentation**
  * Updated documentation with examples demonstrating the new URL query appending APIs and clarification on encoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->