### PR TITLE
:sparkles: qs 6.15.3 parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.1-dev
+
+- [FIX] align list-limit behavior with `qs@6.15.3`: enforce `listLimit` cumulatively across duplicate keys, comma values, bracket/index notation, nested merges, and existing overflow maps; exact-limit values remain lists, while non-throwing overflow becomes a numeric-keyed dictionary.
+- [FIX] treat negative `listLimit` values as immediate overflow (or `DecodeError.listLimitExceeded` when `throwOnLimitExceeded` is enabled), preserve later overflow values as nested entries, and keep `[]=` comma groups as single outer list elements regardless of inner group size.
+- [FIX] keep list parsing enabled regardless of top-level parameter count; only `parseLists: false` disables bracket-list parsing.
+- [TEST] add Swift, Objective-C bridge, Objective-C E2E, and qs comparison coverage for cumulative limits, mixed list notation, unbalanced bracket keys, UTF-16 chunk-boundary encoding, and multi-step Foundation cycles.
+- [CHORE] update the JavaScript comparison fixture dependency from `qs@6.15.2` to `qs@6.15.3`.
+
 ## 1.4.0
 
 - [FEAT] add Foundation `URLComponents` and `URL` helpers for appending QsSwift-encoded nested query strings without double-encoding bracket notation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.1-dev
 
 - [FIX] align list-limit behavior with `qs@6.15.3`: enforce `listLimit` cumulatively across duplicate keys, comma values, bracket/index notation, nested merges, and existing overflow maps; exact-limit values remain lists, while non-throwing overflow becomes a numeric-keyed dictionary.
-- [FIX] treat negative `listLimit` values as immediate overflow (or `DecodeError.listLimitExceeded` when `throwOnLimitExceeded` is enabled), preserve later overflow values as nested entries, and keep `[]=` comma groups as single outer list elements regardless of inner group size.
+- [FIX] treat negative `listLimit` values as immediate overflow whenever list-limit enforcement runs (or `DecodeError.listLimitExceeded` when `throwOnLimitExceeded` is enabled), preserve later overflow values as nested entries, and keep `[]=` comma groups as single outer list elements regardless of inner group size.
 - [FIX] interpret ISO-8859-1 numeric entities before applying non-throwing comma-list overflow, preserving the qs-compatible scalar shape instead of producing a numeric-keyed dictionary.
 - [FIX] keep list parsing enabled regardless of top-level parameter count; only `parseLists: false` disables bracket-list parsing.
 - [TEST] add Swift, Objective-C bridge, Objective-C E2E, and qs comparison coverage for cumulative limits, mixed list notation, unbalanced bracket keys, UTF-16 chunk-boundary encoding, and multi-step Foundation cycles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [FIX] align list-limit behavior with `qs@6.15.3`: enforce `listLimit` cumulatively across duplicate keys, comma values, bracket/index notation, nested merges, and existing overflow maps; exact-limit values remain lists, while non-throwing overflow becomes a numeric-keyed dictionary.
 - [FIX] treat negative `listLimit` values as immediate overflow (or `DecodeError.listLimitExceeded` when `throwOnLimitExceeded` is enabled), preserve later overflow values as nested entries, and keep `[]=` comma groups as single outer list elements regardless of inner group size.
+- [FIX] interpret ISO-8859-1 numeric entities before applying non-throwing comma-list overflow, preserving the qs-compatible scalar shape instead of producing a numeric-keyed dictionary.
 - [FIX] keep list parsing enabled regardless of top-level parameter count; only `parseLists: false` disables bracket-list parsing.
 - [TEST] add Swift, Objective-C bridge, Objective-C E2E, and qs comparison coverage for cumulative limits, mixed list notation, unbalanced bracket keys, UTF-16 chunk-boundary encoding, and multi-step Foundation cycles.
 - [CHORE] update the JavaScript comparison fixture dependency from `qs@6.15.2` to `qs@6.15.3`.

--- a/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCBridgeExtrasTests.m
@@ -144,6 +144,41 @@
     XCTAssertEqualObjects(m3[@"a"], @"2");
 }
 
+- (void)test_decode_qs_6_15_3_cumulative_list_limits {
+    QsDecodeOptions *strict = [[QsDecodeOptions alloc] init];
+    strict.comma = YES;
+    strict.listLimit = 3;
+    strict.throwOnLimitExceeded = YES;
+
+    NSError *err = nil;
+    NSDictionary *failed = [Qs decode:@"a=1,2&a=3,4" options:strict error:&err];
+    XCTAssertNil(failed);
+    XCTAssertNotNil(err);
+    XCTAssertEqualObjects(err.domain, QsDecodeErrorInfo.domain);
+    XCTAssertEqual(err.code, QsDecodeErrorCodeListLimitExceeded);
+
+    QsDecodeOptions *soft = [[QsDecodeOptions alloc] init];
+    soft.comma = YES;
+    soft.listLimit = 3;
+    err = nil;
+    NSDictionary *overflowed = [Qs decode:@"a=1,2&a=3,4" options:soft error:&err];
+    XCTAssertNil(err);
+    NSDictionary *overflow = overflowed[@"a"];
+    XCTAssertEqualObjects(overflow[@"0"], @"1");
+    XCTAssertEqualObjects(overflow[@"3"], @"4");
+
+    QsDecodeOptions *bracketed = [[QsDecodeOptions alloc] init];
+    bracketed.comma = YES;
+    bracketed.listLimit = 1;
+    bracketed.throwOnLimitExceeded = YES;
+    err = nil;
+    NSDictionary *nested = [Qs decode:@"a[]=1,2,3,4" options:bracketed error:&err];
+    XCTAssertNil(err);
+    NSArray *outer = nested[@"a"];
+    XCTAssertEqual(outer.count, 1u);
+    XCTAssertEqualObjects(outer[0], (@[@"1", @"2", @"3", @"4"]));
+}
+
 #pragma mark - 8) RFC1738 uses + for spaces when encoding
 
 - (void)test_encode_rfc1738_space_plus {

--- a/Sources/QsObjC/Models/DecodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/DecodeOptionsObjC.swift
@@ -67,11 +67,20 @@
         /// Allow empty lists like `a[]=` to produce an empty array rather than omitting the key.
         public var allowEmptyLists: Bool = false
 
-        /// Permit sparse arrays (e.g. `a[2]=x` without lower indices). When `false`, gaps are filled.
+        /// Permit sparse arrays (e.g. `a[2]=x` without lower indices). When `false`, gaps are
+        /// compacted; when `true`, public bridge output preserves them as `NSNull` placeholders.
         public var allowSparseLists: Bool = false
 
-        /// Maximum number of items parsed into a single list (defensive cap).
-        /// The highest numeric bracket index that can materialize as an array is `listLimit - 1`.
+        /// Maximum list size and numeric-index threshold used while decoding.
+        ///
+        /// The limit is cumulative across duplicate keys, flat comma-separated values, and list
+        /// merges. A result with exactly `listLimit` elements remains a list; growing past it
+        /// becomes a numeric-keyed dictionary, or throws when `throwOnLimitExceeded` is `true`.
+        /// A negative limit makes every non-empty list overflow or throw immediately.
+        ///
+        /// Comma values written with `[]=` are nested groups: each complete comma group counts as
+        /// one outer list element, regardless of how many values the group contains. Numeric
+        /// bracket indices at or above the limit are represented as dictionary keys.
         public var listLimit: Int = 20
 
         /// When `true`, treat commas as element separators inside a single key (e.g. `a=b,c`).
@@ -99,8 +108,9 @@
         /// Hard cap on the number of key/value pairs processed from the input.
         public var parameterLimit: Int = 1000
 
-        /// If `true`, exceedance of `listLimit`, `depth`, or `parameterLimit` throws instead
-        /// of truncating/ignoring extra data.
+        /// If `true`, exceeding `parameterLimit` or `listLimit` throws. Otherwise parameter
+        /// parsing truncates and list overflow falls back to a numeric-keyed dictionary.
+        /// Depth exceedance is controlled separately by `strictDepth`.
         public var throwOnLimitExceeded: Bool = false
 
         // MARK: - Charset / wire format

--- a/Sources/QsObjC/Models/DecodeOptionsObjC.swift
+++ b/Sources/QsObjC/Models/DecodeOptionsObjC.swift
@@ -76,7 +76,9 @@
         /// The limit is cumulative across duplicate keys, flat comma-separated values, and list
         /// merges. A result with exactly `listLimit` elements remains a list; growing past it
         /// becomes a numeric-keyed dictionary, or throws when `throwOnLimitExceeded` is `true`.
-        /// A negative limit makes every non-empty list overflow or throw immediately.
+        /// A negative limit treats every list construction or merge that reaches limit enforcement
+        /// as exceeded. Parser-recognized empty lists can still be preserved by `allowEmptyLists`
+        /// because they bypass list construction.
         ///
         /// Comma values written with `[]=` are nested groups: each complete comma group counts as
         /// one outer list element, regardless of how many values the group contains. Numeric

--- a/Sources/QsObjC/README.md
+++ b/Sources/QsObjC/README.md
@@ -187,7 +187,9 @@ d.duplicates = QsDuplicatesCombine;    // combine | first | last
 d.parameterLimit = 1000;                // must be > 0 (defensive cap on number of pairs)
 // listLimit is cumulative across duplicate keys, flat comma values, and list merges.
 // Exact-limit results stay arrays; soft overflow and numeric indices at/above the limit use maps.
-// A negative limit overflows every non-empty list. Each comma group in a[]= counts as one element.
+// A negative limit makes limit-enforced list construction/merges overflow or throw;
+// allowEmptyLists can still preserve parser-recognized empty lists by bypassing that enforcement.
+// Each comma group in a[]= counts as one element.
 d.listLimit      = 20;
 d.depth          = 5;                   // maximum bracket nesting (≥ 0)
 

--- a/Sources/QsObjC/README.md
+++ b/Sources/QsObjC/README.md
@@ -185,7 +185,10 @@ d.duplicates = QsDuplicatesCombine;    // combine | first | last
 // Limits and strictness
 
 d.parameterLimit = 1000;                // must be > 0 (defensive cap on number of pairs)
-d.listLimit      = 20;                  // max array element count; index 20+ falls back to a map
+// listLimit is cumulative across duplicate keys, flat comma values, and list merges.
+// Exact-limit results stay arrays; soft overflow and numeric indices at/above the limit use maps.
+// A negative limit overflows every non-empty list. Each comma group in a[]= counts as one element.
+d.listLimit      = 20;
 d.depth          = 5;                   // maximum bracket nesting (≥ 0)
 
 d.strictDepth          = NO;            // YES: throw when over depth; NO (default): collapse the remainder into a literal key
@@ -194,7 +197,7 @@ d.strictMerge          = YES;           // YES: qs-compatible object/scalar conf
 
 d.strictNullHandling   = NO;            // if YES, keys with no value → NSNull instead of ""
 
-d.throwOnLimitExceeded = NO;            // if YES, parameter/list/depth violations throw
+d.throwOnLimitExceeded = NO;            // if YES, parameter/list violations throw; see strictDepth for depth
 
 // Custom scalar decoder (runs before interpretation)
 d.valueDecoderBlock = ^id(NSString * token, NSNumber * charset) {

--- a/Sources/QsSwift/FoundationURL+Qs.swift
+++ b/Sources/QsSwift/FoundationURL+Qs.swift
@@ -9,7 +9,7 @@ public enum QsURLQueryError: Error, Equatable, Sendable {
     case invalidURL
 }
 
-public extension URLComponents {
+extension URLComponents {
     /// Appends QsSwift-encoded query items to this component's percent-encoded query.
     ///
     /// This method appends to `percentEncodedQuery` instead of `queryItems` so qs-style bracket keys stay encoded as
@@ -21,7 +21,7 @@ public extension URLComponents {
     ///     options such as delimiter, list format, sorting, null handling, and custom encoders.
     /// - Throws: `EncodeError` from `Qs.encode`, or `QsURLQueryError.invalidPercentEncodedQuery` when the generated
     ///   query is not valid percent-encoded query text.
-    mutating func appendQsQueryItems(
+    public mutating func appendQsQueryItems(
         _ value: Any?,
         options: EncodeOptions = .init()
     ) throws {
@@ -46,7 +46,7 @@ public extension URLComponents {
     ///
     /// The receiver is restored to its original percent-encoded query if encoding or validation fails.
     @discardableResult
-    mutating func appendQsQueryItemsIfPossible(
+    public mutating func appendQsQueryItemsIfPossible(
         _ value: Any?,
         options: EncodeOptions = .init()
     ) -> Bool {
@@ -62,7 +62,7 @@ public extension URLComponents {
     }
 }
 
-public extension URL {
+extension URL {
     /// Returns a new URL with QsSwift-encoded query items appended.
     ///
     /// The original URL is not mutated. Existing query text and fragments are preserved.
@@ -72,7 +72,7 @@ public extension URL {
     ///   - options: Encoder settings.
     /// - Throws: `EncodeError` from `Qs.encode`, `QsURLQueryError.invalidPercentEncodedQuery`, or
     ///   `QsURLQueryError.invalidURL` if Foundation cannot rebuild the URL.
-    func appendingQsQueryItems(
+    public func appendingQsQueryItems(
         _ value: Any?,
         options: EncodeOptions = .init()
     ) throws -> URL {
@@ -90,7 +90,7 @@ public extension URL {
     }
 
     /// Returns a new URL with QsSwift-encoded query items appended, or `nil` on failure.
-    func appendingQsQueryItemsOrNil(
+    public func appendingQsQueryItemsOrNil(
         _ value: Any?,
         options: EncodeOptions = .init()
     ) -> URL? {

--- a/Sources/QsSwift/Internal/Decoder+ParseList.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseList.swift
@@ -7,16 +7,15 @@ extension QsSwift.Decoder {
     /// Behavior:
     /// - If `options.comma == true` and `value` is a non-empty `String` containing commas,
     ///   split it into a `[String]` (preserving empty segments). Example: `"a,,b"` → `["a", "", "b"]`.
-    /// - If `throwOnLimitExceeded == true`, validates both the split count (for comma lists)
-    ///   and the *next* append (`currentListLength`) against `listLimit`.
-    /// - If `throwOnLimitExceeded == false`, comma values that overflow the limit on first
-    ///   occurrence fall back to indexed-object (overflow) representation.
+    /// - If `throwOnLimitExceeded == true`, validates flat comma values before splitting and
+    ///   validates the *next* scalar append (`currentListLength`) against `listLimit`.
+    /// - Comma groups under `[]=` are nested values and count as one outer list element.
     ///
     /// - Parameters:
     ///   - value: The raw (decoded) RHS value for the current key part.
     ///   - options: The active `DecodeOptions`.
     ///   - currentListLength: The current length of the list under construction for this key, if any.
-    ///   - isFirstOccurrence: Whether this key has not been seen previously in the current query pass.
+    ///   - isFlatListValue: Whether a comma value is flat rather than nested under `[]=`.
     /// - Returns: Either the original `value`, or a `[String]` when comma-splitting applies.
     /// - Throws: `.listLimitExceeded`.
     #if QSBENCH_INLINE
@@ -27,71 +26,19 @@ extension QsSwift.Decoder {
         _ value: Any?,
         options: DecodeOptions,
         currentListLength: Int,
-        isFirstOccurrence: Bool
+        isFlatListValue: Bool = true
     ) throws -> Any? {
-        if options.throwOnLimitExceeded, options.listLimit == 0 {
-            throw DecodeError.listLimitExceeded(limit: options.listLimit)
-        }
         if let stringVal = value as? String, !stringVal.isEmpty, options.comma, stringVal.contains(",") {
-            if options.throwOnLimitExceeded {
-                if options.listLimit <= 0 {
-                    throw DecodeError.listLimitExceeded(limit: options.listLimit)
-                }
-
-                let (remaining, overflowed) = options.listLimit.subtractingReportingOverflow(
-                    currentListLength
-                )
-                if overflowed || remaining < 0 {
-                    throw DecodeError.listLimitExceeded(limit: options.listLimit)
-                }
-
-                let maxParts: Int? = {
-                    let (value, overflowed) = remaining.addingReportingOverflow(1)
-                    return overflowed ? nil : value
-                }()
-                let splitVal = splitCommaValue(stringVal, maxParts: maxParts)
-                if splitVal.count > remaining {
-                    throw DecodeError.listLimitExceeded(limit: options.listLimit)
-                }
-                return splitVal
-            }
-
-            if isFirstOccurrence, options.listLimit >= 0 {
-                let maxParts: Int? = {
-                    let (value, overflowed) = options.listLimit.addingReportingOverflow(1)
-                    return overflowed ? nil : value
-                }()
-                let preview = splitCommaValue(stringVal, maxParts: maxParts)
-                if preview.count > options.listLimit {
-                    let full = splitCommaValue(stringVal, maxParts: nil)
-                    var overflow: [AnyHashable: Any] = [:]
-                    overflow.reserveCapacity(full.count + 1)
-                    for (index, element) in full.enumerated() {
-                        overflow[index] = element
+            if isFlatListValue, options.throwOnLimitExceeded {
+                var commaCount = 0
+                for byte in stringVal.utf8 where byte == 0x2C {
+                    commaCount += 1
+                    if commaCount >= options.listLimit {
+                        throw DecodeError.listLimitExceeded(limit: options.listLimit)
                     }
-                    return Utils.markOverflow(overflow, maxIndex: full.count - 1)
                 }
-                return preview
             }
-
-            let splitVal = splitCommaValue(stringVal, maxParts: nil)
-
-            // qs@6.14.2 parity:
-            // If comma splitting alone overflows and we are not throwing, the first occurrence
-            // falls back to an indexed object shape instead of a list.
-            if !options.throwOnLimitExceeded,
-                isFirstOccurrence,
-                splitVal.count > options.listLimit
-            {
-                var overflow: [AnyHashable: Any] = [:]
-                overflow.reserveCapacity(splitVal.count + 1)
-                for (index, element) in splitVal.enumerated() {
-                    overflow[index] = element
-                }
-                return Utils.markOverflow(overflow, maxIndex: splitVal.count - 1)
-            }
-
-            return splitVal
+            return splitCommaValue(stringVal)
         }
 
         if options.throwOnLimitExceeded, currentListLength >= options.listLimit {
@@ -102,17 +49,13 @@ extension QsSwift.Decoder {
     }
 
     /// Splits a comma-separated scalar preserving empty segments.
-    private static func splitCommaValue(_ value: String, maxParts: Int?) -> [String] {
-        if let maxParts, maxParts <= 0 { return [] }
-
+    private static func splitCommaValue(_ value: String) -> [String] {
         var parts: [String] = []
-        let reserveHint = min(maxParts ?? 8, min(value.utf8.count, 7) + 1)
+        let reserveHint = min(value.utf8.count, 7) + 1
         parts.reserveCapacity(reserveHint)
 
         var start = value.startIndex
         while true {
-            if let maxParts, parts.count >= maxParts { break }
-
             let comma = value[start...].firstIndex(of: ",")
             let end = comma ?? value.endIndex
             parts.append(String(value[start..<end]))

--- a/Sources/QsSwift/Internal/Decoder+ParseObject.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseObject.swift
@@ -102,6 +102,7 @@ extension QsSwift.Decoder {
                     obj = mutableObj
                 } else if let idx = Int(decodedRoot),
                     idx >= 0,
+                    idx < Int.max,  // overflow metadata must remain incrementable
                     root != decodedRoot,  // must have been "[0]"
                     String(idx) == decodedRoot,
                     options.parseLists

--- a/Sources/QsSwift/Internal/Decoder+ParseObject.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseObject.swift
@@ -100,12 +100,9 @@ extension QsSwift.Decoder {
                     // Treat "[]" as dictionary key "0"
                     mutableObj["0"] = (leaf ?? NSNull())
                     obj = mutableObj
-                } else if let idx = Int(decodedRoot),
-                    idx >= 0,
-                    idx < Int.max,  // overflow metadata must remain incrementable
-                    root != decodedRoot,  // must have been "[0]"
-                    String(idx) == decodedRoot,
-                    options.parseLists
+                } else if root != decodedRoot,  // must have been "[0]"
+                    options.parseLists,
+                    let idx = parseJavaScriptArrayIndex(decodedRoot)
                 {
                     if idx < options.listLimit {
                         // valid bracketed numeric index ⇒ array shell
@@ -130,6 +127,18 @@ extension QsSwift.Decoder {
         }
 
         return leaf
+    }
+
+    /// Mirrors qs's `String(parseInt(root, 10)) === root` numeric-index check.
+    private static func parseJavaScriptArrayIndex(_ root: String) -> Int? {
+        guard let index = Int(root), index >= 0, String(index) == root else {
+            return nil
+        }
+        if index <= Utils.maximumSafeJavaScriptInteger { return index }
+        guard let number = Double(root), number.isFinite,
+            Utils.javascriptIntegerDescription(number) == root
+        else { return nil }
+        return index
     }
 
     @inline(__always)

--- a/Sources/QsSwift/Internal/Decoder+ParseObject.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseObject.swift
@@ -51,7 +51,7 @@ extension QsSwift.Decoder {
                 value,
                 options: options,
                 currentListLength: currentListLength,
-                isFirstOccurrence: true
+                isFlatListValue: true
             )
 
         // Walk backwards from leaf to root
@@ -72,7 +72,7 @@ extension QsSwift.Decoder {
                         if let arrOpt = leaf as? [Any?] { return arrOpt }
                         return leaf ?? NSNull()
                     }()
-                    obj = Utils.combine([], valueForCombine, listLimit: options.listLimit)
+                    obj = try Utils.combine([], valueForCombine, options: options)
                 }
             } else {
                 var mutableObj: [AnyHashable: Any] = [:]

--- a/Sources/QsSwift/Internal/Decoder+ParseObject.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseObject.swift
@@ -115,8 +115,8 @@ extension QsSwift.Decoder {
                         if options.throwOnLimitExceeded {
                             throw DecodeError.listLimitExceeded(limit: options.listLimit)
                         }
-                        mutableObj[decodedRoot] = (leaf ?? NSNull())
-                        obj = mutableObj
+                        mutableObj[idx] = (leaf ?? NSNull())
+                        obj = Utils.markOverflow(mutableObj, maxIndex: idx)
                     }
                 } else {
                     // default: dictionary with *string* key

--- a/Sources/QsSwift/Internal/Decoder+ParseQuery.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseQuery.swift
@@ -151,19 +151,6 @@ extension QsSwift.Decoder {
                     value = parsed
                 }
 
-                // Flat comma values are list values in their own right. Enforce the
-                // soft limit after decoding their elements but before numeric-entity
-                // interpretation so the established indexed overflow representation
-                // continues through that transform.
-                // `[]=` comma groups are nested values and are handled by their outer
-                // list after wrapping below.
-                if !hadBracketedEmpty, options.comma {
-                    if let arr = value as? [Any], arr.count > options.listLimit {
-                        value = try Utils.combine([], arr, options: options)
-                    } else if let arr = value as? [Any?], arr.count > options.listLimit {
-                        value = try Utils.combine([], arr, options: options)
-                    }
-                }
             }
 
             // Interpret numeric entities if asked (ISO‑8859‑1 only).
@@ -207,7 +194,10 @@ extension QsSwift.Decoder {
                 // else leave scalars as-is; parseObject will handle "[]"
             }
 
-            if hadBracketedEmpty, options.comma {
+            // Match qs ordering: numeric-entity interpretation may collapse a comma
+            // array to a scalar before the soft list limit is applied. Bracketed
+            // comma groups are wrapped first, so each group counts as one element.
+            if options.comma {
                 if let arr = value as? [Any], arr.count > options.listLimit {
                     value = try Utils.combine([], arr, options: options)
                 } else if let arr = value as? [Any?], arr.count > options.listLimit {

--- a/Sources/QsSwift/Internal/Decoder+ParseQuery.swift
+++ b/Sources/QsSwift/Internal/Decoder+ParseQuery.swift
@@ -119,7 +119,6 @@ extension QsSwift.Decoder {
                     continue
                 }
                 key = decodedKey
-                let isFirstOccurrence = (obj[key] == nil)
 
                 // Determine current list length for limit checks (only if key already has a list)
                 let currentLen = effectiveListLength(obj[key])
@@ -128,7 +127,7 @@ extension QsSwift.Decoder {
                     rhs,
                     options: options,
                     currentListLength: currentLen,
-                    isFirstOccurrence: isFirstOccurrence
+                    isFlatListValue: !hadBracketedEmpty
                 )
 
                 // IMPORTANT: distinguish custom decoder vs default decoder
@@ -150,6 +149,20 @@ extension QsSwift.Decoder {
                     value = decodeOverflowElements(overflow, options: options, charset: charset)
                 } else {
                     value = parsed
+                }
+
+                // Flat comma values are list values in their own right. Enforce the
+                // soft limit after decoding their elements but before numeric-entity
+                // interpretation so the established indexed overflow representation
+                // continues through that transform.
+                // `[]=` comma groups are nested values and are handled by their outer
+                // list after wrapping below.
+                if !hadBracketedEmpty, options.comma {
+                    if let arr = value as? [Any], arr.count > options.listLimit {
+                        value = try Utils.combine([], arr, options: options)
+                    } else if let arr = value as? [Any?], arr.count > options.listLimit {
+                        value = try Utils.combine([], arr, options: options)
+                    }
                 }
             }
 
@@ -190,17 +203,16 @@ extension QsSwift.Decoder {
                     value = [arr]
                 } else if let arrOpt = value as? [Any?] {
                     value = [arrOpt.map { $0 ?? NSNull() }]
-                } else if let overflow = value as? [AnyHashable: Any], Utils.isOverflow(overflow) {
-                    // Explicit "[]": preserve list-of-lists semantics even when comma overflow
-                    // temporarily used indexed-map fallback.
-                    if let dense = overflowElementsAsArray(overflow, listLimit: options.listLimit) {
-                        value = [dense]
-                    } else {
-                        // Avoid unbounded dense allocation; keep overflow-map representation.
-                        value = overflow
-                    }
                 }
                 // else leave scalars as-is; parseObject will handle "[]"
+            }
+
+            if hadBracketedEmpty, options.comma {
+                if let arr = value as? [Any], arr.count > options.listLimit {
+                    value = try Utils.combine([], arr, options: options)
+                } else if let arr = value as? [Any?], arr.count > options.listLimit {
+                    value = try Utils.combine([], arr, options: options)
+                }
             }
 
             // Duplicates handling (only arrayify on subsequent duplicates, like Kotlin)
@@ -209,7 +221,7 @@ extension QsSwift.Decoder {
             if shouldCombine {
                 if exists {
                     let prev: Any? = obj[key] ?? nil
-                    let combined = Utils.combine(prev, value, listLimit: options.listLimit)
+                    let combined = try Utils.combine(prev, value, options: options)
                     if let combinedArray = combined as? [Any?] {
                         obj[key] = combinedArray.map { $0 ?? NSNull() }  // normalize optionals
                     } else if let combinedArray = combined as? [Any] {
@@ -1046,42 +1058,4 @@ extension QsSwift.Decoder {
         return out
     }
 
-    /// Materializes an overflow dictionary into a dense, index-ordered array payload.
-    /// Missing indices are represented as `NSNull` to preserve positional semantics.
-    ///
-    /// Returns `nil` when the dense size would be unbounded for the current parser limits.
-    private static func overflowElementsAsArray(
-        _ overflow: [AnyHashable: Any],
-        listLimit: Int
-    ) -> [Any]? {
-        let explicitMax = overflow.keys.compactMap(Utils.intIndex).max() ?? -1
-        let metadataMax = Utils.overflowMaxIndex(overflow) ?? -1
-        let maxIndex = max(explicitMax, metadataMax)
-        guard maxIndex >= 0 else { return [] }
-
-        let (elementCount, overflowed) = maxIndex.addingReportingOverflow(1)
-        guard !overflowed else { return nil }
-
-        let normalizedListLimit = max(listLimit, 0)
-        let nearLimitAllowance: Int = {
-            let (value, didOverflow) = normalizedListLimit.addingReportingOverflow(1)
-            return didOverflow ? Int.max : value
-        }()
-        let materializationLimit = max(nearLimitAllowance, overflowDenseArrayMaterializationFloor)
-        guard elementCount <= materializationLimit else { return nil }
-
-        var out = Array(repeating: NSNull() as Any, count: elementCount)
-        for (key, value) in overflow where !Utils.isOverflowKey(key) {
-            guard let idx = Utils.intIndex(key), idx >= 0, idx <= maxIndex else { continue }
-            out[idx] = value
-        }
-        return out
-    }
-
-    /// Lower bound for dense overflow materialization when applying parser limits.
-    /// This keeps modest sparse overflows materializable even when `listLimit` is very small,
-    /// preserving list-like semantics instead of immediately falling back to overflow maps.
-    /// At 4_096 elements, pointer-sized storage is roughly 32 KiB (4_096 * 8 bytes) before
-    /// container overhead, which keeps the memory tradeoff bounded.
-    private static let overflowDenseArrayMaterializationFloor = 4_096
 }

--- a/Sources/QsSwift/Internal/Utils+Combine.swift
+++ b/Sources/QsSwift/Internal/Utils+Combine.swift
@@ -27,11 +27,14 @@ extension Utils {
         return result
     }
 
-    /// Combines two objects while honoring list limits; may return an overflow map.
+    /// Combines two objects while honoring list limits; may throw or return an overflow map.
     /// - Returns: `[Any?]` when within limit, or `[AnyHashable: Any]` when exceeded.
     @usableFromInline
-    static func combine(_ first: Any?, _ second: Any?, listLimit: Int) -> Any {
+    static func combine(_ first: Any?, _ second: Any?, options: DecodeOptions) throws -> Any {
         if let dict = first as? [AnyHashable: Any], isOverflow(dict) {
+            if options.throwOnLimitExceeded {
+                throw DecodeError.listLimitExceeded(limit: options.listLimit)
+            }
             return appendOverflow(dict, value: second)
         }
 
@@ -39,11 +42,17 @@ extension Utils {
         appendCombineValue(first, into: &result)
         appendCombineValue(second, into: &result)
 
-        guard listLimit >= 0, result.count > listLimit else {
-            return result
-        }
+        return try enforceListLimit(result, options: options)
+    }
 
-        return arrayToOverflowObject(result)
+    /// Keeps an in-limit list, throws in strict mode, or converts every value to an overflow map.
+    @usableFromInline
+    static func enforceListLimit<Element>(_ values: [Element], options: DecodeOptions) throws -> Any {
+        guard values.count > options.listLimit else { return values }
+        if options.throwOnLimitExceeded {
+            throw DecodeError.listLimitExceeded(limit: options.listLimit)
+        }
+        return arrayToOverflowObject(values.map { $0 as Any? })
     }
 
     private static func appendCombineValue(_ value: Any?, into array: inout [Any?]) {
@@ -74,24 +83,8 @@ extension Utils {
     ) -> [AnyHashable: Any] {
         var copy = dict
         var maxIndex = overflowMaxIndex(copy) ?? -1
-
-        func appendElement(_ element: Any?) {
-            maxIndex += 1
-            copy[maxIndex] = element ?? NSNull()
-        }
-
-        if let arrOpt = value as? [Any?] {
-            for element in arrOpt {
-                appendElement(element)
-            }
-        } else if let arr = value as? [Any] {
-            for element in arr {
-                appendElement(element)
-            }
-        } else {
-            appendElement(value)
-        }
-
+        maxIndex += 1
+        copy[maxIndex] = value ?? NSNull()
         setOverflowMaxIndex(&copy, maxIndex)
         return copy
     }

--- a/Sources/QsSwift/Internal/Utils+Combine.swift
+++ b/Sources/QsSwift/Internal/Utils+Combine.swift
@@ -71,7 +71,7 @@ extension Utils {
     private static func arrayToOverflowObject(_ array: [Any?]) -> [AnyHashable: Any] {
         var dict: [AnyHashable: Any] = [:]
         dict.reserveCapacity(array.count + 1)
-        for (index, value) in array.enumerated() {
+        for (index, value) in array.enumerated() where !(value is Undefined) {
             dict[index] = value ?? NSNull()
         }
         return markOverflow(dict, maxIndex: array.count - 1)

--- a/Sources/QsSwift/Internal/Utils+Combine.swift
+++ b/Sources/QsSwift/Internal/Utils+Combine.swift
@@ -35,7 +35,7 @@ extension Utils {
             if options.throwOnLimitExceeded {
                 throw DecodeError.listLimitExceeded(limit: options.listLimit)
             }
-            return appendOverflow(dict, value: second)
+            return try appendOverflow(dict, value: second, options: options)
         }
 
         var result: [Any?] = []
@@ -79,11 +79,19 @@ extension Utils {
 
     private static func appendOverflow(
         _ dict: [AnyHashable: Any],
-        value: Any?
-    ) -> [AnyHashable: Any] {
+        value: Any?,
+        options: DecodeOptions
+    ) throws -> Any {
         var copy = dict
         var maxIndex = overflowMaxIndex(copy) ?? -1
-        maxIndex += 1
+        guard let nextIndex = nextOverflowIndex(after: maxIndex) else {
+            let values: [Any?] = [
+                removingOverflowMetadata(from: copy),
+                value ?? NSNull(),
+            ]
+            return try enforceListLimit(values, options: options)
+        }
+        maxIndex = nextIndex
         copy[maxIndex] = value ?? NSNull()
         setOverflowMaxIndex(&copy, maxIndex)
         return copy

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -21,6 +21,7 @@ extension QsSwift.Utils {
         options: DecodeOptions = DecodeOptions()
     ) throws -> Any? {
         guard let source = source else { return target }
+        if isFalsyMergeSource(source) { return target }
 
         if let tArr = target as? [Any?], let sDict = source as? [AnyHashable: Any] {
             var tDict: [AnyHashable: Any] = [:]
@@ -84,72 +85,57 @@ extension QsSwift.Utils {
             }
 
             if let targetArray = target as? [Any] {
-                if targetArray.contains(where: { $0 is Undefined }) {
+                if let seq = asSequence(source) {
                     var mutableTarget: [Int: Any?] = [:]
 
                     for (index, value) in targetArray.enumerated() {
                         mutableTarget[index] = value
                     }
 
-                    if let seq = asSequence(source) {
-                        for (index, item) in seq.enumerated() where !(item is Undefined) {
+                    var logicalLength = targetArray.count
+                    for (index, item) in seq.enumerated() where !(item is Undefined) {
+                        if let existing = mutableTarget[index], !(existing is Undefined) {
+                            let existingIsContainer =
+                                existing is [Any] || existing is [AnyHashable: Any]
+                            let itemIsContainer =
+                                item is [Any] || item is [AnyHashable: Any]
+                            if existingIsContainer, itemIsContainer {
+                                mutableTarget[index] = try mergeValues(
+                                    target: existing,
+                                    source: item,
+                                    options: options
+                                )
+                            } else {
+                                mutableTarget[logicalLength] = item
+                                logicalLength += 1
+                            }
+                        } else {
                             mutableTarget[index] = item
+                            if index >= logicalLength {
+                                logicalLength = index + 1
+                            }
                         }
-                    } else {
-                        mutableTarget[mutableTarget.count] = source
                     }
 
+                    let merged = (0..<logicalLength).map {
+                        mutableTarget[$0] ?? Undefined.instance
+                    }
                     if !options.parseLists
-                        && mutableTarget.values.contains(where: { $0 is Undefined })
+                        && merged.contains(where: { $0 is Undefined })
                     {
                         // Preserve original element order by iterating indices in ascending order.
                         // Drop both `nil` and `Undefined` entries to match prior semantics.
-                        let orderedIndices = mutableTarget.keys.sorted()
-                        let pruned: [Any] = orderedIndices.compactMap { idx in
-                            guard let value = mutableTarget[idx] else { return nil }
+                        let pruned: [Any] = merged.compactMap { value in
+                            guard let value else { return nil }
                             return (value is Undefined) ? nil : value
                         }
                         return try enforceListLimit(pruned, options: options)
                     }
 
-                    // We’re in the Array-target branch. `target` cannot be a Set/OrderedSet here.
-                    let merged = mutableTarget.sorted { $0.key < $1.key }.map(\.value)
                     return try enforceListLimit(merged, options: options)
                 } else {
-                    if let seq = asSequence(source) {
-                        let targetMaps = targetArray.allSatisfy {
-                            $0 is [AnyHashable: Any] || $0 is Undefined
-                        }
-                        let sourceMaps = seq.allSatisfy {
-                            $0 is [AnyHashable: Any] || $0 is Undefined
-                        }
-
-                        if targetMaps && sourceMaps {
-                            var mutableTarget: [Int: Any?] = [:]
-
-                            for (index, value) in targetArray.enumerated() {
-                                mutableTarget[index] = value
-                            }
-
-                            for (index, item) in seq.enumerated() {
-                                if let existing = mutableTarget[index] {
-                                    mutableTarget[index] = try mergeValues(
-                                        target: existing, source: item, options: options)
-                                } else {
-                                    mutableTarget[index] = item
-                                }
-                            }
-
-                            let merged = mutableTarget.sorted { $0.key < $1.key }.map(\.value)
-                            return try enforceListLimit(merged, options: options)
-                        } else {
-                            let filtered = seq.filter { !($0 is Undefined) }
-                            return try enforceListLimit(targetArray + filtered, options: options)
-                        }
-                    } else {
-                        // source is not a sequence and we are in the Array-target branch; target cannot be any Set/OrderedSet here.
-                        return try enforceListLimit(targetArray + [source], options: options)
-                    }
+                    // Source is not a sequence and target cannot be a Set/OrderedSet here.
+                    return try enforceListLimit(targetArray + [source], options: options)
                 }
             } else if let targetDict = target as? [AnyHashable: Any] {
                 if Utils.isOverflow(targetDict) {

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -190,10 +190,12 @@ extension QsSwift.Utils {
                 return mutableTarget
             } else {
                 if let seq = asSequence(source) {
-                    let filtered = seq.filter { !($0 is Undefined) }
                     var result: [Any?] = [target]  // preserve nil at index 0
-                    result.append(contentsOf: filtered)
-                    return try enforceListLimit(result, options: options)
+                    result.append(contentsOf: seq)
+                    if result.count > options.listLimit {
+                        return try enforceListLimit(result, options: options)
+                    }
+                    return result.filter { !($0 is Undefined) }
                 }
                 // qs returns the scalar pair directly here. Limit enforcement
                 // applies to array/primitive directions, while scalar collisions

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -194,7 +194,7 @@ extension QsSwift.Utils {
                     if result.count > options.listLimit {
                         return try enforceListLimit(result, options: options)
                     }
-                    return result.filter { !($0 is Undefined) }
+                    return result
                 }
                 // qs returns the scalar pair directly here. Limit enforcement
                 // applies to array/primitive directions, while scalar collisions
@@ -409,9 +409,10 @@ extension QsSwift.Utils {
 
             if frame.index < frame.sourceItems.count {
                 let (key, value) = frame.sourceItems[frame.index]
+                let targetKey = matchingDictionaryKey(for: key, in: frame.target)
                 frame.index += 1
 
-                if let existingValue = frame.target[key] {
+                if let existingValue = frame.target[targetKey] {
                     if let existingDict = existingValue as? [AnyHashable: Any],
                         let valueDict = value as? [AnyHashable: Any]
                     {
@@ -420,23 +421,23 @@ extension QsSwift.Utils {
                         {
                             throw DecodeError.listLimitExceeded(limit: options.listLimit)
                         }
-                        frame.pendingKey = key
+                        frame.pendingKey = targetKey
                         stack.append(frame)
                         stack.append(
                             makeDictionaryMergeFrame(target: existingDict, source: valueDict)
                         )
                         continue
                     }
-                    frame.target[key] = try mergeValues(
+                    frame.target[targetKey] = try mergeValues(
                         target: existingValue,
                         source: value,
                         options: options
                     )
                 } else {
-                    frame.target[key] = value
+                    frame.target[targetKey] = value
                 }
 
-                if let idx = Utils.intIndex(key), let current = frame.overflowMax, idx > current {
+                if let idx = Utils.intIndex(targetKey), let current = frame.overflowMax, idx > current {
                     frame.overflowMax = idx
                 }
 
@@ -456,5 +457,27 @@ extension QsSwift.Utils {
         }
 
         return completed ?? target
+    }
+
+    /// JavaScript object keys do not distinguish an integer index from its canonical string form.
+    private static func matchingDictionaryKey(
+        for key: AnyHashable,
+        in target: [AnyHashable: Any]
+    ) -> AnyHashable {
+        if target[key] != nil { return key }
+
+        if let index = Utils.intIndex(key) {
+            let stringKey = AnyHashable(String(index))
+            if target[stringKey] != nil { return stringKey }
+        } else if let stringKey = key.base as? String,
+            let index = Int(stringKey),
+            index >= 0,
+            String(index) == stringKey
+        {
+            let integerKey = AnyHashable(index)
+            if target[integerKey] != nil { return integerKey }
+        }
+
+        return key
     }
 }

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -13,51 +13,39 @@ extension QsSwift.Utils {
     ///   - source: The source object to merge from.
     ///   - options: Optional decode options for merging behavior.
     /// - Returns: The merged object.
+    /// - Throws: `DecodeError.listLimitExceeded` when strict limit enforcement rejects growth.
     @usableFromInline
-    static func merge(target: Any?, source: Any?, options: DecodeOptions = DecodeOptions()) -> Any? {
+    static func merge(
+        target: Any?,
+        source: Any?,
+        options: DecodeOptions = DecodeOptions()
+    ) throws -> Any? {
         guard let source = source else { return target }
 
         if let tArr = target as? [Any?], let sDict = source as? [AnyHashable: Any] {
             var tDict: [AnyHashable: Any] = [:]
-            var maxIndex = -1
 
             for (idx, element) in tArr.enumerated() where !(element is Undefined) {
                 tDict[idx] = element ?? NSNull()
-                if idx > maxIndex { maxIndex = idx }
             }
 
-            for (key, value) in sDict where !Utils.isOverflowKey(key) {
-                tDict[key] = value
-                if let idx = Utils.intIndex(key), idx > maxIndex {
-                    maxIndex = idx
-                }
-            }
-
-            if Utils.isOverflow(sDict) {
-                if let sourceMax = Utils.overflowMaxIndex(sDict), sourceMax > maxIndex {
-                    maxIndex = sourceMax
-                }
-                Utils.setOverflowMaxIndex(&tDict, maxIndex)
-            }
-            return tDict
+            return try mergeDictionariesIterative(
+                target: tDict,
+                source: sDict,
+                options: options
+            )
         }
 
         if let tDict = target as? [AnyHashable: Any], let sArr = source as? [Any?] {
-            if Utils.isOverflow(tDict) {
-                var overflow = tDict
-                var maxIndex = Utils.overflowMaxIndex(overflow) ?? -1
-                for element in sArr where !(element is Undefined) {
-                    maxIndex += 1
-                    overflow[maxIndex] = element ?? NSNull()
-                }
-                Utils.setOverflowMaxIndex(&overflow, maxIndex)
-                return overflow
-            }
             var sDict: [AnyHashable: Any] = [:]
             for (idx, element) in sArr.enumerated() where !(element is Undefined) {
                 sDict[idx] = element ?? NSNull()
             }
-            return merge(target: tDict, source: sDict, options: options)
+            return try mergeDictionariesIterative(
+                target: tDict,
+                source: sDict,
+                options: options
+            )
         }
 
         if !(source is [AnyHashable: Any]) {
@@ -121,11 +109,12 @@ extension QsSwift.Utils {
                             guard let value = mutableTarget[idx] else { return nil }
                             return (value is Undefined) ? nil : value
                         }
-                        return pruned
+                        return try enforceListLimit(pruned, options: options)
                     }
 
                     // We’re in the Array-target branch. `target` cannot be a Set/OrderedSet here.
-                    return mutableTarget.sorted { $0.key < $1.key }.map(\.value)
+                    let merged = mutableTarget.sorted { $0.key < $1.key }.map(\.value)
+                    return try enforceListLimit(merged, options: options)
                 } else {
                     if let seq = asSequence(source) {
                         let targetMaps = targetArray.allSatisfy {
@@ -144,25 +133,29 @@ extension QsSwift.Utils {
 
                             for (index, item) in seq.enumerated() {
                                 if let existing = mutableTarget[index] {
-                                    mutableTarget[index] = mergeValues(
+                                    mutableTarget[index] = try mergeValues(
                                         target: existing, source: item, options: options)
                                 } else {
                                     mutableTarget[index] = item
                                 }
                             }
 
-                            return mutableTarget.sorted { $0.key < $1.key }.map(\.value)
+                            let merged = mutableTarget.sorted { $0.key < $1.key }.map(\.value)
+                            return try enforceListLimit(merged, options: options)
                         } else {
                             let filtered = seq.filter { !($0 is Undefined) }
-                            return targetArray + filtered
+                            return try enforceListLimit(targetArray + filtered, options: options)
                         }
                     } else {
                         // source is not a sequence and we are in the Array-target branch; target cannot be any Set/OrderedSet here.
-                        return targetArray + [source]
+                        return try enforceListLimit(targetArray + [source], options: options)
                     }
                 }
             } else if let targetDict = target as? [AnyHashable: Any] {
                 if Utils.isOverflow(targetDict) {
+                    if options.throwOnLimitExceeded {
+                        throw DecodeError.listLimitExceeded(limit: options.listLimit)
+                    }
                     var overflow = targetDict
                     var maxIndex = Utils.overflowMaxIndex(overflow) ?? -1
 
@@ -200,14 +193,20 @@ extension QsSwift.Utils {
                     let filtered = seq.filter { !($0 is Undefined) }
                     var result: [Any?] = [target]  // preserve nil at index 0
                     result.append(contentsOf: filtered)
-                    return result
+                    return try enforceListLimit(result, options: options)
                 }
+                // qs returns the scalar pair directly here. Limit enforcement
+                // applies to array/primitive directions, while scalar collisions
+                // inside an overflow map remain a nested two-element value.
                 return [target as Any?, source as Any?]
             }
         }
 
         if target == nil || !(target is [AnyHashable: Any]) {
             if let sourceDict = source as? [AnyHashable: Any], Utils.isOverflow(sourceDict) {
+                if options.throwOnLimitExceeded {
+                    throw DecodeError.listLimitExceeded(limit: options.listLimit)
+                }
                 if let targetArray = target as? [Any] {
                     var mutableTarget: [AnyHashable: Any] = [:]
                     var maxIndex = -1
@@ -268,7 +267,7 @@ extension QsSwift.Utils {
                     mutableTarget.append(source)
                 }
 
-                return mutableTarget
+                return try enforceListLimit(mutableTarget, options: options)
             }
         }
 
@@ -290,7 +289,11 @@ extension QsSwift.Utils {
         }
 
         if let sourceDict = source as? [AnyHashable: Any] {
-            return mergeDictionariesIterative(target: mergeTarget, source: sourceDict, options: options)
+            return try mergeDictionariesIterative(
+                target: mergeTarget,
+                source: sourceDict,
+                options: options
+            )
         }
 
         return mergeTarget
@@ -316,11 +319,19 @@ extension QsSwift.Utils {
     }
 
     @inline(__always)
-    private static func mergeValues(target: Any?, source: Any?, options: DecodeOptions) -> Any? {
+    private static func mergeValues(
+        target: Any?,
+        source: Any?,
+        options: DecodeOptions
+    ) throws -> Any? {
         if let targetDict = target as? [AnyHashable: Any], let sourceDict = source as? [AnyHashable: Any] {
-            return mergeDictionariesIterative(target: targetDict, source: sourceDict, options: options)
+            return try mergeDictionariesIterative(
+                target: targetDict,
+                source: sourceDict,
+                options: options
+            )
         }
-        return merge(target: target, source: source, options: options)
+        return try merge(target: target, source: source, options: options)
     }
 
     private struct DictionaryMergeFrame {
@@ -363,7 +374,13 @@ extension QsSwift.Utils {
         target: [AnyHashable: Any],
         source: [AnyHashable: Any],
         options: DecodeOptions
-    ) -> [AnyHashable: Any] {
+    ) throws -> [AnyHashable: Any] {
+        if options.throwOnLimitExceeded,
+            Utils.isOverflow(target) || Utils.isOverflow(source)
+        {
+            throw DecodeError.listLimitExceeded(limit: options.listLimit)
+        }
+
         var stack: [DictionaryMergeFrame] = [makeDictionaryMergeFrame(target: target, source: source)]
         var completed: [AnyHashable: Any]?
 
@@ -382,6 +399,11 @@ extension QsSwift.Utils {
                     if let existingDict = existingValue as? [AnyHashable: Any],
                         let valueDict = value as? [AnyHashable: Any]
                     {
+                        if options.throwOnLimitExceeded,
+                            Utils.isOverflow(existingDict) || Utils.isOverflow(valueDict)
+                        {
+                            throw DecodeError.listLimitExceeded(limit: options.listLimit)
+                        }
                         frame.pendingKey = key
                         stack.append(frame)
                         stack.append(
@@ -389,7 +411,11 @@ extension QsSwift.Utils {
                         )
                         continue
                     }
-                    frame.target[key] = mergeValues(target: existingValue, source: value, options: options)
+                    frame.target[key] = try mergeValues(
+                        target: existingValue,
+                        source: value,
+                        options: options
+                    )
                 } else {
                     frame.target[key] = value
                 }

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -247,9 +247,11 @@ extension QsSwift.Utils {
                     }
                 }
 
-                guard let newMax = Utils.nextOverflowIndex(
-                    after: Utils.overflowMaxIndex(sourceDict) ?? -1
-                ) else {
+                guard
+                    let newMax = Utils.nextOverflowIndex(
+                        after: Utils.overflowMaxIndex(sourceDict) ?? -1
+                    )
+                else {
                     return try merge(
                         target: target,
                         source: Utils.removingOverflowMetadata(from: sourceDict),

--- a/Sources/QsSwift/Internal/Utils+Merge.swift
+++ b/Sources/QsSwift/Internal/Utils+Merge.swift
@@ -160,12 +160,25 @@ extension QsSwift.Utils {
                     var maxIndex = Utils.overflowMaxIndex(overflow) ?? -1
 
                     if let seq = asSequence(source) {
-                        for item in seq where !(item is Undefined) {
-                            maxIndex += 1
+                        let items = seq.filter { !($0 is Undefined) }
+                        for (offset, item) in items.enumerated() {
+                            guard let nextIndex = Utils.nextOverflowIndex(after: maxIndex) else {
+                                var values: [Any?] = [Utils.removingOverflowMetadata(from: overflow)]
+                                values.append(contentsOf: items[offset...].map { $0 as Any? })
+                                return try enforceListLimit(values, options: options)
+                            }
+                            maxIndex = nextIndex
                             overflow[maxIndex] = item
                         }
                     } else if !(source is Undefined) {
-                        maxIndex += 1
+                        guard let nextIndex = Utils.nextOverflowIndex(after: maxIndex) else {
+                            let values: [Any?] = [
+                                Utils.removingOverflowMetadata(from: overflow),
+                                source,
+                            ]
+                            return try enforceListLimit(values, options: options)
+                        }
+                        maxIndex = nextIndex
                         overflow[maxIndex] = source
                     }
 
@@ -235,13 +248,28 @@ extension QsSwift.Utils {
 
                 for (key, value) in sourceDict where !Utils.isOverflowKey(key) {
                     if let idx = Utils.intIndex(key) {
-                        result[idx + 1] = value
+                        guard let shiftedIndex = Utils.nextOverflowIndex(after: idx) else {
+                            return try merge(
+                                target: target,
+                                source: Utils.removingOverflowMetadata(from: sourceDict),
+                                options: options
+                            )
+                        }
+                        result[shiftedIndex] = value
                     } else {
                         result[key] = value
                     }
                 }
 
-                let newMax = (Utils.overflowMaxIndex(sourceDict) ?? -1) + 1
+                guard let newMax = Utils.nextOverflowIndex(
+                    after: Utils.overflowMaxIndex(sourceDict) ?? -1
+                ) else {
+                    return try merge(
+                        target: target,
+                        source: Utils.removingOverflowMetadata(from: sourceDict),
+                        options: options
+                    )
+                }
                 return Utils.markOverflow(result, maxIndex: newMax)
             }
 

--- a/Sources/QsSwift/Internal/Utils+Overflow.swift
+++ b/Sources/QsSwift/Internal/Utils+Overflow.swift
@@ -45,6 +45,22 @@ extension Utils {
         key.base is OverflowKey
     }
 
+    @inline(__always)
+    @usableFromInline
+    internal static func nextOverflowIndex(after index: Int) -> Int? {
+        let (next, overflowed) = index.addingReportingOverflow(1)
+        return overflowed ? nil : next
+    }
+
+    @usableFromInline
+    internal static func removingOverflowMetadata(
+        from dict: [AnyHashable: Any]
+    ) -> [AnyHashable: Any] {
+        var copy = dict
+        copy.removeValue(forKey: overflowKey)
+        return copy
+    }
+
     @usableFromInline
     /// Scans non-overflow keys to compute the maximum integer index and stores it.
     /// Sets -1 if no integer keys are present.

--- a/Sources/QsSwift/Internal/Utils+Overflow.swift
+++ b/Sources/QsSwift/Internal/Utils+Overflow.swift
@@ -6,6 +6,9 @@ extension Utils {
     @usableFromInline
     internal static let overflowKey = OverflowKey()
 
+    @usableFromInline
+    internal static let maximumSafeJavaScriptInteger = 9_007_199_254_740_991
+
     @inline(__always)
     @usableFromInline
     internal static func intIndex(_ key: AnyHashable) -> Int? {
@@ -48,8 +51,31 @@ extension Utils {
     @inline(__always)
     @usableFromInline
     internal static func nextOverflowIndex(after index: Int) -> Int? {
-        let (next, overflowed) = index.addingReportingOverflow(1)
-        return overflowed ? nil : next
+        if index <= maximumSafeJavaScriptInteger { return index + 1 }
+        // qs advances overflow keys with JavaScript Number arithmetic, including
+        // its rounding behavior above Number.MAX_SAFE_INTEGER.
+        let next = Double(index) + 1
+        return next.isFinite ? Int(javascriptIntegerDescription(next)) : nil
+    }
+
+    /// Expands Swift's shortest `Double` description to JavaScript's fixed integer form.
+    @usableFromInline
+    internal static func javascriptIntegerDescription(_ value: Double) -> String {
+        let description = String(value)
+        guard let exponentIndex = description.firstIndex(where: { $0 == "e" || $0 == "E" }) else {
+            return description.hasSuffix(".0") ? String(description.dropLast(2)) : description
+        }
+
+        let mantissa = description[..<exponentIndex]
+        let exponentStart = description.index(after: exponentIndex)
+        guard let exponent = Int(description[exponentStart...]) else { return description }
+
+        let components = mantissa.split(separator: ".", omittingEmptySubsequences: false)
+        guard let whole = components.first else { return description }
+        let fraction = components.count == 2 ? components[1] : Substring()
+        let zeroCount = exponent - fraction.count
+        guard zeroCount >= 0 else { return description }
+        return String(whole) + String(fraction) + String(repeating: "0", count: zeroCount)
     }
 
     @usableFromInline

--- a/Sources/QsSwift/Models/DecodeOptions.swift
+++ b/Sources/QsSwift/Models/DecodeOptions.swift
@@ -98,8 +98,9 @@ public struct DecodeOptions: @unchecked Sendable {
     /// The limit is cumulative across duplicate keys, flat comma-separated values, and
     /// list merges. A result with exactly `listLimit` elements remains a list; growing
     /// past it becomes a numeric-keyed dictionary, or throws when
-    /// `throwOnLimitExceeded` is `true`. A negative limit makes every non-empty list
-    /// overflow or throw immediately.
+    /// `throwOnLimitExceeded` is `true`. A negative limit treats every list construction
+    /// or merge that reaches limit enforcement as exceeded. Parser-recognized empty lists
+    /// can still be preserved by `allowEmptyLists` because they bypass list construction.
     ///
     /// Comma values written with `[]=` are nested groups: each complete comma group counts
     /// as one outer list element, regardless of how many values the group contains.

--- a/Sources/QsSwift/Models/DecodeOptions.swift
+++ b/Sources/QsSwift/Models/DecodeOptions.swift
@@ -93,9 +93,17 @@ public struct DecodeOptions: @unchecked Sendable {
     /// When compacted, holes may be removed unless `allowSparseLists` is true.
     public let allowSparseLists: Bool
 
-    /// Maximum number of elements that will be materialized as a list before falling back
-    /// to a dictionary. For example, with the default `20`, `a[20]=x` decodes as
-    /// `["a": ["20": "x"]]` instead of allocating a 21-element list.
+    /// Maximum list size and numeric-index threshold used while decoding.
+    ///
+    /// The limit is cumulative across duplicate keys, flat comma-separated values, and
+    /// list merges. A result with exactly `listLimit` elements remains a list; growing
+    /// past it becomes a numeric-keyed dictionary, or throws when
+    /// `throwOnLimitExceeded` is `true`. A negative limit makes every non-empty list
+    /// overflow or throw immediately.
+    ///
+    /// Comma values written with `[]=` are nested groups: each complete comma group counts
+    /// as one outer list element, regardless of how many values the group contains.
+    /// Numeric bracket indices above the limit are represented as dictionary keys.
     public let listLimit: Int
 
     /// Character encoding to use (`.utf8` or `.isoLatin1`). May be overridden by the charset sentinel.
@@ -132,7 +140,8 @@ public struct DecodeOptions: @unchecked Sendable {
     /// Interpret HTML numeric entities (`&#...;`) when `charset == .isoLatin1`.
     public let interpretNumericEntities: Bool
 
-    /// Disable list parsing entirely. Useful for strict “map only” modes.
+    /// Enable bracket-list parsing. Set to `false` for strict “map only” modes.
+    /// This is the only option that disables bracket-list parsing; parameter count does not.
     public let parseLists: Bool
 
     /// If `true`, exceeding `depth` throws instead of collapsing the remainder.
@@ -145,7 +154,8 @@ public struct DecodeOptions: @unchecked Sendable {
     /// If `true`, values without `=` decode to `nil` (vs `""` by default).
     public let strictNullHandling: Bool
 
-    /// If `true`, exceeding `parameterLimit` throws; otherwise parsing truncates silently.
+    /// If `true`, exceeding `parameterLimit` or `listLimit` throws. Otherwise parameter
+    /// parsing truncates and list overflow falls back to a numeric-keyed dictionary.
     public let throwOnLimitExceeded: Bool
 
     // MARK: - Computed Properties

--- a/Sources/QsSwift/Models/DecodeOptions.swift
+++ b/Sources/QsSwift/Models/DecodeOptions.swift
@@ -103,7 +103,7 @@ public struct DecodeOptions: @unchecked Sendable {
     ///
     /// Comma values written with `[]=` are nested groups: each complete comma group counts
     /// as one outer list element, regardless of how many values the group contains.
-    /// Numeric bracket indices above the limit are represented as dictionary keys.
+    /// Numeric bracket indices at or above the limit are represented as dictionary keys.
     public let listLimit: Int
 
     /// Character encoding to use (`.utf8` or `.isoLatin1`). May be overridden by the charset sentinel.

--- a/Sources/QsSwift/Qs+Decode.swift
+++ b/Sources/QsSwift/Qs+Decode.swift
@@ -214,11 +214,7 @@ extension Qs {
             }
         }()
 
-        // If there are too many top-level params, match Kotlin: disable list parsing
-        var finalOptions = options
-        if options.parseLists, options.listLimit > 0, tmp.count > options.listLimit {
-            finalOptions = options.copy(parseLists: false)
-        }
+        let finalOptions = options
 
         let decodeFromString = (input is String)
         let structuredScan: StructuredKeyScan = {
@@ -260,7 +256,7 @@ extension Qs {
                 {
                     if let existing = obj[key] {
                         obj[key] =
-                            Utils.merge(target: existing, source: value, options: finalOptions)
+                            try Utils.merge(target: existing, source: value, options: finalOptions)
                             ?? existing
                     } else {
                         obj[key] = value
@@ -309,21 +305,33 @@ extension Qs {
                     for (index, element) in list.enumerated() where !(element is Undefined) {
                         indexed[String(index)] = element
                     }
-                    if let merged = Utils.merge(target: obj, source: indexed, options: finalOptions)
+                    if let merged = try Utils.merge(
+                        target: obj,
+                        source: indexed,
+                        options: finalOptions
+                    )
                         as? [String: Any]
                     {
                         obj = merged
                     }
                 } else if let overflow = parsed as? [AnyHashable: Any], Utils.isOverflow(overflow) {
                     let indexed = objectifyOverflow(overflow)
-                    if let merged = Utils.merge(target: obj, source: indexed, options: finalOptions)
+                    if let merged = try Utils.merge(
+                        target: obj,
+                        source: indexed,
+                        options: finalOptions
+                    )
                         as? [String: Any]
                     {
                         obj = merged
                     }
                 } else if let parsed = parsed {
                     // Non-array, non-nil fragment → merge as-is
-                    if let merged = Utils.merge(target: obj, source: parsed, options: finalOptions)
+                    if let merged = try Utils.merge(
+                        target: obj,
+                        source: parsed,
+                        options: finalOptions
+                    )
                         as? [String: Any]
                     {
                         obj = merged

--- a/Tests/QsObjCTests/ObjCDecodeTests.swift
+++ b/Tests/QsObjCTests/ObjCDecodeTests.swift
@@ -250,9 +250,9 @@
             #expect(a?["1"] as? String == "X:c")
         }
 
-        @Test("objc-decode: comma overflow + iso entities preserves indexed map")
-        func commaLimitNonThrowFallbackIsoEntitiesPreserveMap() throws {
-            let r = decode("a=1,%26%239786%3B") { o in
+        @Test("objc-decode: iso entities precede soft comma overflow")
+        func commaLimitNonThrowFallbackIsoEntitiesCollapseFirst() throws {
+            let r = decode("a=x&a=%26%239786%3B,%26%239787%3B") { o in
                 o.comma = true
                 o.listLimit = 1
                 o.throwOnLimitExceeded = false
@@ -260,8 +260,8 @@
                 o.interpretNumericEntities = true
             }
             let a = r["a"] as? NSDictionary
-            #expect(a?["0"] as? String == "1")
-            #expect(a?["1"] as? String == "☺")
+            #expect(a?["0"] as? String == "x")
+            #expect(a?["1"] as? String == "☺,☻")
         }
 
         // MARK: - Dot / decodeDotInKeys combinations (subset)

--- a/Tests/QsObjCTests/ObjCDecodeTests.swift
+++ b/Tests/QsObjCTests/ObjCDecodeTests.swift
@@ -184,6 +184,44 @@
             #expect(a?["1"] as? String == "c")
         }
 
+        @Test("objc-decode: cumulative duplicate growth throws at listLimit")
+        func cumulativeListLimitThrow() throws {
+            let error = try #require(
+                decodeExpectingError("a=1,2&a=3,4") { o in
+                    o.comma = true
+                    o.listLimit = 3
+                    o.throwOnLimitExceeded = true
+                }
+            )
+            #expect(DecodeErrorObjC.kind(from: error) == .listLimitExceeded)
+            #expect(DecodeErrorObjC.limit(from: error) == 3)
+        }
+
+        @Test("objc-decode: cumulative duplicate growth becomes an indexed map")
+        func cumulativeListLimitSoftOverflow() throws {
+            let decoded = decode("a=1,2&a=3,4") { o in
+                o.comma = true
+                o.listLimit = 3
+            }
+            let overflow = decoded["a"] as? NSDictionary
+            #expect(overflow?["0"] as? String == "1")
+            #expect(overflow?["1"] as? String == "2")
+            #expect(overflow?["2"] as? String == "3")
+            #expect(overflow?["3"] as? String == "4")
+        }
+
+        @Test("objc-decode: bracketed comma group counts as one outer element")
+        func bracketedCommaGroupCountsAsOneOuterElement() throws {
+            let decoded = decode("a[]=1,2,3,4") { o in
+                o.comma = true
+                o.listLimit = 1
+                o.throwOnLimitExceeded = true
+            }
+            let outer = decoded["a"] as? [Any]
+            #expect(outer?.count == 1)
+            #expect(outer?.first as? [String] == ["1", "2", "3", "4"])
+        }
+
         @Test("objc-decode: comma non-throw fallback percent-decodes split elements")
         func commaLimitNonThrowFallbackDecodesElements() throws {
             let r = decode("a=b%20c,d%20e") { o in

--- a/Tests/QsSwiftTests/DecodeFastPathTests.swift
+++ b/Tests/QsSwiftTests/DecodeFastPathTests.swift
@@ -167,14 +167,18 @@ struct DecodeFastPathTests {
         }
     }
 
-    @Test("top-level list-limit gate still counts empty-key pairs")
-    func listLimit_gateCountsEmptyKeyPairs() throws {
+    @Test("parameter count no longer disables list parsing when it exceeds listLimit")
+    func parameterCountDoesNotDisableListParsing() throws {
         let decoded = try Qs.decode("=&a[]=b&a[]=c", options: .init(listLimit: 1))
         let forcedNoLists = try Qs.decode(
             "=&a[]=b&a[]=c",
             options: .init(listLimit: 1, parseLists: false)
         )
-        #expect(NSDictionary(dictionary: decoded).isEqual(to: forcedNoLists))
+
+        let overflow = decoded["a"] as? [String: Any]
+        #expect(overflow?["0"] as? String == "b")
+        #expect(overflow?["1"] as? String == "c")
+        #expect(!NSDictionary(dictionary: decoded).isEqual(to: forcedNoLists))
         #expect(decoded[""] == nil)
     }
 

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -615,6 +615,22 @@ struct DecodeTests {
         }
     }
 
+    @Test("maximum numeric bracket index remains a dictionary key without trapping")
+    func maximumNumericBracketIndexDoesNotTrap() throws {
+        let query = "a[\(Int.max)]=x&a=y"
+
+        for shouldThrow in [false, true] {
+            let decoded = try Qs.decode(
+                query,
+                options: DecodeOptions(throwOnLimitExceeded: shouldThrow)
+            )
+            let values = try #require(decoded["a"] as? [Any])
+            let indexed = try #require(values.first as? [String: Any])
+            #expect(indexed[String(Int.max)] as? String == "x")
+            #expect(values[1] as? String == "y")
+        }
+    }
+
     @Test("qs 6.15.3: overflow values merge with bracket assignments by index")
     func qs6153_overflowValuesMergeWithBracketAssignments() throws {
         let cases: [(String, [String: Any])] = [

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -615,19 +615,39 @@ struct DecodeTests {
         }
     }
 
-    @Test("maximum numeric bracket index remains a dictionary key without trapping")
-    func maximumNumericBracketIndexDoesNotTrap() throws {
-        let query = "a[\(Int.max)]=x&a=y"
+    @Test("numeric bracket indices follow qs JavaScript number round trips")
+    func numericBracketIndicesFollowJavaScriptNumberRoundTrips() throws {
+        for index in ["9007199254740993", String(Int.max - 1), String(Int.max)] {
+            let query = "a[\(index)]=x&a=y"
+            for shouldThrow in [false, true] {
+                let decoded = try Qs.decode(
+                    query,
+                    options: DecodeOptions(throwOnLimitExceeded: shouldThrow)
+                )
+                let values = try #require(decoded["a"] as? [Any])
+                let indexed = try #require(values.first as? [String: Any])
+                #expect(indexed[index] as? String == "x")
+                #expect(values[1] as? String == "y")
+            }
+        }
 
-        for shouldThrow in [false, true] {
-            let decoded = try Qs.decode(
-                query,
-                options: DecodeOptions(throwOnLimitExceeded: shouldThrow)
-            )
-            let values = try #require(decoded["a"] as? [Any])
-            let indexed = try #require(values.first as? [String: Any])
-            #expect(indexed[String(Int.max)] as? String == "x")
-            #expect(values[1] as? String == "y")
+        let roundedAppend = try Qs.decode("a[9007199254740994]=x&a=y")
+        let roundedMap = try #require(asDictString(roundedAppend["a"]))
+        #expect(roundedMap["9007199254740994"] as? String == "x")
+        #expect(roundedMap["9007199254740996"] as? String == "y")
+
+        let repeatedIndex = try Qs.decode("a[9007199254740992]=x&a=y")
+        let repeatedMap = try #require(asDictString(repeatedIndex["a"]))
+        #expect(repeatedMap.count == 1)
+        #expect(repeatedMap["9007199254740992"] as? String == "y")
+
+        for index in ["9007199254740992", "9007199254740994"] {
+            #expect(throws: DecodeError.listLimitExceeded(limit: 20)) {
+                _ = try Qs.decode(
+                    "a[\(index)]=x&a=y",
+                    options: DecodeOptions(throwOnLimitExceeded: true)
+                )
+            }
         }
     }
 

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -749,6 +749,59 @@ struct DecodeTests {
         #expect(overflow["3"] as? String == "y")
     }
 
+    @Test("qs 6.15.3: sparse positions survive until cumulative limit enforcement")
+    func qs6153_sparsePositionsSurviveUntilCumulativeLimitEnforcement() throws {
+        let query = "a=x&a[1]&a[]=y"
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+
+        let decoded = try Qs.decode(query, options: DecodeOptions(listLimit: 3))
+        let overflow = try #require(asDictString(decoded["a"]))
+        #expect(overflow["0"] as? String == "x")
+        #expect(overflow["1"] == nil)
+        #expect(overflow["2"] as? String == "")
+        #expect(overflow["3"] as? String == "y")
+    }
+
+    @Test("qs 6.15.3: numeric string and integer keys collide when lists are disabled")
+    func qs6153_numericPropertyKeysCollideWhenListsAreDisabled() throws {
+        let cases: [(query: String, nested: [String])] = [
+            ("a[0]=1,2,3&a=1,,3", ["1", "2", "3", "1"]),
+            ("a=1,,3&a[0]=1,2,3", ["1", "1", "2", "3"]),
+        ]
+
+        for item in cases {
+            #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+                _ = try Qs.decode(
+                    item.query,
+                    options: DecodeOptions(
+                        listLimit: 3,
+                        comma: true,
+                        parseLists: false,
+                        throwOnLimitExceeded: true
+                    )
+                )
+            }
+
+            let decoded = try Qs.decode(
+                item.query,
+                options: DecodeOptions(listLimit: 3, comma: true, parseLists: false)
+            )
+            let outer = try #require(asDictString(decoded["a"]))
+            let nested = try #require(asDictString(outer["0"]))
+            for (index, expected) in item.nested.enumerated() {
+                #expect(nested[String(index)] as? String == expected)
+            }
+            #expect(outer["1"] as? String == "")
+            #expect(outer["2"] as? String == "3")
+        }
+    }
+
     @Test("qs 6.15.3: falsy scalar merges do not grow lists")
     func qs6153_falsyScalarMergeDoesNotGrowList() throws {
         let decoded = try Qs.decode(

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -475,8 +475,8 @@ struct DecodeTests {
         #expect((a?["1"] as? String) == "X:c")
     }
 
-    @Test("comma overflow + iso entities preserves map shape")
-    func testComma_ListLimit_NonThrowingOverflowIsoEntitiesPreserveMap() throws {
+    @Test("comma + iso entities collapses before soft overflow")
+    func testComma_ListLimit_NonThrowingOverflowIsoEntitiesCollapseFirst() throws {
         let opts = DecodeOptions(
             listLimit: 1,
             charset: .isoLatin1,
@@ -485,9 +485,7 @@ struct DecodeTests {
             throwOnLimitExceeded: false
         )
         let r = try Qs.decode("a=1,%26%239786%3B", options: opts)
-        let a = asDictString(r["a"])
-        #expect((a?["0"] as? String) == "1")
-        #expect((a?["1"] as? String) == "☺")
+        #expect(r["a"] as? String == "1,☺")
     }
 
     // MARK: - GHSA-w7fw-mjwx-w883 parity (qs PR #545 / v6.14.2)
@@ -704,6 +702,76 @@ struct DecodeTests {
                 options: DecodeOptions(listLimit: 2, throwOnLimitExceeded: true)
             )
         }
+    }
+
+    @Test("qs 6.15.3: nested comma arrays merge before enforcing listLimit")
+    func qs6153_nestedCommaArraysMergeBeforeLimitEnforcement() throws {
+        let query = "a[0]=1,2&a[]=1,,3"
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 3, comma: true, throwOnLimitExceeded: true)
+            )
+        }
+
+        let decoded = try Qs.decode(
+            query,
+            options: DecodeOptions(listLimit: 3, comma: true)
+        )
+        let outer = try #require(decoded["a"] as? [Any])
+        let inner = try #require(asDictString(outer.first))
+        #expect(inner["0"] as? String == "1")
+        #expect(inner["1"] as? String == "2")
+        #expect(inner["2"] as? String == "1")
+        #expect(inner["3"] as? String == "")
+        #expect(inner["4"] as? String == "3")
+    }
+
+    @Test("qs 6.15.3: sparse array collisions append before enforcing listLimit")
+    func qs6153_sparseArrayCollisionsAppendBeforeLimitEnforcement() throws {
+        let query = "a[2]=1,2&a[]=1,2&a[0]=y"
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 3, comma: true, throwOnLimitExceeded: true)
+            )
+        }
+
+        let decoded = try Qs.decode(
+            query,
+            options: DecodeOptions(listLimit: 3, comma: true)
+        )
+        let overflow = try #require(asDictString(decoded["a"]))
+        #expect((overflow["0"] as? [String]) == ["1", "2"])
+        #expect((overflow["2"] as? [String]) == ["1", "2"])
+        #expect(overflow["3"] as? String == "y")
+    }
+
+    @Test("qs 6.15.3: falsy scalar merges do not grow lists")
+    func qs6153_falsyScalarMergeDoesNotGrowList() throws {
+        let decoded = try Qs.decode(
+            "a[0]=x&a=",
+            options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+        )
+        #expect(asStrings(decoded["a"]) == ["x"])
+    }
+
+    @Test("qs 6.15.3: numeric entities are interpreted before soft comma overflow")
+    func qs6153_numericEntitiesBeforeSoftCommaOverflow() throws {
+        let decoded = try Qs.decode(
+            "a=x&a=%26%239786%3B,%26%239787%3B",
+            options: DecodeOptions(
+                listLimit: 1,
+                charset: .isoLatin1,
+                comma: true,
+                interpretNumericEntities: true
+            )
+        )
+        let overflow = try #require(asDictString(decoded["a"]))
+        #expect(overflow["0"] as? String == "x")
+        #expect(overflow["1"] as? String == "☺,☻")
     }
 
     @Test("qs 6.15.3: bracketed comma groups count as outer elements")

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -333,55 +333,51 @@ struct DecodeTests {
                 "value",
                 options: .init(listLimit: 0, throwOnLimitExceeded: true),
                 currentListLength: 0,
-                isFirstOccurrence: true
+                isFlatListValue: true
             )
         }
     }
 
-    @Test("comma helper: throwing path handles negative limits, remaining capacity, and success")
+    @Test("comma helper: throwing path checks the current flat token, not cumulative length")
     func testParseListValue_ThrowingCommaBranches() throws {
         #expect(throws: DecodeError.listLimitExceeded(limit: -1)) {
             _ = try Decoder.parseListValue(
                 "a,b",
                 options: .init(listLimit: -1, comma: true, throwOnLimitExceeded: true),
                 currentListLength: 0,
-                isFirstOccurrence: true
-            )
-        }
-
-        #expect(throws: DecodeError.listLimitExceeded(limit: 2)) {
-            _ = try Decoder.parseListValue(
-                "a,b",
-                options: .init(listLimit: 2, comma: true, throwOnLimitExceeded: true),
-                currentListLength: 1,
-                isFirstOccurrence: true
+                isFlatListValue: true
             )
         }
 
         let parsed = try Decoder.parseListValue(
             "a,b",
-            options: .init(listLimit: 3, comma: true, throwOnLimitExceeded: true),
+            options: .init(listLimit: 2, comma: true, throwOnLimitExceeded: true),
             currentListLength: 1,
-            isFirstOccurrence: true
+            isFlatListValue: true
         )
 
         let list = parsed as? [String]
         #expect(list == ["a", "b"])
+
+        let bracketed = try Decoder.parseListValue(
+            "a,b,c",
+            options: .init(listLimit: 1, comma: true, throwOnLimitExceeded: true),
+            currentListLength: 0,
+            isFlatListValue: false
+        )
+        #expect(bracketed as? [String] == ["a", "b", "c"])
     }
 
-    @Test("comma helper: non-throwing negative limit falls back to overflow map")
-    func testParseListValue_NonThrowingNegativeLimitFallsBackToOverflowMap() throws {
+    @Test("comma helper: non-throwing values are split before cumulative enforcement")
+    func testParseListValue_NonThrowingNegativeLimitReturnsSplitValue() throws {
         let parsed = try Decoder.parseListValue(
             "a,b",
             options: .init(listLimit: -1, comma: true, throwOnLimitExceeded: false),
             currentListLength: 0,
-            isFirstOccurrence: true
+            isFlatListValue: true
         )
 
-        let overflow = try #require(parsed as? [AnyHashable: Any])
-        #expect(Utils.isOverflow(overflow))
-        #expect(overflow[0] as? String == "a")
-        #expect(overflow[1] as? String == "b")
+        #expect(parsed as? [String] == ["a", "b"])
     }
 
     @Test("comma helper: throwing scalar append uses current list length gate")
@@ -391,7 +387,7 @@ struct DecodeTests {
                 "value",
                 options: .init(listLimit: 1, throwOnLimitExceeded: true),
                 currentListLength: 1,
-                isFirstOccurrence: false
+                isFlatListValue: true
             )
         }
     }
@@ -415,16 +411,19 @@ struct DecodeTests {
         #expect(first?.compactMap { $0 as? String } == ["b", "c"])
     }
 
-    @Test("comma: explicit [] huge overflow keeps sparse map to avoid dense allocation")
-    func testComma_ListLimit_NonThrowingOverflowExplicitArrayKeyHugeStaysOverflowMap() throws {
+    @Test("comma: explicit [] groups stay nested above the old allocation threshold")
+    func testComma_ListLimit_ExplicitArrayKeyHugeStaysNested() throws {
         let opts = DecodeOptions(listLimit: 1, comma: true, throwOnLimitExceeded: false)
         let count = 5_000
         let rhs = Array(repeating: "x", count: count).joined(separator: ",")
 
         let r = try Qs.decode("a[]=\(rhs)", options: opts)
-        let a = asDictString(r["a"])
-        #expect((a?["0"] as? String) == "x")
-        #expect((a?["\(count - 1)"] as? String) == "x")
+        let outer = r["a"] as? [Any]
+        let inner = outer?.first as? [String]
+        #expect(outer?.count == 1)
+        #expect(inner?.count == count)
+        #expect(inner?.first == "x")
+        #expect(inner?.last == "x")
     }
 
     @Test("comma: negative list limit still falls back to indexed map when non-throwing")
@@ -436,14 +435,15 @@ struct DecodeTests {
         #expect((a?["1"] as? String) == "c")
     }
 
-    @Test("comma overflow fallback applies only on true first occurrence")
-    func testComma_ListLimit_NonThrowingDuplicateKeyStaysFlat() throws {
+    @Test("comma overflow appended after a duplicate remains nested")
+    func testComma_ListLimit_NonThrowingDuplicateKeyKeepsOverflowNested() throws {
         let opts = DecodeOptions(listLimit: 1, comma: true, throwOnLimitExceeded: false)
         let r = try Qs.decode("a=x&a=b,c", options: opts)
         let a = asDictString(r["a"])
         #expect((a?["0"] as? String) == "x")
-        #expect((a?["1"] as? String) == "b")
-        #expect((a?["2"] as? String) == "c")
+        let nested = asDictString(a?["1"])
+        #expect((nested?["0"] as? String) == "b")
+        #expect((nested?["1"] as? String) == "c")
     }
 
     @Test("comma overflow fallback still percent-decodes split elements")
@@ -522,6 +522,195 @@ struct DecodeTests {
         #expect((a?["1"] as? String) == "2")
     }
 
+    // MARK: - qs 6.15.3 cumulative list-limit parity
+
+    @Test("qs 6.15.3: cumulative comma growth enforces listLimit")
+    func qs6153_cumulativeCommaGrowth() throws {
+        let strict = DecodeOptions(listLimit: 5, comma: true, throwOnLimitExceeded: true)
+        #expect(throws: DecodeError.listLimitExceeded(limit: 5)) {
+            _ = try Qs.decode("a=1,2,3&a=4,5,6", options: strict)
+        }
+
+        let exact = try Qs.decode("a=1,2,3&a=4,5", options: strict)
+        #expect(asStrings(exact["a"]) == ["1", "2", "3", "4", "5"])
+
+        let soft = try Qs.decode(
+            "a=1,2,3&a=4,5,6",
+            options: DecodeOptions(listLimit: 5, comma: true)
+        )
+        let overflow = asDictString(soft["a"])
+        #expect(overflow?["0"] as? String == "1")
+        #expect(overflow?["5"] as? String == "6")
+    }
+
+    @Test("qs 6.15.3: duplicate scalar and bracket growth throws at the boundary")
+    func qs6153_duplicateGrowthThrows() {
+        let options = DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+        for query in ["a=x&a=y", "a[]=x&a[]=y"] {
+            #expect(throws: DecodeError.listLimitExceeded(limit: 1), Comment(rawValue: query)) {
+                _ = try Qs.decode(query, options: options)
+            }
+        }
+    }
+
+    @Test("qs 6.15.3: mixed list notation enforces listLimit")
+    func qs6153_mixedListGrowth() throws {
+        let queries = ["a=x&a[0]=y", "a[0]=x&a=y", "a[0]=x&a[]=y"]
+        let strict = DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+
+        for query in queries {
+            #expect(throws: DecodeError.listLimitExceeded(limit: 1), Comment(rawValue: query)) {
+                _ = try Qs.decode(query, options: strict)
+            }
+
+            let decoded = try Qs.decode(query, options: DecodeOptions(listLimit: 1))
+            let overflow = asDictString(decoded["a"])
+            #expect(overflow?["0"] as? String == "x", Comment(rawValue: query))
+            #expect(overflow?["1"] as? String == "y", Comment(rawValue: query))
+        }
+    }
+
+    @Test("qs 6.15.3: overflow values merge with bracket assignments by index")
+    func qs6153_overflowValuesMergeWithBracketAssignments() throws {
+        let cases: [(String, [String: Any])] = [
+            (
+                "a=1,2&a[]=x",
+                ["0": ["1", "x"], "1": "2"]
+            ),
+            (
+                "a[]=x&a=1,2",
+                ["0": ["x", "1"], "1": "2"]
+            ),
+            (
+                "a=x&a=x&a[]=x",
+                ["0": ["x", "x"], "1": "x"]
+            ),
+        ]
+
+        for (query, expected) in cases {
+            let decoded = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 1, comma: true)
+            )
+            let actual = try #require(decoded["a"] as? [String: Any])
+            #expect(NSDictionary(dictionary: actual).isEqual(to: expected), Comment(rawValue: query))
+        }
+
+        let sparse = try Qs.decode(
+            "a=1,2&a[2]=z&a[]=x",
+            options: DecodeOptions(listLimit: 2, comma: true)
+        )
+        let sparseValue = try #require(sparse["a"] as? [String: Any])
+        #expect(
+            NSDictionary(dictionary: sparseValue).isEqual(
+                to: ["0": ["1", "x"], "1": "2", "2": "z"]
+            )
+        )
+    }
+
+    @Test("qs 6.15.3: nested bracket growth enforces the cumulative limit")
+    func qs6153_nestedBracketGrowth() throws {
+        let query = "a[0][]=1&a[0][]=2&a[0][]=3"
+        let decoded = try Qs.decode(
+            query,
+            options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+        )
+        #expect(as2DStrings(decoded["a"] as Any?) == [["1", "2", "3"]])
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 2)) {
+            _ = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 2, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
+    @Test("qs 6.15.3: bracketed comma groups count as outer elements")
+    func qs6153_bracketedCommaGroupsCountAsOuterElements() throws {
+        let options = DecodeOptions(listLimit: 2, comma: true, throwOnLimitExceeded: true)
+        let decoded = try Qs.decode(
+            "a[]=1,2,3,4,5,6&a[]=7,8,9,10,11,12",
+            options: options
+        )
+        #expect(
+            as2DStrings(decoded["a"] as Any?) == [
+                ["1", "2", "3", "4", "5", "6"],
+                ["7", "8", "9", "10", "11", "12"],
+            ]
+        )
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 0)) {
+            _ = try Qs.decode(
+                "a[]=1,2,3",
+                options: DecodeOptions(listLimit: 0, comma: true, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
+    @Test("qs 6.15.3: oversized flat comma values throw before value decoding")
+    func qs6153_flatCommaThrowsBeforeDecoding() {
+        final class Counter: @unchecked Sendable {
+            var valueCalls = 0
+        }
+        let counter = Counter()
+        let decoder: ScalarDecoder = { token, _, kind in
+            if kind == .value { counter.valueCalls += 1 }
+            return token
+        }
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 2)) {
+            _ = try Qs.decode(
+                "a=1,2,3",
+                options: DecodeOptions(
+                    decoder: decoder,
+                    listLimit: 2,
+                    comma: true,
+                    throwOnLimitExceeded: true
+                )
+            )
+        }
+        #expect(counter.valueCalls == 0)
+    }
+
+    @Test("qs 6.15.3: bracketed comma groups decode every inner value")
+    func qs6153_bracketedCommaDecodesEveryInnerValue() throws {
+        final class Counter: @unchecked Sendable {
+            var values: [String] = []
+        }
+        let counter = Counter()
+        let decoder: ScalarDecoder = { token, _, kind in
+            if kind == .value, let token { counter.values.append(token) }
+            return token
+        }
+
+        let decoded = try Qs.decode(
+            "a[]=1,2,3,4,5,6",
+            options: DecodeOptions(
+                decoder: decoder,
+                listLimit: 1,
+                comma: true,
+                throwOnLimitExceeded: true
+            )
+        )
+        #expect(as2DStrings(decoded["a"] as Any?) == [["1", "2", "3", "4", "5", "6"]])
+        #expect(counter.values == ["1", "2", "3", "4", "5", "6"])
+    }
+
+    @Test("qs 6.15.3: negative listLimit overflows duplicate growth")
+    func qs6153_negativeLimitDuplicateGrowth() throws {
+        let decoded = try Qs.decode("a=x&a=y", options: DecodeOptions(listLimit: -1))
+        let overflow = asDictString(decoded["a"])
+        #expect(overflow?["0"] as? String == "x")
+        #expect(overflow?["1"] as? String == "y")
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: -1)) {
+            _ = try Qs.decode(
+                "a=x",
+                options: DecodeOptions(listLimit: -1, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
     @Test("allows enabling dot notation")
     func testAllowDots() async throws {
         do {
@@ -533,6 +722,64 @@ struct DecodeTests {
             let a = r["a"] as? [String: Any]
             #expect((a?["b"] as? String) == "c")
         }
+    }
+
+    @Test("qs 6.15.3: unbalanced bracket keys retain qs's lenient literal segments")
+    func qs6153_unbalancedBracketKeys() throws {
+        let cases: [(String, [String: Any])] = [
+            ("a[bc=v", ["a": ["[bc": "v"]]),
+            ("a[=v", ["a": ["[": "v"]]),
+            ("a[b][c=v", ["a": ["b": ["[c": "v"]]]),
+            ("a[b]c[d=v", ["a": ["b": ["[d": "v"]]]),
+            ("filters[customtags:Env: Prod=v", ["filters": ["[customtags:Env: Prod": "v"]]),
+            ("][a=v", ["]": ["[a": "v"]]),
+            ("a][b=v", ["a]": ["[b": "v"]]),
+            ("a[b[c=v", ["a": ["[b[c": "v"]]),
+            ("a[b[c]=v", ["a": ["[b[c]": "v"]]),
+            ("a[b][c[d=v", ["a": ["b": ["[c[d": "v"]]]),
+            ("[abc=v", ["[abc": "v"]),
+            ("[[]b=v", ["[[]b": "v"]),
+            ("a]b=v", ["a]b": "v"]),
+            ("a[b]extra=v", ["a": ["b": "v"]]),
+        ]
+
+        for (query, expected) in cases {
+            let decoded = try Qs.decode(query)
+            #expect(NSDictionary(dictionary: decoded).isEqual(to: expected), Comment(rawValue: query))
+        }
+    }
+
+    @Test("qs 6.15.3: unbalanced bracket handling respects depth and allowDots")
+    func qs6153_unbalancedBracketOptions() throws {
+        let depthFive = try Qs.decode(
+            "a[b]c[d]e[f=v",
+            options: DecodeOptions(depth: 5)
+        )
+        #expect(
+            NSDictionary(dictionary: depthFive).isEqual(
+                to: ["a": ["b": ["d": ["[f": "v"]]]]
+            )
+        )
+
+        let depthOne = try Qs.decode(
+            "a[b]c[d]e[f=v",
+            options: DecodeOptions(depth: 1)
+        )
+        #expect(
+            NSDictionary(dictionary: depthOne).isEqual(
+                to: ["a": ["b": ["[d]e[f": "v"]]]
+            )
+        )
+
+        let depthZero = try Qs.decode("a[bc=v", options: DecodeOptions(depth: 0))
+        #expect(depthZero["a[bc"] as? String == "v")
+
+        let dotted = try Qs.decode("a.b[c=v", options: DecodeOptions(allowDots: true))
+        #expect(
+            NSDictionary(dictionary: dotted).isEqual(
+                to: ["a": ["b": ["[c": "v"]]]
+            )
+        )
     }
 
     @Test("decode dot keys correctly")

--- a/Tests/QsSwiftTests/DecodeTests.swift
+++ b/Tests/QsSwiftTests/DecodeTests.swift
@@ -570,6 +570,51 @@ struct DecodeTests {
         }
     }
 
+    @Test("qs 6.15.3: sparse scalar merges count numeric positions before compaction")
+    func qs6153_sparseScalarMergeCountsPositions() throws {
+        let query = "a=x&a[2]=y"
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Qs.decode(
+                query,
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+
+        let soft = try Qs.decode(query, options: DecodeOptions(listLimit: 3))
+        let overflow = asDictString(soft["a"])
+        #expect(overflow?["0"] as? String == "x")
+        #expect(overflow?["3"] as? String == "y")
+        #expect(overflow?["1"] == nil)
+        #expect(overflow?["2"] == nil)
+
+        let withinLimit = try Qs.decode(
+            query,
+            options: DecodeOptions(listLimit: 4, throwOnLimitExceeded: true)
+        )
+        #expect(asStrings(withinLimit["a"]) == ["x", "y"])
+    }
+
+    @Test("qs 6.15.3: threshold index maps preserve overflow metadata across mixed merges")
+    func qs6153_thresholdIndexOverflowMetadata() throws {
+        let cases: [(String, Int, [String: String])] = [
+            ("a[1]=x&a=y", 1, ["1": "x", "2": "y"]),
+            ("a=x&a[1]=y", 1, ["0": "x", "2": "y"]),
+            ("a[1]=x&a[]=y", 1, ["0": "y", "1": "x"]),
+            ("a[0]=x&a=y", -1, ["0": "x", "1": "y"]),
+            ("a=x&a[0]=y", -1, ["0": "x", "1": "y"]),
+        ]
+
+        for (query, limit, expected) in cases {
+            let decoded = try Qs.decode(query, options: DecodeOptions(listLimit: limit))
+            let overflow = asDictString(decoded["a"])
+            #expect(overflow?.count == expected.count, Comment(rawValue: query))
+            for (key, value) in expected {
+                #expect(overflow?[key] as? String == value, Comment(rawValue: query))
+            }
+        }
+    }
+
     @Test("qs 6.15.3: overflow values merge with bracket assignments by index")
     func qs6153_overflowValuesMergeWithBracketAssignments() throws {
         let cases: [(String, [String: Any])] = [

--- a/Tests/QsSwiftTests/FoundationURLTests.swift
+++ b/Tests/QsSwiftTests/FoundationURLTests.swift
@@ -40,7 +40,7 @@ struct FoundationURLTests {
                 "where": [
                     "age": ["gte": 30],
                     "name": "John",
-                ],
+                ]
             ],
             "tags": ["a", "b"],
         ]
@@ -54,7 +54,7 @@ struct FoundationURLTests {
         #expect(
             url.absoluteString
                 == "https://api.example.com/products?filter%5Bwhere%5D%5Bage%5D%5Bgte%5D=30"
-                    + "&filter%5Bwhere%5D%5Bname%5D=John&tags%5B0%5D=a&tags%5B1%5D=b"
+                + "&filter%5Bwhere%5D%5Bname%5D=John&tags%5B0%5D=a&tags%5B1%5D=b"
         )
         #expect(url.absoluteString.contains("filter%5Bwhere%5D"))
         #expect(!url.absoluteString.contains("%255B"))
@@ -117,7 +117,7 @@ struct FoundationURLTests {
         #expect(
             components.url?.absoluteString
                 == "https://user:pass@api.example.com:8443/products"
-                    + "?existing=x%20y&flag&filter%5Bname%5D=John#frag"
+                + "?existing=x%20y&flag&filter%5Bname%5D=John#frag"
         )
     }
 

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1033,6 +1033,50 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.merge - preserves sparse positions for later cumulative growth")
+    func testMergePreservesSparsePositionsForCumulativeGrowth() throws {
+        let first = try #require(
+            try Utils.merge(
+                target: "x",
+                source: [Undefined.instance, ""],
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            ) as? [Any?]
+        )
+        try #require(first.count == 3)
+        #expect(first[0] as? String == "x")
+        #expect(first[1] is Undefined)
+        #expect(first[2] as? String == "")
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: first,
+                source: ["y"],
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
+    @Test("Utils.merge - treats numeric strings and integer indices as the same property")
+    func testMergeNumericPropertyKeyEquivalence() {
+        let nested = ["1", "2", "3"]
+        let options = DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: [AnyHashable("0"): nested],
+                source: ["1", "", "3"],
+                options: options
+            )
+        }
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: ["1", "", "3"],
+                source: [AnyHashable("0"): nested],
+                options: options
+            )
+        }
+    }
+
     @Test("Utils.merge - sparse primitive-array growth counts holes but omits them from overflow")
     func testMergeSparsePrimitiveArrayLimit() throws {
         let sparse: [Any] = [Undefined.instance, Undefined.instance, "y"]
@@ -1064,9 +1108,11 @@ struct UtilsTests {
             source: sparse,
             options: DecodeOptions(listLimit: 4, throwOnLimitExceeded: true)
         ) as? [Any?]
-        #expect(withinLimit?.count == 2)
+        try #require(withinLimit?.count == 4)
         #expect(withinLimit?[0] as? String == "x")
-        #expect(withinLimit?[1] as? String == "y")
+        #expect(withinLimit?[1] is Undefined)
+        #expect(withinLimit?[2] is Undefined)
+        #expect(withinLimit?[3] as? String == "y")
     }
 
     @Test("Overflow index arithmetic preserves values at Int.max without trapping")
@@ -2588,16 +2634,16 @@ struct UtilsTests {
         }
     }
 
-    @Test("Utils.merge merges nil targets with typed [Any] sources and filters Undefined")
+    @Test("Utils.merge merges nil targets with typed [Any] sources and preserves sparse positions")
     func utils_merge_nilTarget_typedArraySource() throws {
         let source: [Any] = [Undefined.instance, "ok", 42]
         if let merged = try Utils.merge(target: nil, source: source, options: .init()) as? [Any?] {
-            #expect(merged.count == 3)
+            #expect(merged.count == 4)
             let head = merged.first.flatMap { $0 }
             #expect(head == nil)
-            #expect(merged.dropFirst().contains { $0 is Undefined } == false)
-            #expect(merged[1] as? String == "ok")
-            #expect(merged[2] as? Int == 42)
+            #expect(merged[1] is Undefined)
+            #expect(merged[2] as? String == "ok")
+            #expect(merged[3] as? Int == 42)
         } else {
             Issue.record("Nil-target array merge branch not exercised")
         }

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -965,6 +965,74 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.merge - recursively merges nested arrays before limit enforcement")
+    func testMergeNestedArraysBeforeLimitEnforcement() throws {
+        let target: [Any] = [["1", "2"]]
+        let source: [Any] = [["1", "", "3"]]
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+
+        let merged = try #require(
+            try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 3)
+            ) as? [Any?]
+        )
+        let inner = try #require(merged[0] as? [AnyHashable: Any])
+        #expect(Utils.isOverflow(inner))
+        #expect(inner[AnyHashable(0)] as? String == "1")
+        #expect(inner[AnyHashable(1)] as? String == "2")
+        #expect(inner[AnyHashable(2)] as? String == "1")
+        #expect(inner[AnyHashable(3)] as? String == "")
+        #expect(inner[AnyHashable(4)] as? String == "3")
+    }
+
+    @Test("Utils.merge - sparse collisions append at the logical end")
+    func testMergeSparseCollisionLimit() throws {
+        let target: [Any] = [["1", "2"], Undefined.instance, ["1", "2"]]
+        let source: [Any] = ["y"]
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+
+        let merged = try #require(
+            try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 3)
+            ) as? [AnyHashable: Any]
+        )
+        #expect(Utils.isOverflow(merged))
+        #expect((merged[AnyHashable(0)] as? [String]) == ["1", "2"])
+        #expect(merged[AnyHashable(1)] == nil)
+        #expect((merged[AnyHashable(2)] as? [String]) == ["1", "2"])
+        #expect(merged[AnyHashable(3)] as? String == "y")
+    }
+
+    @Test("Utils.merge - ignores falsy sources before list-limit enforcement")
+    func testMergeFalsySourcesDoNotGrowLists() throws {
+        for source: Any in ["", false, 0, NSNull()] {
+            let merged = try Utils.merge(
+                target: ["x"],
+                source: source,
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+            #expect(merged as? [String] == ["x"])
+        }
+    }
+
     @Test("Utils.merge - sparse primitive-array growth counts holes but omits them from overflow")
     func testMergeSparsePrimitiveArrayLimit() throws {
         let sparse: [Any] = [Undefined.instance, Undefined.instance, "y"]
@@ -2407,12 +2475,12 @@ struct UtilsTests {
         let mergedArray = try Utils.merge(target: arrayWithUndefined, source: ["b", undefined], options: options) as? [Any]
         #expect(mergedArray?.compactMap { $0 as? String }.contains("b") == true)
 
-        // Array target + sequence of maps to trigger recursive merge
+        // Array target + sequence of maps recursively merges scalar collisions.
         let targetMaps: [Any] = [["k": "v"], Undefined.instance]
         let sourceMaps: [Any] = [["k": "override"], ["new": "value"]]
         if let mergedMaps = try Utils.merge(target: targetMaps, source: sourceMaps, options: .init()) as? [Any?] {
             let first = mergedMaps[0] as? [AnyHashable: Any]
-            #expect(first?["k"] as? String == "override")
+            #expect(first?["k"] as? [String] == ["v", "override"])
         }
 
         // Dictionary target with non-sequence source coerces key from description
@@ -2477,17 +2545,18 @@ struct UtilsTests {
         }
     }
 
-    @Test("Utils.merge overlays Swift [Any] with sequence indices")
-    func utils_merge_arraySequenceOverlay() throws {
+    @Test("Utils.merge applies qs collision rules to Swift [Any] sequence indices")
+    func utils_merge_arraySequenceCollisions() throws {
         let undefined = Undefined.instance
         let target = [Any](arrayLiteral: undefined, "keep")
         let source: [Any] = ["replaced", "new"]
         if let merged = try Utils.merge(target: target, source: source, options: .init(parseLists: true)) as? [Any?] {
             #expect(merged[0] as? String == "replaced")
-            #expect(merged[1] as? String == "new")
-            #expect(merged.count == 2)
+            #expect(merged[1] as? String == "keep")
+            #expect(merged[2] as? String == "new")
+            #expect(merged.count == 3)
         } else {
-            Issue.record("Sequence overlay branch not exercised")
+            Issue.record("Sequence collision branch not exercised")
         }
     }
 

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -965,6 +965,42 @@ struct UtilsTests {
         }
     }
 
+    @Test("Utils.merge - sparse primitive-array growth counts holes but omits them from overflow")
+    func testMergeSparsePrimitiveArrayLimit() throws {
+        let sparse: [Any] = [Undefined.instance, Undefined.instance, "y"]
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 3)) {
+            _ = try Utils.merge(
+                target: "x",
+                source: sparse,
+                options: DecodeOptions(listLimit: 3, throwOnLimitExceeded: true)
+            )
+        }
+
+        let soft = try #require(
+            try Utils.merge(
+                target: "x",
+                source: sparse,
+                options: DecodeOptions(listLimit: 3)
+            ) as? [AnyHashable: Any]
+        )
+        #expect(Utils.isOverflow(soft))
+        #expect(Utils.overflowMaxIndex(soft) == 3)
+        #expect(soft[AnyHashable(0)] as? String == "x")
+        #expect(soft[AnyHashable(1)] == nil)
+        #expect(soft[AnyHashable(2)] == nil)
+        #expect(soft[AnyHashable(3)] as? String == "y")
+
+        let withinLimit = try Utils.merge(
+            target: "x",
+            source: sparse,
+            options: DecodeOptions(listLimit: 4, throwOnLimitExceeded: true)
+        ) as? [Any?]
+        #expect(withinLimit?.count == 2)
+        #expect(withinLimit?[0] as? String == "x")
+        #expect(withinLimit?[1] as? String == "y")
+    }
+
     @Test("Utils.combine - keeps arrays nested when appending to overflow objects")
     func testCombineKeepsOverflowAppendNested() async throws {
         let overflow = try Utils.combine(["a"], "b", options: DecodeOptions(listLimit: 1))

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OrderedCollections
+
 @_spi(Testing) @testable import QsSwift
 
 #if canImport(Testing)
@@ -1103,11 +1104,12 @@ struct UtilsTests {
         #expect(soft[AnyHashable(2)] == nil)
         #expect(soft[AnyHashable(3)] as? String == "y")
 
-        let withinLimit = try Utils.merge(
-            target: "x",
-            source: sparse,
-            options: DecodeOptions(listLimit: 4, throwOnLimitExceeded: true)
-        ) as? [Any?]
+        let withinLimit =
+            try Utils.merge(
+                target: "x",
+                source: sparse,
+                options: DecodeOptions(listLimit: 4, throwOnLimitExceeded: true)
+            ) as? [Any?]
         try #require(withinLimit?.count == 4)
         #expect(withinLimit?[0] as? String == "x")
         #expect(withinLimit?[1] is Undefined)
@@ -1188,11 +1190,12 @@ struct UtilsTests {
 
     @Test("Utils.merge - handles overflow objects")
     func testMergeOverflowObjects() async throws {
-        let overflow = try Utils.combine(
-            ["a"],
-            "b",
-            options: DecodeOptions(listLimit: 1)
-        ) as? [AnyHashable: Any]
+        let overflow =
+            try Utils.combine(
+                ["a"],
+                "b",
+                options: DecodeOptions(listLimit: 1)
+            ) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(overflow))
 
         if let overflow {
@@ -1216,11 +1219,12 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges an array target into overflow values by numeric index")
     func testMergeOverflowIntoArrayTarget() async throws {
-        let overflow = try Utils.combine(
-            ["a"],
-            "b",
-            options: DecodeOptions(listLimit: 1)
-        ) as? [AnyHashable: Any]
+        let overflow =
+            try Utils.combine(
+                ["a"],
+                "b",
+                options: DecodeOptions(listLimit: 1)
+            ) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(overflow))
 
         if let overflow {
@@ -2504,7 +2508,8 @@ struct UtilsTests {
             #expect(!orderedResult.isEmpty)
         }
 
-        let orderedWithSequence = try Utils.merge(target: OrderedSet(["a"]), source: [undefined, "b"], options: .init())
+        let orderedWithSequence = try Utils.merge(
+            target: OrderedSet(["a"]), source: [undefined, "b"], options: .init())
         if let orderedSequenceArray = orderedWithSequence as? [Any?] {
             #expect(orderedSequenceArray.contains { ($0 as? String) == "b" })
         }
@@ -2518,7 +2523,8 @@ struct UtilsTests {
         // Array target with Undefined elements and parseLists disabled
         let options = DecodeOptions(parseLists: false)
         let arrayWithUndefined: [Any] = [undefined, "a"]
-        let mergedArray = try Utils.merge(target: arrayWithUndefined, source: ["b", undefined], options: options) as? [Any]
+        let mergedArray =
+            try Utils.merge(target: arrayWithUndefined, source: ["b", undefined], options: options) as? [Any]
         #expect(mergedArray?.compactMap { $0 as? String }.contains("b") == true)
 
         // Array target + sequence of maps recursively merges scalar collisions.
@@ -2531,7 +2537,8 @@ struct UtilsTests {
 
         // Dictionary target with non-sequence source coerces key from description
         let dictTarget: [AnyHashable: Any] = ["keep": 1]
-        if let mergedDict = try Utils.merge(target: dictTarget, source: "flag", options: .init()) as? [AnyHashable: Any] {
+        if let mergedDict = try Utils.merge(target: dictTarget, source: "flag", options: .init()) as? [AnyHashable: Any]
+        {
             #expect(mergedDict.keys.contains { ($0 as? String) == "flag" })
         }
 
@@ -2563,7 +2570,8 @@ struct UtilsTests {
             Issue.record("OrderedSet union branch not exercised")
         }
 
-        if let unchanged = try Utils.merge(target: target, source: undefined, options: .init()) as? OrderedSet<AnyHashable>
+        if let unchanged = try Utils.merge(target: target, source: undefined, options: .init())
+            as? OrderedSet<AnyHashable>
         {
             #expect(unchanged.elementsEqual(target))
         } else {

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -1001,6 +1001,44 @@ struct UtilsTests {
         #expect(withinLimit?[1] as? String == "y")
     }
 
+    @Test("Overflow index arithmetic preserves values at Int.max without trapping")
+    func testOverflowIndexArithmeticAtIntMax() throws {
+        let boundary = Utils.markOverflow(
+            [AnyHashable(Int.max): "x"],
+            maxIndex: Int.max
+        )
+        let options = DecodeOptions(listLimit: 20)
+
+        let combined = try #require(
+            try Utils.combine(boundary, "y", options: options) as? [Any]
+        )
+        let combinedMap = try #require(combined[0] as? [AnyHashable: Any])
+        #expect(!Utils.isOverflow(combinedMap))
+        #expect(combinedMap[AnyHashable(Int.max)] as? String == "x")
+        #expect(combined[1] as? String == "y")
+
+        let merged = try #require(
+            try Utils.merge(
+                target: boundary,
+                source: OrderedSet<AnyHashable>(["y", "z"]),
+                options: options
+            ) as? [Any]
+        )
+        let mergedMap = try #require(merged[0] as? [AnyHashable: Any])
+        #expect(!Utils.isOverflow(mergedMap))
+        #expect(mergedMap[AnyHashable(Int.max)] as? String == "x")
+        #expect(merged[1] as? String == "y")
+        #expect(merged[2] as? String == "z")
+
+        let shifted = try #require(
+            try Utils.merge(target: "z", source: boundary, options: options) as? [Any]
+        )
+        #expect(shifted[0] as? String == "z")
+        let shiftedMap = try #require(shifted[1] as? [AnyHashable: Any])
+        #expect(!Utils.isOverflow(shiftedMap))
+        #expect(shiftedMap[AnyHashable(Int.max)] as? String == "x")
+    }
+
     @Test("Utils.combine - keeps arrays nested when appending to overflow objects")
     func testCombineKeepsOverflowAppendNested() async throws {
         let overflow = try Utils.combine(["a"], "b", options: DecodeOptions(listLimit: 1))

--- a/Tests/QsSwiftTests/UtilsTests.swift
+++ b/Tests/QsSwiftTests/UtilsTests.swift
@@ -108,6 +108,18 @@ struct UtilsTests {
         #expect(Utils.encode(longString) == expectedString)
     }
 
+    @Test("Utils.encode - preserves an emoji across the first qs chunk boundary")
+    func testEncodeEmojiAtFirstChunkBoundary() {
+        let prefix = String(repeating: "a", count: 1_023)
+        #expect(Utils.encode(prefix + "😀") == prefix + "%F0%9F%98%80")
+    }
+
+    @Test("Utils.encode - preserves an emoji across a later qs chunk boundary")
+    func testEncodeEmojiAtLaterChunkBoundary() {
+        let prefix = String(repeating: "a", count: 2_047)
+        #expect(Utils.encode(prefix + "😀") == prefix + "%F0%9F%98%80")
+    }
+
     @Test("Utils.encode - encodes parentheses")
     func testEncodeParentheses() async throws {
         #expect(Utils.encode("()") == "%28%29")
@@ -447,7 +459,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges Map with List")
     func testMergeMapWithList() async throws {
-        let result = Utils.merge(target: [0: "a"], source: [Undefined(), "b"])
+        let result = try Utils.merge(target: [0: "a"], source: [Undefined(), "b"])
         let out: [AnyHashable: Any] = result as! [AnyHashable: Any]
         // Compare contents directly to avoid NSNumber/Int key-bridging differences on Linux
         #expect(out.count == 2)
@@ -459,7 +471,7 @@ struct UtilsTests {
     func testMergeTwoObjectsSameKeyDifferentValues() async throws {
         let target = ["foo": [["a": "a", "b": "b"], ["a": "aa"]]]
         let source = ["foo": [Undefined(), ["b": "bb"]]]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let expected = ["foo": [["a": "a", "b": "b"], ["a": "aa", "b": "bb"]]]
 
         // Deep comparison needed for nested structures
@@ -472,7 +484,7 @@ struct UtilsTests {
     func testMergeTwoObjectsSameKeyDifferentListValues() async throws {
         let target = ["foo": [["baz": ["15"]]]]
         let source = ["foo": [["baz": [Undefined(), "16"]]]]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let expected = ["foo": [["baz": ["15", "16"]]]]
 
         let resultDict = result as! [String: Any]
@@ -484,7 +496,7 @@ struct UtilsTests {
     func testMergeTwoObjectsSameKeyIntoList() async throws {
         let target = ["foo": [["a": "b"]]]
         let source = ["foo": [["c": "d"]]]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let expected = ["foo": [["a": "b", "c": "d"]]]
 
         let resultDict = result as! [String: Any]
@@ -494,7 +506,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges true into null")
     func testMergeTrueIntoNull() async throws {
-        let result = Utils.merge(target: nil, source: true)
+        let result = try Utils.merge(target: nil, source: true)
         let resultArray = result as! [Any?]
         #expect(resultArray.count == 2)
         #expect(resultArray[0] == nil)
@@ -503,7 +515,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges null into a list")
     func testMergeNullIntoList() async throws {
-        let result = Utils.merge(target: nil, source: [42])
+        let result = try Utils.merge(target: nil, source: [42])
         let resultArray = result as! [Any?]
         #expect(resultArray.count == 2)
         #expect(resultArray[0] == nil)
@@ -512,7 +524,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges null into a set")
     func testMergeNullIntoSet() async throws {
-        let result = Utils.merge(target: nil, source: Set(["foo"]))
+        let result = try Utils.merge(target: nil, source: Set(["foo"]))
         let resultArray = result as! [Any?]
         #expect(resultArray.count == 2)
         #expect(resultArray[0] == nil)
@@ -521,7 +533,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges String into set")
     func testMergeStringIntoSet() async throws {
-        let result = Utils.merge(target: Set(["foo"]), source: "bar")
+        let result = try Utils.merge(target: Set(["foo"]), source: "bar")
         let resultSet = result as! Set<AnyHashable>
         #expect(resultSet.contains("foo"))
         #expect(resultSet.contains("bar"))
@@ -530,7 +542,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges two objects with the same key")
     func testMergeTwoObjectsSameKey() async throws {
-        let result = Utils.merge(target: ["a": "b"], source: ["a": "c"])
+        let result = try Utils.merge(target: ["a": "b"], source: ["a": "c"])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("a"))
 
@@ -543,7 +555,7 @@ struct UtilsTests {
     func testMergeStandaloneAndObjectIntoList() async throws {
         let target = ["foo": "bar"]
         let source = ["foo": ["first": "123"]]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
 
@@ -555,7 +567,7 @@ struct UtilsTests {
     func testMergeStandaloneAndTwoObjectsIntoList() async throws {
         let target = ["foo": ["bar", ["first": "123"]]]
         let source = ["foo": ["second": "456"]]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
     }
@@ -564,7 +576,7 @@ struct UtilsTests {
     func testMergeObjectSandwichedByStandalones() async throws {
         let target = ["foo": ["bar", ["first": "123", "second": "456"]]]
         let source = ["foo": "baz"]
-        let result = Utils.merge(target: target, source: source)
+        let result = try Utils.merge(target: target, source: source)
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
 
@@ -574,11 +586,11 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges two lists into a list")
     func testMergeTwoListsIntoList() async throws {
-        let result1 = Utils.merge(target: ["foo"], source: ["bar", "xyzzy"])
+        let result1 = try Utils.merge(target: ["foo"], source: ["bar", "xyzzy"])
         let resultArray1 = result1 as! [String]
         #expect(resultArray1 == ["foo", "bar", "xyzzy"])
 
-        let result2 = Utils.merge(target: ["foo": ["baz"]], source: ["foo": ["bar", "xyzzy"]])
+        let result2 = try Utils.merge(target: ["foo": ["baz"]], source: ["foo": ["bar", "xyzzy"]])
         let resultDict2 = result2 as! [String: Any]
         #expect(resultDict2.keys.contains("foo"))
 
@@ -588,13 +600,13 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges two sets into a list")
     func testMergeTwoSetsIntoList() async throws {
-        let result1 = Utils.merge(target: Set(["foo"]), source: Set(["bar", "xyzzy"]))
+        let result1 = try Utils.merge(target: Set(["foo"]), source: Set(["bar", "xyzzy"]))
         let resultSet1 = result1 as! Set<AnyHashable>
         #expect(resultSet1.contains("foo"))
         #expect(resultSet1.contains("bar"))
         #expect(resultSet1.contains("xyzzy"))
 
-        let result2 = Utils.merge(
+        let result2 = try Utils.merge(
             target: ["foo": Set(["baz"])], source: ["foo": Set(["bar", "xyzzy"])])
         let resultDict2 = result2 as! [String: Any]
         #expect(resultDict2.keys.contains("foo"))
@@ -602,7 +614,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges a set into a list")
     func testMergeSetIntoList() async throws {
-        let result = Utils.merge(target: ["foo": ["baz"]], source: ["foo": Set(["bar"])])
+        let result = try Utils.merge(target: ["foo": ["baz"]], source: ["foo": Set(["bar"])])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
 
@@ -613,7 +625,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges a list into a set")
     func testMergeListIntoSet() async throws {
-        let result = Utils.merge(target: ["foo": Set(["baz"])], source: ["foo": ["bar"]])
+        let result = try Utils.merge(target: ["foo": Set(["baz"])], source: ["foo": ["bar"]])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
 
@@ -624,7 +636,7 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges a set into a list with multiple elements")
     func testMergeSetIntoListMultipleElements() async throws {
-        let result = Utils.merge(target: ["foo": ["baz"]], source: ["foo": Set(["bar", "xyzzy"])])
+        let result = try Utils.merge(target: ["foo": ["baz"]], source: ["foo": Set(["bar", "xyzzy"])])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
 
@@ -634,14 +646,14 @@ struct UtilsTests {
 
     @Test("Utils.merge - merges an object into a list")
     func testMergeObjectIntoList() async throws {
-        let result = Utils.merge(target: ["foo": ["bar"]], source: ["foo": ["baz": "xyzzy"]])
+        let result = try Utils.merge(target: ["foo": ["bar"]], source: ["foo": ["baz": "xyzzy"]])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
     }
 
     @Test("Utils.merge - merges a list into an object")
     func testMergeListIntoObject() async throws {
-        let result = Utils.merge(target: ["foo": ["bar": "baz"]], source: ["foo": ["xyzzy"]])
+        let result = try Utils.merge(target: ["foo": ["bar": "baz"]], source: ["foo": ["xyzzy"]])
         let resultDict = result as! [String: Any]
         #expect(resultDict.keys.contains("foo"))
     }
@@ -650,7 +662,7 @@ struct UtilsTests {
     func testMergeSetWithUndefinedWithAnotherSet() async throws {
         let undefined = Undefined()
 
-        let result1 = Utils.merge(
+        let result1 = try Utils.merge(
             target: ["foo": Set<AnyHashable>(["bar"])],
             source: ["foo": Set<AnyHashable>([undefined, "baz"])]
         )
@@ -661,7 +673,7 @@ struct UtilsTests {
         #expect(valueSet1.contains("bar"))
         #expect(valueSet1.contains("baz"))
 
-        let result2 = Utils.merge(
+        let result2 = try Utils.merge(
             target: ["foo": Set<AnyHashable>([undefined, "bar"])],
             source: ["foo": Set<AnyHashable>(["baz"])]
         )
@@ -671,14 +683,14 @@ struct UtilsTests {
 
     @Test("Utils.merge - merge set of Maps with another set of Maps")
     func testMergeSetOfMapsWithAnotherSetOfMaps() async throws {
-        let result1 = Utils.merge(
+        let result1 = try Utils.merge(
             target: Set<AnyHashable>([["bar": "baz"]]),
             source: Set<AnyHashable>([["baz": "xyzzy"]])
         )
         let resultSet1 = result1 as! Set<AnyHashable>
         #expect(resultSet1.count >= 1)
 
-        let result2 = Utils.merge(
+        let result2 = try Utils.merge(
             target: ["foo": Set<AnyHashable>([["bar": "baz"]])],
             source: ["foo": Set<AnyHashable>([["baz": "xyzzy"]])]
         )
@@ -690,7 +702,7 @@ struct UtilsTests {
     func testMergeArrayOverlayWithUndefined_Default() async throws {
         let target: [Any?] = ["x", Undefined(), "z"]
         let source: [Any?] = [Undefined(), "Y", Undefined()]
-        let merged = Utils.merge(target: target, source: source) as! [Any?]
+        let merged = try Utils.merge(target: target, source: source) as! [Any?]
         #expect(merged.count == 3)
         #expect(merged[0] as? String == "x")  // undefined in source leaves target
         #expect(merged[1] as? String == "Y")  // replaced
@@ -702,7 +714,7 @@ struct UtilsTests {
         let target: [Any?] = [Undefined(), "b", Undefined()]
         let source: [Any?] = [Undefined(), Undefined()]
         let opts = DecodeOptions(parseLists: false)
-        let merged = Utils.merge(target: target, source: source, options: opts) as! [Any?]
+        let merged = try Utils.merge(target: target, source: source, options: opts) as! [Any?]
         // remaining Undefined entries are pruned under parseLists=false
         #expect(merged.count == 1)
         #expect(merged[0] as? String == "b")
@@ -711,7 +723,7 @@ struct UtilsTests {
     @Test("Utils.merge - non-sequence source appends to array")
     func testMergeArrayWithNonSequenceSourceAppends() async throws {
         let target: [Any] = ["a", "b"]
-        let merged = Utils.merge(target: target, source: 42) as! [Any]
+        let merged = try Utils.merge(target: target, source: 42) as! [Any]
         #expect(merged.count == 3)
         #expect(merged[0] as? String == "a")
         #expect(merged[1] as? String == "b")
@@ -723,7 +735,7 @@ struct UtilsTests {
         let undefined = Undefined()
         let target = Set<AnyHashable>(["a"])
         let source: [Any?] = [undefined, "c", "a"]
-        let merged = Utils.merge(target: target, source: source) as! Set<AnyHashable>
+        let merged = try Utils.merge(target: target, source: source) as! Set<AnyHashable>
         #expect(merged.contains("a"))
         #expect(merged.contains("c"))
         #expect(merged.count == 2)
@@ -781,13 +793,25 @@ struct UtilsTests {
 
     @Test("Utils.combine - applies list limit and overflow tracking")
     func testCombineListLimitOverflow() async throws {
-        let under = Utils.combine(["a", "b"], "c", listLimit: 10)
+        let under = try Utils.combine(
+            ["a", "b"],
+            "c",
+            options: DecodeOptions(listLimit: 10)
+        )
         #expect((under as? [Any]) != nil)
 
-        let exact = Utils.combine(["a", "b"], "c", listLimit: 3)
+        let exact = try Utils.combine(
+            ["a", "b"],
+            "c",
+            options: DecodeOptions(listLimit: 3)
+        )
         #expect((exact as? [Any]) != nil)
 
-        let over = Utils.combine(["a", "b", "c"], "d", listLimit: 3)
+        let over = try Utils.combine(
+            ["a", "b", "c"],
+            "d",
+            options: DecodeOptions(listLimit: 3)
+        )
         let overDict = over as? [AnyHashable: Any]
         #expect(overDict != nil)
         #expect(Utils.isOverflow(overDict))
@@ -797,7 +821,7 @@ struct UtilsTests {
             #expect(cleaned[AnyHashable(3)] as? String == "d")
         }
 
-        let zero = Utils.combine([], "a", listLimit: 0)
+        let zero = try Utils.combine([], "a", options: DecodeOptions(listLimit: 0))
         let zeroDict = zero as? [AnyHashable: Any]
         #expect(zeroDict != nil)
         if let zeroDict {
@@ -808,11 +832,11 @@ struct UtilsTests {
 
     @Test("Utils.combine - appends to overflow objects")
     func testCombineAppendsToOverflow() async throws {
-        let overflow = Utils.combine(["a"], "b", listLimit: 1)
+        let overflow = try Utils.combine(["a"], "b", options: DecodeOptions(listLimit: 1))
         let overflowDict = overflow as? [AnyHashable: Any]
         #expect(Utils.isOverflow(overflowDict))
 
-        let combined = Utils.combine(overflow, "c", listLimit: 10)
+        let combined = try Utils.combine(overflow, "c", options: DecodeOptions(listLimit: 10))
         let combinedDict = combined as? [AnyHashable: Any]
         #expect(Utils.isOverflow(combinedDict))
         if let combinedDict {
@@ -822,37 +846,169 @@ struct UtilsTests {
         }
     }
 
-    @Test("Utils.combine - flattens arrays when appending to overflow objects")
-    func testCombineFlattensOverflowAppend() async throws {
-        let overflow = Utils.combine(["a"], "b", listLimit: 1)
-        let combined = Utils.combine(overflow, ["c", "d"], listLimit: 10)
+    @Test("Utils.combine - enforces strict and negative list limits")
+    func testCombineStrictAndNegativeLimits() throws {
+        let exact = try Utils.combine(
+            ["a"],
+            "b",
+            options: DecodeOptions(listLimit: 2, throwOnLimitExceeded: true)
+        )
+        #expect(exact as? [String] == ["a", "b"])
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+            _ = try Utils.combine(
+                ["a"],
+                "b",
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+        }
+
+        let negative = try Utils.combine([], "a", options: DecodeOptions(listLimit: -1))
+        #expect(Utils.isOverflow(negative as? [AnyHashable: Any]))
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: -1)) {
+            _ = try Utils.combine(
+                [],
+                "a",
+                options: DecodeOptions(listLimit: -1, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
+    @Test("Utils.combine - strict mode rejects an existing overflow without mutation")
+    func testCombineStrictExistingOverflow() throws {
+        let overflow = try #require(
+            try Utils.combine(["a"], "b", options: DecodeOptions(listLimit: 1))
+                as? [AnyHashable: Any]
+        )
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+            _ = try Utils.combine(
+                overflow,
+                ["c", "d"],
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+        }
+        #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+            _ = try Utils.merge(
+                target: overflow,
+                source: "c",
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+        }
+        #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+            _ = try Utils.merge(
+                target: "z",
+                source: overflow,
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+        }
+        #expect(overflow[AnyHashable(2)] == nil)
+        #expect(Utils.overflowMaxIndex(overflow) == 1)
+    }
+
+    @Test("Utils.merge - enforces list limits in every array and primitive direction")
+    func testMergeListLimitDirections() throws {
+        let soft = DecodeOptions(listLimit: 1)
+        let strict = DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+
+        for (target, source) in [
+            (["a"] as Any, "b" as Any),
+            ("a" as Any, ["b", "c"] as Any),
+            (["a"] as Any, ["b"] as Any),
+        ] {
+            let merged = try Utils.merge(target: target, source: source, options: soft)
+            #expect(Utils.isOverflow(merged as? [AnyHashable: Any]))
+            #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+                _ = try Utils.merge(target: target, source: source, options: strict)
+            }
+        }
+
+        let exact = try Utils.merge(target: [Any](), source: "a", options: strict)
+        #expect(exact as? [String] == ["a"])
+
+        let negative = try Utils.merge(
+            target: [Any](),
+            source: "a",
+            options: DecodeOptions(listLimit: -1)
+        )
+        #expect(Utils.isOverflow(negative as? [AnyHashable: Any]))
+    }
+
+    @Test("Utils.merge - enforces limits after nested array merges")
+    func testMergeNestedArrayLimit() throws {
+        let target: [Any] = [[AnyHashable("a"): 1]]
+        let source: [Any] = [
+            [AnyHashable("b"): 2],
+            [AnyHashable("c"): 3],
+        ]
+
+        let merged = try #require(
+            try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 1)
+            ) as? [AnyHashable: Any]
+        )
+        #expect(Utils.isOverflow(merged))
+        let first = merged[AnyHashable(0)] as? [AnyHashable: Any]
+        #expect(first?[AnyHashable("a")] as? Int == 1)
+        #expect(first?[AnyHashable("b")] as? Int == 2)
+        #expect((merged[AnyHashable(1)] as? [AnyHashable: Any])?[AnyHashable("c")] as? Int == 3)
+
+        #expect(throws: DecodeError.listLimitExceeded(limit: 1)) {
+            _ = try Utils.merge(
+                target: target,
+                source: source,
+                options: DecodeOptions(listLimit: 1, throwOnLimitExceeded: true)
+            )
+        }
+    }
+
+    @Test("Utils.combine - keeps arrays nested when appending to overflow objects")
+    func testCombineKeepsOverflowAppendNested() async throws {
+        let overflow = try Utils.combine(["a"], "b", options: DecodeOptions(listLimit: 1))
+        let combined = try Utils.combine(
+            overflow,
+            ["c", "d"],
+            options: DecodeOptions(listLimit: 10)
+        )
         let combinedDict = combined as? [AnyHashable: Any]
         #expect(Utils.isOverflow(combinedDict))
         if let combinedDict {
             let cleaned = combinedDict.filter { !Utils.isOverflowKey($0.key) }
             #expect(cleaned[AnyHashable(0)] as? String == "a")
             #expect(cleaned[AnyHashable(1)] as? String == "b")
-            #expect(cleaned[AnyHashable(2)] as? String == "c")
-            #expect(cleaned[AnyHashable(3)] as? String == "d")
+            #expect(cleaned[AnyHashable(2)] as? [String] == ["c", "d"])
         }
 
-        let combinedWithNil = Utils.combine(overflow, [nil, "e"], listLimit: 10)
+        let combinedWithNil = try Utils.combine(
+            overflow,
+            [nil, "e"],
+            options: DecodeOptions(listLimit: 10)
+        )
         let combinedNilDict = combinedWithNil as? [AnyHashable: Any]
         #expect(Utils.isOverflow(combinedNilDict))
         if let combinedNilDict {
             let cleaned = combinedNilDict.filter { !Utils.isOverflowKey($0.key) }
-            #expect((cleaned[AnyHashable(2)] as AnyObject) is NSNull)
-            #expect(cleaned[AnyHashable(3)] as? String == "e")
+            let nested = cleaned[AnyHashable(2)] as? [Any?]
+            #expect(nested?.count == 2)
+            #expect(nested?[0] == nil)
+            #expect(nested?[1] as? String == "e")
         }
     }
 
     @Test("Utils.merge - handles overflow objects")
     func testMergeOverflowObjects() async throws {
-        let overflow = Utils.combine(["a"], "b", listLimit: 1) as? [AnyHashable: Any]
+        let overflow = try Utils.combine(
+            ["a"],
+            "b",
+            options: DecodeOptions(listLimit: 1)
+        ) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(overflow))
 
         if let overflow {
-            let merged = Utils.merge(target: overflow, source: "c") as? [AnyHashable: Any]
+            let merged = try Utils.merge(target: overflow, source: "c") as? [AnyHashable: Any]
             #expect(Utils.isOverflow(merged))
             if let merged {
                 let cleaned = merged.filter { !Utils.isOverflowKey($0.key) }
@@ -860,7 +1016,7 @@ struct UtilsTests {
                 #expect(cleaned[AnyHashable(2)] as? String == "c")
             }
 
-            let mergedIntoPrimitive = Utils.merge(target: "z", source: overflow) as? [AnyHashable: Any]
+            let mergedIntoPrimitive = try Utils.merge(target: "z", source: overflow) as? [AnyHashable: Any]
             #expect(Utils.isOverflow(mergedIntoPrimitive))
             if let mergedIntoPrimitive {
                 let cleaned = mergedIntoPrimitive.filter { !Utils.isOverflowKey($0.key) }
@@ -870,20 +1026,25 @@ struct UtilsTests {
         }
     }
 
-    @Test("Utils.merge - preserves overflow max index when merging into array target")
+    @Test("Utils.merge - merges an array target into overflow values by numeric index")
     func testMergeOverflowIntoArrayTarget() async throws {
-        let overflow = Utils.combine(["a"], "b", listLimit: 1) as? [AnyHashable: Any]
+        let overflow = try Utils.combine(
+            ["a"],
+            "b",
+            options: DecodeOptions(listLimit: 1)
+        ) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(overflow))
 
         if let overflow {
-            let merged = Utils.merge(target: ["z"], source: overflow) as? [AnyHashable: Any]
+            let merged = try Utils.merge(target: ["z"], source: overflow) as? [AnyHashable: Any]
             #expect(Utils.isOverflow(merged))
 
-            let appended = Utils.merge(target: merged, source: "c") as? [AnyHashable: Any]
+            let appended = try Utils.merge(target: merged, source: "c") as? [AnyHashable: Any]
             #expect(Utils.isOverflow(appended))
             if let appended {
                 let cleaned = appended.filter { !Utils.isOverflowKey($0.key) }
-                #expect(cleaned[AnyHashable(0)] as? String == "a")
+                #expect(cleaned[AnyHashable(0)] as? [String] == ["z", "a"])
+                #expect(cleaned[AnyHashable(1)] as? String == "b")
                 #expect(cleaned[AnyHashable(2)] as? String == "c")
             }
         }
@@ -900,26 +1061,26 @@ struct UtilsTests {
             maxIndex: 9
         )
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
         if let merged {
             #expect(Utils.overflowMaxIndex(merged) == 9)
-            #expect(merged[AnyHashable(0)] as? String == "a")
+            #expect(merged[AnyHashable(0)] as? [String] == ["z", "a"])
             #expect(merged[AnyHashable(1)] as? String == "b")
         }
     }
 
-    @Test("Utils.merge - overflow target appends array source by index")
-    func testMergeOverflowTarget_ArraySourceAppendPath() async throws {
+    @Test("Utils.merge - overflow target merges array source by numeric index")
+    func testMergeOverflowTarget_ArraySourceIndexPath() async throws {
         let target = Utils.markOverflow([AnyHashable(0): "a"], maxIndex: 2)
         let source: [Any?] = ["x", nil, Undefined.instance]
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
         if let merged {
-            #expect(merged[AnyHashable(3)] as? String == "x")
-            #expect(merged[AnyHashable(4)] is NSNull)
-            #expect(Utils.overflowMaxIndex(merged) == 4)
+            #expect(merged[AnyHashable(0)] as? [String] == ["a", "x"])
+            #expect(merged[AnyHashable(1)] is NSNull)
+            #expect(Utils.overflowMaxIndex(merged) == 2)
         }
     }
 
@@ -928,7 +1089,7 @@ struct UtilsTests {
         let target = Utils.markOverflow([AnyHashable(0): "a"], maxIndex: 0)
         let source = OrderedSet<AnyHashable>([AnyHashable("x"), AnyHashable("y")])
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
         if let merged {
             #expect((merged[AnyHashable(1)] as? AnyHashable)?.base as? String == "x")
@@ -948,7 +1109,7 @@ struct UtilsTests {
             maxIndex: 2
         )
 
-        let merged = Utils.merge(target: nil, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: nil, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
         if let merged {
             #expect(merged[AnyHashable(0)] is NSNull)
@@ -967,7 +1128,7 @@ struct UtilsTests {
             AnyHashable(3): "tail",
         ]
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(merged != nil)
         if let merged {
             #expect(merged[AnyHashable(0)] as? String == "left")
@@ -982,7 +1143,7 @@ struct UtilsTests {
         let target = Utils.markOverflow([AnyHashable(0): "a"], maxIndex: 0)
         let source = Utils.markOverflow([AnyHashable(1): "b"], maxIndex: 10)
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
         if let merged {
             #expect(merged[AnyHashable(1)] as? String == "b")
@@ -1008,13 +1169,13 @@ struct UtilsTests {
             )
         ]
 
-        let merged = Utils.merge(target: parent, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: parent, source: source) as? [AnyHashable: Any]
         #expect(Utils.isOverflow(merged))
 
         if let merged {
             #expect(Utils.overflowMaxIndex(merged) == 0)
 
-            let appended = Utils.merge(target: merged, source: "tail") as? [AnyHashable: Any]
+            let appended = try Utils.merge(target: merged, source: "tail") as? [AnyHashable: Any]
             #expect(Utils.isOverflow(appended))
             #expect(appended?[AnyHashable(1)] as? String == "tail")
             #expect(appended?[AnyHashable(102)] == nil)
@@ -1046,7 +1207,7 @@ struct UtilsTests {
             source = ["p": source]
         }
 
-        let merged = Utils.merge(target: target, source: source) as? [AnyHashable: Any]
+        let merged = try Utils.merge(target: target, source: source) as? [AnyHashable: Any]
         #expect(merged != nil)
 
         var node: Any? = merged
@@ -1964,6 +2125,40 @@ struct UtilsTests {
         #endif
     }
 
+    @Test("Utils.compact and compactToAny replace multi-step Foundation cycle back-edges with NSNull")
+    func utils_compact_foundationMultiStepCycle() throws {
+        #if os(Linux)
+            try withKnownIssue(Comment("Linux: corelibs-foundation segfault constructing NSDictionary cycles")) {
+                #expect(
+                    Bool(false),
+                    Comment("Skipped: cannot safely build cyclic Foundation containers on Linux"))
+            }
+        #else
+            let root = NSMutableDictionary()
+            let middle = NSMutableDictionary()
+            let leaf = NSMutableDictionary()
+            root["b"] = middle
+            middle["c"] = leaf
+            leaf["d"] = root
+            leaf["keep"] = "x"
+
+            var compactRoot: [String: Any?] = ["root": root]
+            let compacted = Utils.compact(&compactRoot, allowSparseLists: true)
+            let compactedRoot = compacted["root"] as? [String: Any?]
+            let compactedMiddle = compactedRoot?["b"] as? [String: Any?]
+            let compactedLeaf = compactedMiddle?["c"] as? [String: Any?]
+            #expect(compactedLeaf?["keep"] as? String == "x")
+            #expect((compactedLeaf?["d"] ?? nil) is NSNull)
+
+            let compactedAny = Utils.compactToAny(["root": root], allowSparseLists: true)
+            let anyRoot = compactedAny["root"] as? [String: Any]
+            let anyMiddle = anyRoot?["b"] as? [String: Any]
+            let anyLeaf = anyMiddle?["c"] as? [String: Any]
+            #expect(anyLeaf?["keep"] as? String == "x")
+            #expect(anyLeaf?["d"] is NSNull)
+        #endif
+    }
+
     @Test("Utils.containsUndefined detects sentinel in nested structures")
     func utils_containsUndefined_detects() {
         let undefined = Undefined.instance
@@ -2096,13 +2291,13 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge handles heterogeneous containers")
-    func utils_merge_coversBranches() {
+    func utils_merge_coversBranches() throws {
         let undefined = Undefined.instance
 
         // [Any?] target merged with dictionary source
         let targetArray: [Any?] = ["a", nil, undefined]
         let sourceDict: [AnyHashable: Any] = ["extra": "value"]
-        let merged1 = Utils.merge(target: targetArray, source: sourceDict, options: .init())
+        let merged1 = try Utils.merge(target: targetArray, source: sourceDict, options: .init())
         #expect(merged1 is [AnyHashable: Any])
         if let mergedDict1 = merged1 as? [AnyHashable: Any] {
             #expect(mergedDict1["extra"] as? String == "value")
@@ -2110,24 +2305,24 @@ struct UtilsTests {
         }
 
         // Dictionary target merged with array source
-        let merged2 = Utils.merge(target: merged1, source: [undefined, "tail"], options: .init())
+        let merged2 = try Utils.merge(target: merged1, source: [undefined, "tail"], options: .init())
         #expect(merged2 is [AnyHashable: Any])
 
         // OrderedSet union and sequence merging
         let ordered = OrderedSet<AnyHashable>([1, 2])
-        let mergedOrdered = Utils.merge(target: ordered, source: OrderedSet([2, 3]), options: .init())
+        let mergedOrdered = try Utils.merge(target: ordered, source: OrderedSet([2, 3]), options: .init())
         #expect(mergedOrdered is OrderedSet<AnyHashable>)
         if let orderedResult = mergedOrdered as? OrderedSet<AnyHashable> {
             #expect(!orderedResult.isEmpty)
         }
 
-        let orderedWithSequence = Utils.merge(target: OrderedSet(["a"]), source: [undefined, "b"], options: .init())
+        let orderedWithSequence = try Utils.merge(target: OrderedSet(["a"]), source: [undefined, "b"], options: .init())
         if let orderedSequenceArray = orderedWithSequence as? [Any?] {
             #expect(orderedSequenceArray.contains { ($0 as? String) == "b" })
         }
 
         // Set union and sequence merging
-        let mergedSet = Utils.merge(target: Set([1, 2]), source: [undefined, 3], options: .init())
+        let mergedSet = try Utils.merge(target: Set([1, 2]), source: [undefined, 3], options: .init())
         if let setResult = mergedSet as? Set<AnyHashable> {
             #expect(setResult.contains { ($0 as? Int) == 3 })
         }
@@ -2135,34 +2330,34 @@ struct UtilsTests {
         // Array target with Undefined elements and parseLists disabled
         let options = DecodeOptions(parseLists: false)
         let arrayWithUndefined: [Any] = [undefined, "a"]
-        let mergedArray = Utils.merge(target: arrayWithUndefined, source: ["b", undefined], options: options) as? [Any]
+        let mergedArray = try Utils.merge(target: arrayWithUndefined, source: ["b", undefined], options: options) as? [Any]
         #expect(mergedArray?.compactMap { $0 as? String }.contains("b") == true)
 
         // Array target + sequence of maps to trigger recursive merge
         let targetMaps: [Any] = [["k": "v"], Undefined.instance]
         let sourceMaps: [Any] = [["k": "override"], ["new": "value"]]
-        if let mergedMaps = Utils.merge(target: targetMaps, source: sourceMaps, options: .init()) as? [Any?] {
+        if let mergedMaps = try Utils.merge(target: targetMaps, source: sourceMaps, options: .init()) as? [Any?] {
             let first = mergedMaps[0] as? [AnyHashable: Any]
             #expect(first?["k"] as? String == "override")
         }
 
         // Dictionary target with non-sequence source coerces key from description
         let dictTarget: [AnyHashable: Any] = ["keep": 1]
-        if let mergedDict = Utils.merge(target: dictTarget, source: "flag", options: .init()) as? [AnyHashable: Any] {
+        if let mergedDict = try Utils.merge(target: dictTarget, source: "flag", options: .init()) as? [AnyHashable: Any] {
             #expect(mergedDict.keys.contains { ($0 as? String) == "flag" })
         }
 
         // Nil target with array source produces array with filtered Undefined
-        if let mergedFromNil = Utils.merge(target: nil, source: ["a", undefined], options: .init()) as? [Any?] {
+        if let mergedFromNil = try Utils.merge(target: nil, source: ["a", undefined], options: .init()) as? [Any?] {
             #expect(mergedFromNil.contains { ($0 as? String) == "a" })
         }
     }
 
     @Test("Utils.merge extends OrderedSet<AnyHashable> with sequences and skips Undefined")
-    func utils_merge_orderedSet_anyHashable_sequence() {
+    func utils_merge_orderedSet_anyHashable_sequence() throws {
         let undefined = Undefined.instance
         let target = OrderedSet<AnyHashable>([AnyHashable("a")])
-        let merged = Utils.merge(target: target, source: [undefined, "b", "a"], options: .init())
+        let merged = try Utils.merge(target: target, source: [undefined, "b", "a"], options: .init())
 
         if let ordered = merged as? OrderedSet<AnyHashable> {
             #expect(ordered.contains("a"))
@@ -2172,7 +2367,7 @@ struct UtilsTests {
             Issue.record("OrderedSet branch did not return OrderedSet: \(String(describing: merged))")
         }
 
-        if let unioned = Utils.merge(target: target, source: OrderedSet([AnyHashable("b")]), options: .init())
+        if let unioned = try Utils.merge(target: target, source: OrderedSet([AnyHashable("b")]), options: .init())
             as? OrderedSet<AnyHashable>
         {
             #expect(unioned.elementsEqual([AnyHashable("a"), AnyHashable("b")]))
@@ -2180,7 +2375,7 @@ struct UtilsTests {
             Issue.record("OrderedSet union branch not exercised")
         }
 
-        if let unchanged = Utils.merge(target: target, source: undefined, options: .init()) as? OrderedSet<AnyHashable>
+        if let unchanged = try Utils.merge(target: target, source: undefined, options: .init()) as? OrderedSet<AnyHashable>
         {
             #expect(unchanged.elementsEqual(target))
         } else {
@@ -2189,10 +2384,10 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge unions Set<AnyHashable> with sequence input")
-    func utils_merge_set_anyHashable_sequence() {
+    func utils_merge_set_anyHashable_sequence() throws {
         let undefined = Undefined.instance
         let target = Set<AnyHashable>(["seed"])
-        let merged = Utils.merge(target: target, source: [undefined, "extra"], options: .init())
+        let merged = try Utils.merge(target: target, source: [undefined, "extra"], options: .init())
 
         if let setResult = merged as? Set<AnyHashable> {
             #expect(setResult.contains("seed"))
@@ -2201,7 +2396,7 @@ struct UtilsTests {
             Issue.record("Set branch did not return Set: \(String(describing: merged))")
         }
 
-        if let unchanged = Utils.merge(target: target, source: undefined, options: .init()) as? Set<AnyHashable> {
+        if let unchanged = try Utils.merge(target: target, source: undefined, options: .init()) as? Set<AnyHashable> {
             #expect(unchanged == target)
         } else {
             Issue.record("Set Undefined branch not exercised")
@@ -2209,11 +2404,11 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge overlays Swift [Any] with sequence indices")
-    func utils_merge_arraySequenceOverlay() {
+    func utils_merge_arraySequenceOverlay() throws {
         let undefined = Undefined.instance
         let target = [Any](arrayLiteral: undefined, "keep")
         let source: [Any] = ["replaced", "new"]
-        if let merged = Utils.merge(target: target, source: source, options: .init(parseLists: true)) as? [Any?] {
+        if let merged = try Utils.merge(target: target, source: source, options: .init(parseLists: true)) as? [Any?] {
             #expect(merged[0] as? String == "replaced")
             #expect(merged[1] as? String == "new")
             #expect(merged.count == 2)
@@ -2223,11 +2418,11 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge promotes array target to dictionary when merging with map")
-    func utils_merge_arrayToDictionaryTarget() {
+    func utils_merge_arrayToDictionaryTarget() throws {
         let undefined = Undefined.instance
         let target: [Any] = ["a", undefined]
         let sourceDict: [AnyHashable: Any] = ["b": 2]
-        let merged = Utils.merge(target: target, source: sourceDict, options: .init())
+        let merged = try Utils.merge(target: target, source: sourceDict, options: .init())
         if let dict = merged as? [AnyHashable: Any] {
             #expect(dict[0] as? String == "a")
             #expect(dict["b"] as? Int == 2)
@@ -2237,11 +2432,11 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge dictionary target consumes OrderedSet sequences")
-    func utils_merge_dictionaryOrderedSetSequence() {
+    func utils_merge_dictionaryOrderedSetSequence() throws {
         let target: [AnyHashable: Any] = ["existing": "value"]
         let ordered = OrderedSet<AnyHashable>([AnyHashable("first"), AnyHashable(2)])
 
-        if let merged = Utils.merge(target: target, source: ordered, options: .init()) as? [AnyHashable: Any] {
+        if let merged = try Utils.merge(target: target, source: ordered, options: .init()) as? [AnyHashable: Any] {
             #expect(merged["existing"] as? String == "value")
             #expect(merged[0] as? AnyHashable == AnyHashable("first"))
             #expect(merged[1] as? AnyHashable == AnyHashable(2))
@@ -2251,9 +2446,9 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge merges nil targets with typed [Any] sources and filters Undefined")
-    func utils_merge_nilTarget_typedArraySource() {
+    func utils_merge_nilTarget_typedArraySource() throws {
         let source: [Any] = [Undefined.instance, "ok", 42]
-        if let merged = Utils.merge(target: nil, source: source, options: .init()) as? [Any?] {
+        if let merged = try Utils.merge(target: nil, source: source, options: .init()) as? [Any?] {
             #expect(merged.count == 3)
             let head = merged.first.flatMap { $0 }
             #expect(head == nil)
@@ -2266,10 +2461,10 @@ struct UtilsTests {
     }
 
     @Test("Utils.merge overlays arrays with scalars when no sequence is available")
-    func utils_merge_arrayAppendsScalarOnNonSequenceSource() {
+    func utils_merge_arrayAppendsScalarOnNonSequenceSource() throws {
         let undefined = Undefined.instance
         let target: [Any] = [undefined, "keep"]
-        let merged = Utils.merge(target: target, source: "tail", options: .init())
+        let merged = try Utils.merge(target: target, source: "tail", options: .init())
 
         if let out = merged as? [Any?] {
             #expect(out.count == 3)

--- a/Tools/QsSwiftComparison/js/package.json
+++ b/Tools/QsSwiftComparison/js/package.json
@@ -5,11 +5,11 @@
   "description": "A comparison of query string parsing libraries",
   "author": "Klemen Tusar",
   "license": "BSD-3-Clause",
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.11.0",
   "engines": {
     "node": ">=24"
   },
   "dependencies": {
-    "qs": "^6.15.2"
+    "qs": "^6.15.3"
   }
 }

--- a/Tools/QsSwiftComparison/js/pnpm-lock.yaml
+++ b/Tools/QsSwiftComparison/js/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       qs:
-        specifier: ^6.15.2
-        version: 6.15.2
+        specifier: ^6.15.3
+        version: 6.15.3
 
 packages:
 
@@ -69,8 +69,8 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.2.tgz}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.3.tgz}
     engines: {node: '>=0.6'}
 
   side-channel-list@1.0.1:
@@ -85,8 +85,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==, tarball: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==, tarball: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==, tarball: https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz}
     engines: {node: '>= 0.4'}
 
 snapshots:
@@ -147,9 +147,10 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   side-channel-list@1.0.1:
     dependencies:
@@ -171,7 +172,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4

--- a/Tools/QsSwiftComparison/js/test_cases.json
+++ b/Tools/QsSwiftComparison/js/test_cases.json
@@ -115,6 +115,118 @@
     },
     {
         "data": {
+            "a": {
+                "[bc": "v"
+            }
+        },
+        "encoded": "a[bc=v"
+    },
+    {
+        "data": {
+            "a": {
+                "[": "v"
+            }
+        },
+        "encoded": "a[=v"
+    },
+    {
+        "data": {
+            "a": {
+                "b": {
+                    "[c": "v"
+                }
+            }
+        },
+        "encoded": "a[b][c=v"
+    },
+    {
+        "data": {
+            "a": {
+                "b": {
+                    "[d": "v"
+                }
+            }
+        },
+        "encoded": "a[b]c[d=v"
+    },
+    {
+        "data": {
+            "filters": {
+                "[customtags:Env: Prod": "v"
+            }
+        },
+        "encoded": "filters[customtags:Env: Prod=v"
+    },
+    {
+        "data": {
+            "]": {
+                "[a": "v"
+            }
+        },
+        "encoded": "][a=v"
+    },
+    {
+        "data": {
+            "a]": {
+                "[b": "v"
+            }
+        },
+        "encoded": "a][b=v"
+    },
+    {
+        "data": {
+            "a": {
+                "[b[c": "v"
+            }
+        },
+        "encoded": "a[b[c=v"
+    },
+    {
+        "data": {
+            "a": {
+                "[b[c]": "v"
+            }
+        },
+        "encoded": "a[b[c]=v"
+    },
+    {
+        "data": {
+            "a": {
+                "b": {
+                    "[c[d": "v"
+                }
+            }
+        },
+        "encoded": "a[b][c[d=v"
+    },
+    {
+        "data": {
+            "[abc": "v"
+        },
+        "encoded": "[abc=v"
+    },
+    {
+        "data": {
+            "[[]b": "v"
+        },
+        "encoded": "[[]b=v"
+    },
+    {
+        "data": {
+            "a]b": "v"
+        },
+        "encoded": "a]b=v"
+    },
+    {
+        "data": {
+            "a": {
+                "b": "v"
+            }
+        },
+        "encoded": "a[b]extra=v"
+    },
+    {
+        "data": {
             "a": [
                 {
                     "b": "c"

--- a/skills/qs-swift/SKILL.md
+++ b/skills/qs-swift/SKILL.md
@@ -287,7 +287,9 @@ Use these options with `Qs.decode(query, options: .init(...))`:
 - Cumulative list growth: duplicate keys, flat comma values, mixed scalar/index/
   bracket notation, and nested merges all share `listLimit`. Exactly-at-limit
   results remain lists; non-throwing overflow becomes a numeric-keyed
-  dictionary. A negative limit overflows every non-empty list immediately.
+  dictionary. A negative limit treats every list construction or merge that
+  reaches limit enforcement as exceeded. With `allowEmptyLists`, a
+  parser-recognized empty list can bypass that enforcement and remain a list.
 - Comma-separated values such as `a=b,c`: `comma: true`. With strict limit
   handling, an oversized flat comma value throws before its values reach a
   custom decoder.

--- a/skills/qs-swift/SKILL.md
+++ b/skills/qs-swift/SKILL.md
@@ -282,7 +282,7 @@ Use these options with `Qs.decode(query, options: .init(...))`:
 - Empty list tokens such as `foo[]`: `allowEmptyLists: true`.
 - Sparse numeric indices: `allowSparseLists: true` preserves holes as
   `NSNull()` placeholders; the default compacts lists.
-- Large list indices: default `listLimit` is `20`; indices above the limit
+- Large list indices: default `listLimit` is `20`; indices at or above the limit
   become dictionary keys.
 - Cumulative list growth: duplicate keys, flat comma values, mixed scalar/index/
   bracket notation, and nested merges all share `listLimit`. Exactly-at-limit

--- a/skills/qs-swift/SKILL.md
+++ b/skills/qs-swift/SKILL.md
@@ -299,7 +299,9 @@ Use these options with `Qs.decode(query, options: .init(...))`:
 - Legacy charset input: `charset: .isoLatin1`; use `charsetSentinel: true`
   when a form may include `utf8=...` to signal the real charset.
 - HTML numeric entities: `interpretNumericEntities: true`, usually with
-  ISO-8859-1 or charset sentinel handling.
+  ISO-8859-1 or charset sentinel handling. Entity interpretation can collapse a
+  comma list to a scalar before non-throwing overflow is applied, preserving the
+  scalar shape instead of producing a numeric-keyed dictionary.
 - Custom scalar decoding: use `decoder` when key/value behavior differs; key
   decoding should return values that can be stringified.
 - Untrusted input: keep `depth`, `parameterLimit`, and `listLimit` bounded; use

--- a/skills/qs-swift/SKILL.md
+++ b/skills/qs-swift/SKILL.md
@@ -277,13 +277,22 @@ Use these options with `Qs.decode(query, options: .init(...))`:
 - Duplicate keys: `duplicates: .combine` keeps all values as a list; use
   `.first` or `.last` to collapse.
 - Bracket lists: enabled by default; set `parseLists: false` to treat list
-  syntax as dictionary keys.
+  syntax as dictionary keys. Top-level parameter count never disables list
+  parsing implicitly.
 - Empty list tokens such as `foo[]`: `allowEmptyLists: true`.
 - Sparse numeric indices: `allowSparseLists: true` preserves holes as
   `NSNull()` placeholders; the default compacts lists.
 - Large list indices: default `listLimit` is `20`; indices above the limit
   become dictionary keys.
-- Comma-separated values such as `a=b,c`: `comma: true`.
+- Cumulative list growth: duplicate keys, flat comma values, mixed scalar/index/
+  bracket notation, and nested merges all share `listLimit`. Exactly-at-limit
+  results remain lists; non-throwing overflow becomes a numeric-keyed
+  dictionary. A negative limit overflows every non-empty list immediately.
+- Comma-separated values such as `a=b,c`: `comma: true`. With strict limit
+  handling, an oversized flat comma value throws before its values reach a
+  custom decoder.
+- Bracketed comma values such as `a[]=b,c,d` are nested groups and count as one
+  outer list element; the inner group is not capped by `listLimit`.
 - Tokens without `=` as `NSNull()`: `strictNullHandling: true`.
 - Custom delimiters: `delimiter: StringDelimiter(";")` or
   `delimiter: try RegexDelimiter("[;,]")`.
@@ -404,7 +413,8 @@ Warn or adjust before giving code for these cases:
 - `DecodeOptions(decodeDotInKeys: true, allowDots: false)` is invalid.
 - `parameterLimit` must be positive and `depth` must be non-negative.
 - `throwOnLimitExceeded: true` turns parameter and list limit violations into
-  thrown errors; without it, parsing truncates or falls back.
+  thrown errors; without it, parameter parsing truncates and list overflow
+  falls back to a numeric-keyed dictionary.
 - `strictDepth: true` throws on well-formed depth overflow; with the default
   `false`, the remainder beyond `depth` is kept as a trailing key segment.
 - Built-in charset handling supports only `.utf8` and `.isoLatin1`; other


### PR DESCRIPTION
This pull request implements a comprehensive update to the query string decoding logic, aligning list-limit enforcement and overflow handling with `qs@6.15.3` for full compatibility. It introduces cumulative list limits across duplicate keys, comma values, and bracket/index notation, and improves error handling and overflow representation. Additionally, it refines the documentation, public API exposure, and test coverage for these behaviors.

**Decoder behavior and compatibility:**

* Enforces `listLimit` cumulatively across all sources of list values (duplicate keys, comma-separated values, bracket/index notation, nested merges), matching `qs@6.15.3` behavior. Lists at the exact limit remain arrays; overflowed lists become numeric-keyed dictionaries, or throw if `throwOnLimitExceeded` is enabled. Negative `listLimit` values now cause immediate overflow or throw. [[1]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL10-R18) [[2]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL30-R41) [[3]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL105-L115) [[4]](diffhunk://#diff-e6d96967ee20c177ff0d2575f26b0ab0784bb1d150f4c0fa2f61a2e4e09ca03eL103-R105) [[5]](diffhunk://#diff-e6d96967ee20c177ff0d2575f26b0ab0784bb1d150f4c0fa2f61a2e4e09ca03eL118-R117) [[6]](diffhunk://#diff-e6d96967ee20c177ff0d2575f26b0ab0784bb1d150f4c0fa2f61a2e4e09ca03eL54-R54) [[7]](diffhunk://#diff-e6d96967ee20c177ff0d2575f26b0ab0784bb1d150f4c0fa2f61a2e4e09ca03eL75-R75) [[8]](diffhunk://#diff-f19f4adb24281edfa7e9917cf6799be6dc1759dd7738590595202b58f54353bcL122) [[9]](diffhunk://#diff-f19f4adb24281edfa7e9917cf6799be6dc1759dd7738590595202b58f54353bcL131-R130)
* Refines how comma-separated values are split and counted for limits, ensuring comma groups under `[]=` count as a single outer list element, and that overflow handling matches qs's indexed-object fallback. [[1]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL10-R18) [[2]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL30-R41) [[3]](diffhunk://#diff-f7d8a5b9331776077d93ec69baecf528d36294ee2ba1874fd1ff2194493a587cL105-L115)
* Adds a dedicated numeric-index parser to mirror JavaScript's behavior for array indices, ensuring only valid indices are treated as such.

**Error handling and options:**

* Updates the `DecodeOptions` model and documentation to clarify cumulative list limits, overflow behavior, and the effects of `throwOnLimitExceeded` (now only applies to parameter and list limits; depth is controlled separately). [[1]](diffhunk://#diff-480fee1d9d0acc71d7491dad9132cfc5fe7d77a08af41ab27bbd8e646c37f299L70-R83) [[2]](diffhunk://#diff-480fee1d9d0acc71d7491dad9132cfc5fe7d77a08af41ab27bbd8e646c37f299L102-R113)
* Improves error reporting for list limit violations, including immediate errors for negative limits and correct domain/codes in Objective-C bridge tests.

**Documentation and API exposure:**

* Updates the README and inline comments to clarify cumulative list limits, overflow handling, and the distinction between strict and soft error modes. [[1]](diffhunk://#diff-711b1e86863f218196f3e46c3170eabbdf3892bd91d8f2bcb79182f058971d35L188-R191) [[2]](diffhunk://#diff-711b1e86863f218196f3e46c3170eabbdf3892bd91d8f2bcb79182f058971d35L197-R200)
* Makes `URLComponents` and `URL` query-append methods public for use by clients, and updates their doc comments. [[1]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L12-R12) [[2]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L24-R24) [[3]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L49-R49) [[4]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L65-R65) [[5]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L75-R75) [[6]](diffhunk://#diff-81a055854e22d1305e4e1e69cd255ea578c07581c49c37321b80764b824532a5L93-R93)

**Test coverage:**

* Adds new Objective-C bridge and E2E tests for cumulative list limits, mixed notations, unbalanced keys, encoding edge cases, and Foundation cycles.

**Changelog and maintenance:**

* Updates `CHANGELOG.md` with all fixes, test additions, and dependency bumps (qs fixture).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cumulative `listLimit` enforcement across duplicates, nested lists, comma-separated values, and bracket/numeric indexes, matching qs 6.15.3 behavior (including strict vs non-throwing overflow outcomes and negative-limit handling).
  * Ensured list parsing stays enabled unless explicitly disabled.
  * Corrected ISO-8859-1 numeric entity interpretation timing so comma-overflow results are consistent.
  * Improved handling for unusual bracket-like query keys.
* **Documentation**
  * Expanded decoding option descriptions for `listLimit`, `parseLists`, sparse lists, and `throwOnLimitExceeded`.
* **Tests**
  * Added extensive Swift and Objective-C compatibility and edge-case coverage for qs 6.15.3 parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->