### PR TITLE
chore(ci): add clang format workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,14 @@
----
 BasedOnStyle: WebKit
+
 IndentWidth: 2
 ColumnLimit: 120
 BreakBeforeBraces: Attach
+
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 
----
-Language: ObjC
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: false
+
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     name: ${{ format('Swift tests ({0}, Xcode {1}, Swift {2}{3})', matrix.runner, matrix.xcode, matrix.swift, matrix.experimental && ' — experimental' || '') }}
     timeout-minutes: 45
     runs-on: ${{ matrix.runner }}
-    needs: swift-lint
+    needs: [swift-lint, clang-format]
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
@@ -198,7 +198,7 @@ jobs:
     name: Objective-C E2E tests (macOS, Xcode)
     timeout-minutes: 45
     runs-on: macos-26
-    needs: [ swift-lint, macos-tests ]
+    needs: [ swift-lint, clang-format, macos-tests ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -351,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     continue-on-error: ${{ matrix.experimental }}
-    needs: swift-lint
+    needs: [ swift-lint, clang-format ]
 
     strategy:
       fail-fast: false
@@ -414,7 +414,7 @@ jobs:
 
   ensure-compatibility:
     name: Ensure compatibility with qs.js
-    needs: [ swift-lint, macos-tests ]
+    needs: [ swift-lint, clang-format, macos-tests ]
     runs-on: macos-26
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run ClangFormat
         uses: RafikFarhad/clang-format-github-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ env:
   SWIFT_VERSION: '6.3'
 
 jobs:
-  analyze:
+  swift-lint:
     permissions:
       contents: read
     name: SwiftLint
@@ -52,6 +52,23 @@ jobs:
         run: |
           set -euo pipefail
           swiftlint lint --reporter github-actions-logging
+  clang-format:
+    permissions:
+      contents: read
+    name: Check Objective-C formatting
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run ClangFormat
+        uses: RafikFarhad/clang-format-github-action@v7
+        with:
+          style: file
+          sources: "**/*.h,**/*.m,**/*.mm"
 
   macos-tests:
     permissions:
@@ -59,7 +76,7 @@ jobs:
     name: ${{ format('Swift tests ({0}, Xcode {1}, Swift {2}{3})', matrix.runner, matrix.xcode, matrix.swift, matrix.experimental && ' — experimental' || '') }}
     timeout-minutes: 45
     runs-on: ${{ matrix.runner }}
-    needs: analyze
+    needs: swift-lint
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
@@ -181,7 +198,7 @@ jobs:
     name: Objective-C E2E tests (macOS, Xcode)
     timeout-minutes: 45
     runs-on: macos-26
-    needs: [ analyze, macos-tests ]
+    needs: [ swift-lint, macos-tests ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -334,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     continue-on-error: ${{ matrix.experimental }}
-    needs: analyze
+    needs: swift-lint
 
     strategy:
       fail-fast: false
@@ -397,7 +414,7 @@ jobs:
 
   ensure-compatibility:
     name: Ensure compatibility with qs.js
-    needs: [ analyze, macos-tests ]
+    needs: [ swift-lint, macos-tests ]
     runs-on: macos-26
     timeout-minutes: 15
     steps:

--- a/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
+++ b/ObjCE2ETests/ObjCE2ETests/ObjCDecodeConvenienceTests.m
@@ -18,8 +18,8 @@ static NSDictionary* Qs_DecodeOrEmpty(id _Nullable input, QsDecodeOptions* _Null
   return out ?: @ { };
 }
 
-static NSDictionary* Qs_DecodeOrDefault(
-    id _Nullable input, QsDecodeOptions* _Nullable opts, NSDictionary* _Nonnull def) {
+static NSDictionary*
+Qs_DecodeOrDefault(id _Nullable input, QsDecodeOptions* _Nullable opts, NSDictionary* _Nonnull def) {
   NSDictionary* out = Qs_DecodeOrNil(input, opts);
   return out ?: def;
 }


### PR DESCRIPTION
This pull request introduces improvements to code formatting standards and CI workflow automation. The main changes are the addition of a `clang-format` job to the GitHub Actions workflow for Objective-C code, updates to the `.clang-format` configuration, and a minor code style tweak in an Objective-C test file.

**CI/CD workflow enhancements:**

* Added a `clang-format` job to `.github/workflows/test.yml` to automatically check Objective-C code formatting on pull requests, ensuring consistent code style. Updated job dependencies so that other jobs depend on both `swift-lint` and `clang-format` checks. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R55-R79) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L22-R22) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L184-R201) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L337-R354) [[5]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L400-R417)

**Formatting and style configuration:**

* Updated `.clang-format` to refine Objective-C formatting rules, including parameter packing and short statement handling, for improved code consistency.

**Code style improvements:**

* Reformatted the `Qs_DecodeOrDefault` function declaration in `ObjCDecodeConvenienceTests.m` to match style guidelines.